### PR TITLE
RAUC: dedicated /uboot-env partition and layout updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,10 @@ See `kas/local.yml.example` for configuration template.
 | Device | Label | Size | Mount | Purpose |
 |--------|-------|------|-------|---------|
 | `/dev/mmcblk0p1` | `boot` | 256M | `/boot` | Bootloader & kernel (shared) |
-| `/dev/mmcblk0p2` | `rootA` | 3G | `/` | Root filesystem Slot A |
-| `/dev/mmcblk0p3` | `rootB` | 3G | - | Root filesystem Slot B |
-| `/dev/mmcblk0p4` | `data` | 2G (auto-expands) | `/data` | Persistent data |
+| `/dev/mmcblk0p2` | `ubootenv` | 16M | `/uboot-env` | Dedicated U-Boot environment store |
+| `/dev/mmcblk0p3` | `rootA` | 3G | `/` | Root filesystem Slot A |
+| `/dev/mmcblk0p4` | `rootB` | 3G | - | Root filesystem Slot B |
+| `/dev/mmcblk0p5` | `data` | 2G (auto-expands) | `/data` | Persistent data |
 
 **Other sizes available:** 32GB, 64GB — see `meta-iot-gateway/wic/` for WKS files.
 **Note:** On first boot, `rauc-grow-data-partition` expands `/data` to fill remaining free space.

--- a/docs/PARTITIONS.md
+++ b/docs/PARTITIONS.md
@@ -36,9 +36,10 @@ on first boot by `rauc-grow-data-partition`.
 | # | Device | Label | Size | Type | Mount | Purpose |
 |---|--------|-------|------|------|-------|---------|
 | 1 | `/dev/mmcblk0p1` | `boot` | 256M | vfat (FAT32) | `/boot` | U-Boot, kernel, DTBs (shared) |
-| 2 | `/dev/mmcblk0p2` | `rootA` | 3G | ext4 | `/` | Root filesystem Slot A |
-| 3 | `/dev/mmcblk0p3` | `rootB` | 3G | ext4 | - | Root filesystem Slot B |
-| 4 | `/dev/mmcblk0p4` | `data` | 2G | ext4 | `/data` | Persistent user data |
+| 2 | `/dev/mmcblk0p2` | `ubootenv` | 16M | vfat (FAT32) | `/uboot-env` | Dedicated U-Boot environment store |
+| 3 | `/dev/mmcblk0p3` | `rootA` | 3G | ext4 | `/` | Root filesystem Slot A |
+| 4 | `/dev/mmcblk0p4` | `rootB` | 3G | ext4 | - | Root filesystem Slot B |
+| 5 | `/dev/mmcblk0p5` | `data` | 2G | ext4 | `/data` | Persistent user data |
 
 **Remaining Space:** ~7GB reserved for auto-grow
 **After First Boot:** `/data` expands to fill remaining free space
@@ -56,9 +57,10 @@ on first boot by `rauc-grow-data-partition`.
 | # | Device | Label | Size | Type | Mount | Purpose |
 |---|--------|-------|------|------|-------|---------|
 | 1 | `/dev/mmcblk0p1` | `boot` | 256M | vfat (FAT32) | `/boot` | U-Boot, kernel, DTBs (shared) |
-| 2 | `/dev/mmcblk0p2` | `rootA` | 6G | ext4 | `/` | Root filesystem Slot A |
-| 3 | `/dev/mmcblk0p3` | `rootB` | 6G | ext4 | - | Root filesystem Slot B |
-| 4 | `/dev/mmcblk0p4` | `data` | 12G | ext4 | `/data` | Persistent user data |
+| 2 | `/dev/mmcblk0p2` | `ubootenv` | 16M | vfat (FAT32) | `/uboot-env` | Dedicated U-Boot environment store |
+| 3 | `/dev/mmcblk0p3` | `rootA` | 6G | ext4 | `/` | Root filesystem Slot A |
+| 4 | `/dev/mmcblk0p4` | `rootB` | 6G | ext4 | - | Root filesystem Slot B |
+| 5 | `/dev/mmcblk0p5` | `data` | 12G | ext4 | `/data` | Persistent user data |
 
 **Remaining Space:** ~8GB reserved for auto-grow
 **After First Boot:** `/data` expands to fill remaining free space
@@ -76,9 +78,10 @@ on first boot by `rauc-grow-data-partition`.
 | # | Device | Label | Size | Type | Mount | Purpose |
 |---|--------|-------|------|------|-------|---------|
 | 1 | `/dev/mmcblk0p1` | `boot` | 256M | vfat (FAT32) | `/boot` | U-Boot, kernel, DTBs (shared) |
-| 2 | `/dev/mmcblk0p2` | `rootA` | 8G | ext4 | `/` | Root filesystem Slot A |
-| 3 | `/dev/mmcblk0p3` | `rootB` | 8G | ext4 | - | Root filesystem Slot B |
-| 4 | `/dev/mmcblk0p4` | `data` | 36G | ext4 | `/data` | Persistent user data |
+| 2 | `/dev/mmcblk0p2` | `ubootenv` | 16M | vfat (FAT32) | `/uboot-env` | Dedicated U-Boot environment store |
+| 3 | `/dev/mmcblk0p3` | `rootA` | 8G | ext4 | `/` | Root filesystem Slot A |
+| 4 | `/dev/mmcblk0p4` | `rootB` | 8G | ext4 | - | Root filesystem Slot B |
+| 5 | `/dev/mmcblk0p5` | `data` | 36G | ext4 | `/data` | Persistent user data |
 
 **Remaining Space:** ~12GB reserved for auto-grow
 **After First Boot:** `/data` expands to fill remaining free space
@@ -109,7 +112,7 @@ on first boot by `rauc-grow-data-partition`.
 
 ---
 
-### Partition 2 & 3: Root A/B (`rootA`, `rootB`)
+### Partition 3 & 4: Root A/B (`rootA`, `rootB`)
 
 **Format:** ext4
 **Mount:** `/` (active slot only)
@@ -195,9 +198,9 @@ mount | grep mmcblk0
 
 **Example Output:**
 ```
-/dev/mmcblk0p2 on / type ext4 (ro,relatime)
+/dev/mmcblk0p3 on / type ext4 (ro,relatime)
 /dev/mmcblk0p1 on /boot type vfat (rw,noatime,nodiratime)
-/dev/mmcblk0p4 on /data type ext4 (rw,noatime,nodiratime,commit=60)
+/dev/mmcblk0p5 on /data type ext4 (rw,noatime,nodiratime,commit=60)
 ```
 
 ### RAUC Slot Status
@@ -252,13 +255,13 @@ cp meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in \
 
 2. Edit partition sizes:
 ```
-# Partition 2: rootA
+# Partition 3: rootA
 part / --source rootfs --rootfs-dir=${IMAGE_ROOTFS} --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 4G --use-uuid
 
-# Partition 3: rootB
+# Partition 4: rootB
 part --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 4G --use-uuid
 
-# Partition 4: data
+# Partition 5: data
 part --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 4G --use-uuid
 ```
 

--- a/docs/RAUC_UPDATE.md
+++ b/docs/RAUC_UPDATE.md
@@ -26,6 +26,13 @@ Manual install workflow (recommended):
 iotgw-rauc-install <bundle>.raucb
 ```
 
+Behavior notes:
+
+- default path: wrapper dispatches through `systemd-run` to execute from system
+  manager context (recommended on hardened systems)
+- fallback path: direct execution (`--direct` or `--no-systemd-run`) for debug
+  only
+
 Track progress:
 
 ```bash
@@ -65,7 +72,7 @@ Continuing after adaptive mode error: ... image/partition size (...) is not a mu
 ### Verify Slot Alignment (target)
 
 ```bash
-for p in /dev/mmcblk0p2 /dev/mmcblk0p3; do
+for p in /dev/mmcblk0p3 /dev/mmcblk0p4; do
   s=$(blockdev --getsize64 "$p")
   echo "$p size=$s mod4096=$((s%4096))"
 done
@@ -87,17 +94,29 @@ Check:
 
 ```bash
 findmnt -no SOURCE,TARGET,FSTYPE,OPTIONS /boot
+findmnt -no SOURCE,TARGET,FSTYPE,OPTIONS /uboot-env
+head -n1 /etc/fw_env.config
 fw_printenv
 fw_setenv iotgw_test 2
 ```
 
-Typical cause: `/boot` is mounted read-only while RAUC needs to update
-`/boot/uboot.env`.
+Typical causes:
+
+- legacy layout: `/boot` is mounted read-only while RAUC needs to update
+  `/boot/uboot.env`
+- dedicated-env layout: `/uboot-env` is unavailable while RAUC needs to update
+  `/uboot-env/uboot.env`
 
 Use the wrapper command for manual installs:
 
 ```bash
 iotgw-rauc-install <bundle>.raucb
+```
+
+For low-level debugging (skip systemd-run dispatch):
+
+```bash
+iotgw-rauc-install --direct <bundle>.raucb
 ```
 
 If `rauc-mark-good.service` unexpectedly appears masked after update, check for

--- a/meta-iot-gateway/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
+++ b/meta-iot-gateway/recipes-bsp/rpi-u-boot-scr/files/boot.cmd.in
@@ -39,6 +39,7 @@ echo "[RAUC] Bootchooser init (env):"
 env print BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT
 
 setenv bootpart
+setenv rootpartnum
 setenv rauc_slot
 
 for BOOT_SLOT in ${BOOT_ORDER}; do
@@ -49,7 +50,8 @@ for BOOT_SLOT in ${BOOT_ORDER}; do
             echo "[RAUC] Considering slot A; tries left before dec=${BOOT_A_LEFT}"
             setexpr BOOT_A_LEFT ${BOOT_A_LEFT} - 1
             echo "[RAUC] Selected slot A; tries left now=${BOOT_A_LEFT}"
-            setenv bootpart "/dev/mmcblk0p2"
+            setenv bootpart "/dev/mmcblk0p3"
+            setenv rootpartnum "3"
             setenv rauc_slot "A"
         else
             echo "[RAUC] Skipping slot A; no tries left"
@@ -59,7 +61,8 @@ for BOOT_SLOT in ${BOOT_ORDER}; do
             echo "[RAUC] Considering slot B; tries left before dec=${BOOT_B_LEFT}"
             setexpr BOOT_B_LEFT ${BOOT_B_LEFT} - 1
             echo "[RAUC] Selected slot B; tries left now=${BOOT_B_LEFT}"
-            setenv bootpart "/dev/mmcblk0p3"
+            setenv bootpart "/dev/mmcblk0p4"
+            setenv rootpartnum "4"
             setenv rauc_slot "B"
         else
             echo "[RAUC] Skipping slot B; no tries left"
@@ -70,7 +73,18 @@ done
 # Build kernel cmdline: start from firmware-provided args, then append root per slot
 fdt addr ${fdt_addr} && fdt get value bootargs /chosen bootargs
 if test -n "${bootpart}"; then
-    setenv bootargs "${bootargs} root=${bootpart} rauc.slot=${rauc_slot}"
+    if test -z "${rootpartnum}"; then
+        echo "[RAUC] Missing root partition number for slot ${rauc_slot}; resetting"
+        reset
+    fi
+    if part uuid @@BOOT_MEDIA@@ 0:${rootpartnum} rootpartuuid; then
+        setenv rootarg "root=PARTUUID=${rootpartuuid}"
+        echo "[RAUC] Using root from PARTUUID=${rootpartuuid} (slot ${rauc_slot})"
+    else
+        echo "[RAUC] PARTUUID lookup failed for slot ${rauc_slot}; resetting"
+        reset
+    fi
+    setenv bootargs "${bootargs} ${rootarg} rauc.slot=${rauc_slot}"
     # Track boot count and last selected slot
     if test -z "${iotgw_bootcount}"; then
         setenv iotgw_bootcount 0
@@ -83,7 +97,7 @@ if test -n "${bootpart}"; then
         setenv bootargs "${bootargs} ${EXTRA_KERNEL_ARGS}"
     fi
     saveenv
-    echo "[RAUC] Bootargs appended; root=${bootpart} rauc.slot=${rauc_slot}"
+    echo "[RAUC] Bootargs appended; ${rootarg} rauc.slot=${rauc_slot}"
 else
     echo "No valid RAUC slot found. Resetting tries to 3"
     setenv BOOT_A_LEFT 3
@@ -103,7 +117,7 @@ else
     echo "[RAUC] Failed to load @@KERNEL_IMAGETYPE@@ from /boot"
     reset
 fi
-if test ! -e @@BOOT_MEDIA@@ 0:1 uboot.env; then saveenv; fi;
+if test ! -e @@BOOT_MEDIA@@ 0:2 uboot.env; then saveenv; fi;
 
 # FIT-mode visibility and explicit configuration selection.
 if test "x@@KERNEL_IMAGETYPE@@" = "xfitImage"; then

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/fw_env.config
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/fw_env.config
@@ -1,0 +1,1 @@
+/uboot-env/uboot.env 0x0000 0x4000

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot.cfg
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot.cfg
@@ -34,6 +34,7 @@ CONFIG_BMP_32BPP=y
 
 # Keep environment in a writable backend (RAUC needs to update slot vars)
 # Do NOT disable saveenv or move env to NOWHERE
+CONFIG_ENV_FAT_DEVICE_AND_PART="0:2"
 
 # Remove built-in U-Boot logo to avoid brief 'boat' flicker
 CONFIG_VIDEO_LOGO=n

--- a/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,7 +1,12 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
 # Add IoT GW hardening and RAUC-friendly settings via Kconfig fragment
-SRC_URI:append = " file://iotgw-uboot.cfg"
+SRC_URI:append = " file://iotgw-uboot.cfg file://fw_env.config"
 
 # Keep boot delay minimal; allow keyed interrupt only
 # Note: Further hardening (FIT signatures) will be added separately per-prod build
+
+do_install:append() {
+    # Override fw_env.config from lower-priority layers.
+    install -m 0644 ${WORKDIR}/fw_env.config ${D}${sysconfdir}/fw_env.config
+}

--- a/meta-iot-gateway/recipes-core/base-files/base-files/fstab
+++ b/meta-iot-gateway/recipes-core/base-files/base-files/fstab
@@ -1,13 +1,13 @@
-# fstab for RAUC A/B system on Raspberry Pi 5
-# This overrides the incorrect fstab from meta-rauc-raspberrypi
-# Our WKS layout has only 4 partitions: boot (p1), rootA (p2), rootB (p3), data (p4)
-#
-# Root is read-only for atomic updates
-# Writable directories (/etc, /var, /home, /root) use overlayfs mounted by overlayfs-setup.service
+# IoT Gateway fstab (Raspberry Pi 5, RAUC A/B + GPT)
+# Root filesystem is mounted read-only for atomic OTA behavior.
+# Persistent writable state is on LABEL=data (/data).
+# overlayfs-setup.service mounts writable overlays for: /etc, /var, /home, /root.
+# LABEL-based mounts are used to avoid dependency on partition numbering.
 
 /dev/root            /                    auto       ro                    1  1
-/dev/mmcblk0p1       /boot                vfat       nodev,nosuid,noexec,noatime,nodiratime   0  0
-/dev/mmcblk0p4       /data                ext4       defaults,noatime,nodiratime,commit=60    0  0
+LABEL=boot           /boot                vfat       nodev,nosuid,noexec,noatime,nodiratime   0  0
+LABEL=ubootenv       /uboot-env           vfat       rw,nodev,nosuid,noexec,noatime,nodiratime,umask=0077   0  0
+LABEL=data           /data                ext4       defaults,noatime,nodiratime,commit=60    0  0
 proc                 /proc                proc       nosuid,nodev,noexec,hidepid=2 0  0
 devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
 tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0

--- a/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
@@ -1,6 +1,6 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/base-files:"
 
-# Override fstab from meta-rauc-raspberrypi to match our 4-partition WKS layout
+# Override fstab from meta-rauc-raspberrypi to match our WKS layout
 # Set custom hostname
 # Note: issue/motd are generated dynamically by iotgw-banner
 SRC_URI += "file://fstab file://hostname file://hosts file://profile.d/10-iotgw-path.sh file://skel/.bashrc"
@@ -13,6 +13,7 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/profile.d/10-iotgw-path.sh ${D}${sysconfdir}/profile.d/10-iotgw-path.sh
     install -d ${D}/etc/skel
     install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/etc/skel/.bashrc
+    install -d ${D}/uboot-env
 
     # Create uninitialized machine-id file
     # This signals systemd to generate a unique ID on first boot

--- a/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
@@ -378,8 +378,8 @@ else
     TARGET_ROOT="${RAUC_SLOT_DEVICE}"
   elif [ -n "${RAUC_SLOT_NAME:-}" ]; then
     case "${RAUC_SLOT_NAME}" in
-      rootfs.0) TARGET_ROOT="/dev/mmcblk0p2" ;;
-      rootfs.1) TARGET_ROOT="/dev/mmcblk0p3" ;;
+      rootfs.0) TARGET_ROOT="PARTLABEL=rootA" ;;
+      rootfs.1) TARGET_ROOT="PARTLABEL=rootB" ;;
     esac
   fi
   if [ -n "$TARGET_ROOT" ] && [ -r "$BOOT_MP/cmdline.txt" ]; then

--- a/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks.sh
@@ -378,8 +378,8 @@ else
     TARGET_ROOT="${RAUC_SLOT_DEVICE}"
   elif [ -n "${RAUC_SLOT_NAME:-}" ]; then
     case "${RAUC_SLOT_NAME}" in
-      rootfs.0) TARGET_ROOT="/dev/mmcblk0p2" ;;
-      rootfs.1) TARGET_ROOT="/dev/mmcblk0p3" ;;
+      rootfs.0) TARGET_ROOT="PARTLABEL=rootA" ;;
+      rootfs.1) TARGET_ROOT="PARTLABEL=rootB" ;;
     esac
   fi
   if [ -n "$TARGET_ROOT" ] && [ -r "$BOOT_MP/cmdline.txt" ]; then

--- a/meta-iot-gateway/recipes-ota/rauc/files/grow-data-partition.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/grow-data-partition.sh
@@ -27,6 +27,26 @@ already_done() {
     [ -f "$STAMP" ]
 }
 
+run_parted_resize() {
+    local disk="$1"
+    local part_num="$2"
+    local err_file="$3"
+
+    if parted -s "$disk" resizepart "$part_num" 100% 2>"$err_file"; then
+        return 0
+    fi
+
+    # Some platforms prompt even in script mode:
+    # 1) GPT backup header not at disk end ("Fix/Ignore")
+    # 2) partition in use ("Yes/No")
+    if printf 'Fix\nYes\n' | parted --pretend-input-tty "$disk" resizepart "$part_num" 100% \
+        > /dev/null 2>"$err_file"; then
+        return 0
+    fi
+
+    return 1
+}
+
 main() {
     if already_done; then
         log "✓ stamp present; nothing to do"
@@ -43,7 +63,7 @@ main() {
     DATA_PART=$(resolve_data_part) || die "could not resolve data partition by label 'data'"
     [ -b "$DATA_PART" ] || die "not a block device: $DATA_PART"
 
-    # Derive parent disk and partition number (handles mmcblk0p4, nvme0n1p4, sda4)
+    # Derive parent disk and partition number (handles mmcblk0p5, nvme0n1p5, sda5)
     base=$(basename "$DATA_PART")
     case "$base" in
         mmcblk*p*[0-9]) DISK="/dev/${base%p*}"; PART_NUM=${base##*p} ;;
@@ -57,12 +77,17 @@ main() {
     # Best-effort rescan before resize
     partprobe "$DISK" 2>/dev/null || true
 
+    # Best-effort GPT backup table relocation (common when image is smaller than media).
+    if command -v sgdisk >/dev/null 2>&1; then
+        sgdisk -e "$DISK" >/dev/null 2>&1 || true
+    fi
+
     # Attempt to grow the partition to 100%. If already at max, just continue.
     RESIZE_ERR=$(mktemp)
-    if parted -s "$DISK" resizepart "$PART_NUM" 100% 2>"$RESIZE_ERR"; then
+    if run_parted_resize "$DISK" "$PART_NUM" "$RESIZE_ERR"; then
         log "📏 resized partition $PART_NUM to 100%"
     else
-        if grep -qi "cannot be grown\|already at maximum size\|out of range" "$RESIZE_ERR" 2>/dev/null; then
+        if grep -qi "cannot be grown\|already at maximum size\|out of range\|is being used\|not all of the space available" "$RESIZE_ERR" 2>/dev/null; then
             log "✓ partition appears already at maximum size; continuing"
         else
             cat "$RESIZE_ERR" >&2 || true

--- a/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
@@ -9,6 +9,9 @@ REMOUNTED_RW=0
 RUN_ID="$(date -u +%Y%m%dT%H%M%SZ)-$$"
 INSTALL_RC=0
 DRY_RUN=0
+DIRECT_MODE=0
+DISPATCHED_MODE=0
+BOOT_RW_REQUIRED=1
 
 log() { printf '[iotgw-rauc-install] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
@@ -22,10 +25,14 @@ audit() {
 
 usage() {
     cat >&2 <<'EOF'
-Usage: iotgw-rauc-install [-n|--n|--dry-run] <bundle|url> [rauc install args...]
+Usage: iotgw-rauc-install [--direct] [--no-systemd-run] [-n|--n|--dry-run] <bundle|url> [rauc install args...]
 
 Wrapper for `rauc install` that temporarily remounts /boot read-write so
 fw_setenv-backed bootloader updates succeed, then restores prior mount state.
+If `/etc/fw_env.config` does not point into `/boot`, remount is skipped.
+
+By default, it dispatches itself through `systemd-run` for consistent
+privilege/mount namespace semantics on hardened systems.
 EOF
     exit 2
 }
@@ -56,6 +63,14 @@ trap restore_mount_state EXIT INT TERM
 
 while [ "$#" -gt 0 ]; do
     case "$1" in
+        --direct)
+            DIRECT_MODE=1
+            shift
+            ;;
+        --no-systemd-run)
+            DISPATCHED_MODE=1
+            shift
+            ;;
         -n|--n|--dry-run)
             DRY_RUN=1
             shift
@@ -81,31 +96,78 @@ command -v rauc >/dev/null 2>&1 || die "rauc command not found"
 command -v mountpoint >/dev/null 2>&1 || die "mountpoint command not found"
 command -v findmnt >/dev/null 2>&1 || die "findmnt command not found"
 
-if mountpoint -q "${BOOT_MP}"; then
-    MOUNTED_BEFORE=1
-else
-    mount "${BOOT_MP}" || die "failed to mount ${BOOT_MP}"
-    MOUNTED_BY_US=1
+if [ -r /etc/fw_env.config ]; then
+    fw_env_target="$(awk '!/^[[:space:]]*#/ && NF {print $1; exit}' /etc/fw_env.config || true)"
+    case "${fw_env_target}" in
+        /boot/*)
+            BOOT_RW_REQUIRED=1
+            ;;
+        *)
+            BOOT_RW_REQUIRED=0
+            ;;
+    esac
 fi
 
-if [ "${MOUNTED_BEFORE}" -eq 1 ] || [ "${MOUNTED_BY_US}" -eq 1 ]; then
-    if findmnt -no OPTIONS "${BOOT_MP}" | grep -qw ro; then
-        RO_BEFORE=1
+# Prefer executing from systemd manager context to avoid hardened SSH session
+# namespace/capability differences from rauc.service.
+if [ "${DIRECT_MODE}" -eq 0 ] && [ "${DISPATCHED_MODE}" -eq 0 ]; then
+    if command -v systemd-run >/dev/null 2>&1; then
+        unit="iotgw-rauc-install-${RUN_ID}"
+        audit "dispatching via systemd-run unit=${unit}"
+        if systemd-run \
+            --quiet \
+            --wait \
+            --collect \
+            --pipe \
+            --unit "${unit}" \
+            /usr/sbin/iotgw-rauc-install --direct "$@"; then
+            INSTALL_RC=0
+            audit "systemd-run install succeeded"
+            exit 0
+        else
+            INSTALL_RC=$?
+            audit "systemd-run install failed rc=${INSTALL_RC}"
+            exit "${INSTALL_RC}"
+        fi
+    fi
+    audit "systemd-run not available; continuing direct"
+fi
+
+if [ "${BOOT_RW_REQUIRED}" -eq 1 ]; then
+    if mountpoint -q "${BOOT_MP}"; then
+        MOUNTED_BEFORE=1
+    else
+        mount "${BOOT_MP}" || die "failed to mount ${BOOT_MP}"
+        MOUNTED_BY_US=1
+    fi
+
+    if [ "${MOUNTED_BEFORE}" -eq 1 ] || [ "${MOUNTED_BY_US}" -eq 1 ]; then
+        if findmnt -no OPTIONS "${BOOT_MP}" | grep -qw ro; then
+            RO_BEFORE=1
+        fi
     fi
 fi
 
 if [ "${DRY_RUN}" -eq 1 ]; then
     audit "dry-run bundle='$*' mounted_before=${MOUNTED_BEFORE} ro_before=${RO_BEFORE}"
-    audit "dry-run would remount ${BOOT_MP} rw"
+    if [ "${BOOT_RW_REQUIRED}" -eq 1 ]; then
+        audit "dry-run would remount ${BOOT_MP} rw"
+    else
+        audit "dry-run: /boot remount not required (fw_env.config target='${fw_env_target:-unknown}')"
+    fi
     audit "dry-run would run: rauc install $*"
     INSTALL_RC=0
     exit 0
 fi
 
 audit "starting bundle='$*' mounted_before=${MOUNTED_BEFORE} ro_before=${RO_BEFORE}"
-mount -o remount,rw "${BOOT_MP}" || die "failed to remount ${BOOT_MP} rw"
-REMOUNTED_RW=1
-audit "remounted /boot rw"
+if [ "${BOOT_RW_REQUIRED}" -eq 1 ]; then
+    mount -o remount,rw "${BOOT_MP}" || die "failed to remount ${BOOT_MP} rw"
+    REMOUNTED_RW=1
+    audit "remounted /boot rw"
+else
+    audit "/boot remount skipped (fw_env.config target='${fw_env_target:-unknown}')"
+fi
 
 audit "running rauc install"
 if rauc install "$@"; then

--- a/meta-iot-gateway/recipes-ota/rauc/files/system.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/system.conf
@@ -17,11 +17,11 @@ tls-ca=/etc/ota/ca.crt
 send-headers=boot-id;machine-id;transaction-id
 
 [slot.rootfs.0]
-device=/dev/mmcblk0p2
+device=/dev/disk/by-partlabel/rootA
 type=ext4
 bootname=A
 
 [slot.rootfs.1]
-device=/dev/mmcblk0p3
+device=/dev/disk/by-partlabel/rootB
 type=ext4
 bootname=B

--- a/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Safe RAUC install wrapper for read-only /boot setups"
-DESCRIPTION = "Runs rauc install with temporary /boot rw remount so fw_setenv-backed bootloader writes succeed, then restores original mount state."
+DESCRIPTION = "Runs rauc install and remounts /boot rw only when fw_env.config targets /boot; otherwise installs directly."
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
@@ -15,4 +15,3 @@ do_install() {
 }
 
 FILES:${PN} += " ${sbindir}/iotgw-rauc-install "
-

--- a/meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in
@@ -1,7 +1,10 @@
 # RAUC A/B layout sized to fit common 16GB SD cards
 
 # Boot partition (shared)
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid --no-fstab-update
+
+# Dedicated U-Boot environment partition (kept writable; separate from /boot)
+part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 3G --uuid rootA-uuid
@@ -10,7 +13,7 @@ part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
 part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 3G --uuid rootB-uuid
 
 # Data partition (persistent)
-part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 2G --fsoptions "defaults"
+part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 2G --fsoptions "defaults" --no-fstab-update
 # Note: runtime mount options (noatime/commit) are set in /etc/fstab, not here.
 
-bootloader --ptable msdos
+bootloader --ptable gpt

--- a/meta-iot-gateway/wic/iot-gw-rauc-32g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-32g.wks.in
@@ -1,7 +1,10 @@
 # RAUC A/B layout sized to fit common 32GB SD cards
 
 # Boot partition (shared)
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid --no-fstab-update
+
+# Dedicated U-Boot environment partition (kept writable; separate from /boot)
+part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 6G --uuid rootA-uuid
@@ -10,7 +13,7 @@ part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
 part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 6G --uuid rootB-uuid
 
 # Data partition (persistent)
-part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 12G --fsoptions "defaults"
+part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 12G --fsoptions "defaults" --no-fstab-update
 # Note: runtime mount options (noatime/commit) are set in /etc/fstab, not here.
 
-bootloader --ptable msdos
+bootloader --ptable gpt

--- a/meta-iot-gateway/wic/iot-gw-rauc-64g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-64g.wks.in
@@ -1,7 +1,10 @@
 # RAUC A/B layout sized to fit common 64GB SD cards
 
 # Boot partition (shared)
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 256M --use-uuid --no-fstab-update
+
+# Dedicated U-Boot environment partition (kept writable; separate from /boot)
+part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 8G --uuid rootA-uuid
@@ -10,7 +13,7 @@ part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
 part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 8G --uuid rootB-uuid
 
 # Data partition (persistent)
-part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 36G --fsoptions "defaults"
+part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 36G --fsoptions "defaults" --no-fstab-update
 # Note: runtime mount options (noatime/commit) are set in /etc/fstab, not here.
 
-bootloader --ptable msdos
+bootloader --ptable gpt

--- a/meta-iot-gateway/wic/iot-gw-rauc.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc.wks.in
@@ -2,7 +2,10 @@
 # Based on Raspberry Pi 5 requirements
 
 # Boot partition (shared between slots)
-part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 512M --use-uuid
+part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boot --active --align 4096 --size 512M --use-uuid --no-fstab-update
+
+# Dedicated U-Boot environment partition (kept writable; separate from /boot)
+part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A (initially active)
 part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 8G --uuid rootA-uuid
@@ -11,10 +14,10 @@ part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096
 part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 8G --uuid rootB-uuid
 
 # Data partition (persistent storage, survives updates)
-part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 10G --fsoptions "defaults"
+part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 10G --fsoptions "defaults" --no-fstab-update
 # Note: runtime mount options (noatime/commit) are set in /etc/fstab, not here.
 
 # Remaining space can be used for logs, caching, etc.
 # Or extend data partition to use full card
 
-bootloader --ptable msdos
+bootloader --ptable gpt


### PR DESCRIPTION
## Summary
- add dedicated FAT /uboot-env partition in WIC layouts
- update U-Boot env config and boot script integration for RAUC slot handling
- update RAUC/system files and hooks for new partition layout
- update docs and fstab comments to reflect GPT + A/B layout
- include grow-data-partition handling updates for resized data partition

## Notes
- commit intentionally scoped to partition/layout work only