### PR TITLE
Post-ubootenv follow-ups: service and image integration fixes

### DIFF
--- a/meta-iot-gateway/recipes-bsp/bootimage/rpi-bootfiles-archive-common.inc
+++ b/meta-iot-gateway/recipes-bsp/bootimage/rpi-bootfiles-archive-common.inc
@@ -11,6 +11,7 @@ S = "${WORKDIR}"
 
 IOTGW_BOOTFILES_ARCHIVE_NAME ?= "bootfiles.tar.gz"
 IOTGW_BOOTFILES_STAGE_FILES ?= "boot.scr u-boot.bin config.txt cmdline.txt splash.bmp Image kernel_2712.img"
+IOTGW_KERNEL_CONSOLE ?= "ttyAMA10,115200"
 
 do_deploy() {
     install -d ${DEPLOYDIR}
@@ -118,6 +119,13 @@ do_deploy() {
     require_staged_file u-boot.bin
     require_staged_file config.txt
     require_staged_file cmdline.txt
+
+    # Normalize kernel console in shipped cmdline.txt.
+    # Keep only one console= token and force the platform default.
+    if [ -n "${IOTGW_KERNEL_CONSOLE}" ]; then
+        cmdline_clean=$(sed -E 's/(^|[[:space:]])console=[^[:space:]]+//g; s/[[:space:]]+/ /g; s/^ //; s/ $//' "$workdir/cmdline.txt")
+        printf '%s console=%s\n' "$cmdline_clean" "${IOTGW_KERNEL_CONSOLE}" > "$workdir/cmdline.txt"
+    fi
 
     # Validate kernel image presence for requested boot flow.
     case " ${IOTGW_BOOTFILES_STAGE_FILES} " in

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-dev.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-dev.bb
@@ -16,6 +16,7 @@ RDEPENDS:${PN} = " \
     htop \
     kernel-hardening-checker \
     ota-certs-devca \
+    ota-updater \
 "
 
 # Optional: container runtime tools (opt-in)

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.service
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.service
@@ -31,7 +31,7 @@ RestrictNamespaces=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/etc/ota /data/ota /var/lib /boot
+ReadWritePaths=/etc/ota /data /var/lib /boot
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-iot-gateway/recipes-security/iotgw-hardening/files/service-hardening-mosquitto.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-hardening/files/service-hardening-mosquitto.conf
@@ -1,4 +1,9 @@
 [Service]
+# Upstream unit creates /var/log/mosquitto in ExecStartPre.
+# On RO root/overlay setups this can fail during boot ordering.
+# We log to stderr/journald, so drop those pre-start filesystem mutations.
+ExecStartPre=
+
 User=mosquitto
 Group=mosquitto
 RuntimeDirectory=mosquitto

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
@@ -60,9 +60,9 @@ done
 # Ensure persistent journald storage exists after /var overlay is mounted.
 if [ ! -d /var/log/journal ]; then
     log "Creating /var/log/journal for persistent journald storage"
-    mkdir -p /var/log/journal
-    chown root:systemd-journal /var/log/journal
-    chmod 2755 /var/log/journal
 fi
+mkdir -p /var/log/journal
+chown root:systemd-journal /var/log/journal
+chmod 2755 /var/log/journal
 
 log "Overlayfs setup complete"


### PR DESCRIPTION
## Summary
- include ota-updater package in dev packagegroup so ota runtime user path is available
- adjust OTA cert provisioning service hardening/mount-write behavior for runtime path needs
- align overlayfs setup behavior and service hardening follow-ups
- update bootfiles archive common include as part of post-layout cleanup

## Scope
Single follow-up PR after /uboot-env partition merge to stabilize runtime services.