### PR TITLE
packagegroups: gate edge-healthd monitoring via feature flag

### DIFF
--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -75,7 +75,7 @@ ROOT_HOME ?= "/root"
 
 # Allow injecting Wi-Fi credentials from the shell environment without committing them
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
-BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
 
 # Prune machine features that are not relevant on Raspberry Pi 5

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-apps.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-apps.bb
@@ -7,6 +7,9 @@ inherit packagegroup
 # Avoid allarch so we can depend on dynamically renamed libs (ABI/versioned)
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+# Optional application feature toggles
+IOTGW_ENABLE_EDGE_HEALTHD ?= "0"
+
 PACKAGES = " \
     ${PN} \
     ${PN}-mqtt \
@@ -45,6 +48,7 @@ RDEPENDS:${PN}-database = " \
 RDEPENDS:${PN}-monitoring = " \
     sysstat \
 "
+RDEPENDS:${PN}-monitoring:append = "${@bb.utils.contains('IOTGW_ENABLE_EDGE_HEALTHD','1',' edge-healthd','',d)}"
 
 RDEPENDS:${PN}-node-runtime = " \
     nodejs \


### PR DESCRIPTION
## Summary
- pass through IOTGW_ENABLE_EDGE_HEALTHD in distro env passthrough additions
- add optional edge-healthd toggle in packagegroup-iot-gw-apps
- append edge-healthd to monitoring packagegroup only when enabled

## Validation
- user-verified in local build/test flow