### PR TITLE
rauc: enforce adaptive alignment guard and fix first-boot bootargs

### DIFF
--- a/docs/PARTITIONS.md
+++ b/docs/PARTITIONS.md
@@ -21,7 +21,7 @@ on first boot by `rauc-grow-data-partition`.
 
 | Card Size | WKS File | RootA/B Size | /data Base Size | Remaining (for auto-grow) |
 |-----------|----------|--------------|-----------------|---------------------------|
-| **16GB** (default) | `iot-gw-rauc-16g.wks.in` | 3G / 3G | 2G | ~7GB |
+| **16GB** (default) | `iot-gw-rauc-16g.wks.in` | 4G / 4G (fixed) | 2G | ~5GB |
 | **32GB** | `iot-gw-rauc-32g.wks.in` | 6G / 6G | 12G | ~8GB |
 | **64GB** | `iot-gw-rauc-64g.wks.in` | 8G / 8G | 36G | ~12GB |
 
@@ -29,7 +29,7 @@ on first boot by `rauc-grow-data-partition`.
 
 ## 16GB Layout (Default)
 
-**Total Allocated (base):** ~8.3GB
+**Total Allocated (base):** ~10.3GB
 **Target Card:** 16GB SD card
 **File:** `iot-gw-rauc-16g.wks.in`
 
@@ -37,11 +37,11 @@ on first boot by `rauc-grow-data-partition`.
 |---|--------|-------|------|------|-------|---------|
 | 1 | `/dev/mmcblk0p1` | `boot` | 256M | vfat (FAT32) | `/boot` | U-Boot, kernel, DTBs (shared) |
 | 2 | `/dev/mmcblk0p2` | `ubootenv` | 16M | vfat (FAT32) | `/uboot-env` | Dedicated U-Boot environment store |
-| 3 | `/dev/mmcblk0p3` | `rootA` | 3G | ext4 | `/` | Root filesystem Slot A |
-| 4 | `/dev/mmcblk0p4` | `rootB` | 3G | ext4 | - | Root filesystem Slot B |
+| 3 | `/dev/mmcblk0p3` | `rootA` | 4G (fixed) | ext4 | `/` | Root filesystem Slot A |
+| 4 | `/dev/mmcblk0p4` | `rootB` | 4G (fixed) | ext4 | - | Root filesystem Slot B |
 | 5 | `/dev/mmcblk0p5` | `data` | 2G | ext4 | `/data` | Persistent user data |
 
-**Remaining Space:** ~7GB reserved for auto-grow
+**Remaining Space:** ~5GB reserved for auto-grow
 **After First Boot:** `/data` expands to fill remaining free space
 
 **Use Case:** Compact IoT gateway, minimal storage requirements
@@ -133,7 +133,7 @@ on first boot by `rauc-grow-data-partition`.
 
 ---
 
-### Partition 4: Data (`data`)
+### Partition 5: Data (`data`)
 
 **Format:** ext4
 **Mount:** `/data`
@@ -218,7 +218,7 @@ rauc status
 
 ## Data Partition Auto-resize
 
-On first boot, the `rauc-grow-data-part` service automatically expands the `/data` partition to use all available unallocated space.
+On first boot, the `rauc-grow-data-partition` service automatically expands the `/data` partition to use all available unallocated space.
 
 **Systemd Unit:** `rauc-grow-data-partition.service`
 
@@ -256,10 +256,10 @@ cp meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in \
 2. Edit partition sizes:
 ```
 # Partition 3: rootA
-part / --source rootfs --rootfs-dir=${IMAGE_ROOTFS} --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 4G --use-uuid
+part / --source rootfs --rootfs-dir=${IMAGE_ROOTFS} --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --fixed-size 4G --use-uuid
 
 # Partition 4: rootB
-part --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 4G --use-uuid
+part --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --fixed-size 4G --use-uuid
 
 # Partition 5: data
 part --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 4G --use-uuid

--- a/docs/RAUC_UPDATE.md
+++ b/docs/RAUC_UPDATE.md
@@ -26,6 +26,12 @@ Manual install workflow (recommended):
 iotgw-rauc-install <bundle>.raucb
 ```
 
+HTTPS streaming install (manual, recommended for OTA server flow):
+
+```bash
+iotgw-rauc-install https://<ota-host>:8443/bundles/<bundle>.raucb
+```
+
 Behavior notes:
 
 - default path: wrapper dispatches through `systemd-run` to execute from system
@@ -45,6 +51,26 @@ Audit wrapper events (/boot rw window + restore):
 journalctl --no-pager -t iotgw-rauc-install
 ```
 
+### Streaming Preflight (mTLS)
+
+Before remote installs, verify cert chain and manifest reachability:
+
+```bash
+openssl verify -CAfile /etc/ota/ca.crt /etc/ota/device.crt
+curl --cert /etc/ota/device.crt \
+     --key /etc/ota/device.key \
+     --cacert /etc/ota/ca.crt \
+     -fsS https://<ota-host>:8443/api/v1/manifest.json | jq .
+```
+
+Then install the exact `bundle_url` from the manifest.
+
+Notes:
+
+- If mDNS hostname (`ota-gw.local`) is not resolvable on your LAN, use the
+  server IP in the install URL for manual testing.
+- Ensure the server certificate SAN matches the URL host you use (DNS name or IP).
+
 ## Check Slot State
 
 ```bash
@@ -61,6 +87,18 @@ Expected:
 
 If enabled (`RAUC_SLOT_rootfs[adaptive] = "block-hash-index"`), RAUC requires
 target rootfs slot sizes to be 4 KiB aligned.
+
+Build-time guard:
+
+- implemented in reusable class:
+  `meta-iot-gateway/classes/iotgw-rauc-adaptive-guard.bbclass`
+- when `IOTGW_RAUC_ADAPTIVE = "1"`, the class task validates IoT Gateway RAUC
+  WKS root slot geometry (`rootA` and `rootB` `--fixed-size`) is a 4096-byte
+  multiple
+- build fails early if either adaptive root slot is missing or misaligned
+- image build also validates generated WIC partition geometry via
+  `do_iotgw_validate_wic_alignment` in
+  `meta-iot-gateway/classes/iotgw-rauc-image.bbclass`
 
 If not aligned, RAUC logs an adaptive mode error and falls back to normal full
 write, for example:
@@ -124,7 +162,7 @@ stale overlay masks in `/data/overlays/etc/upper/systemd/system/`.
 
 ### What To Do If Misaligned
 
-- Keep adaptive mode disabled (`IOTGW_RAUC_ADAPTIVE = "0"`) for current
-  deployed layout.
-- Re-enable adaptive mode only after reflashing with a 4 KiB-aligned partition
-  table.
+- Fix `WKS_FILE` so `rootA` and `rootB` use aligned `--fixed-size` values.
+- Rebuild the bundle with adaptive mode enabled and confirm the gate passes.
+- If deployed devices are already on a non-aligned partition layout, keep
+  adaptive mode disabled for those devices until they are reflashed.

--- a/meta-iot-gateway/classes/iotgw-rauc-adaptive-guard.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rauc-adaptive-guard.bbclass
@@ -1,0 +1,137 @@
+## Reusable adaptive slot geometry validation for RAUC bundle recipes.
+##
+## This class enforces that rootA/rootB partition sizes in IoT Gateway RAUC
+## WKS layouts are exact multiples of 4096 bytes when adaptive mode is on.
+
+python do_iotgw_rauc_alignment_check() {
+    import glob
+    import os
+    import re
+
+    if d.getVar("IOTGW_RAUC_ADAPTIVE") != "1":
+        bb.note("Adaptive alignment gate skipped (IOTGW_RAUC_ADAPTIVE != 1)")
+        return
+
+    alignment = 4096
+
+    def parse_size_to_bytes(size_token):
+        match = re.match(r"^\s*([0-9]+)\s*([KMGT]?)\s*$", size_token)
+        if not match:
+            bb.fatal("Invalid WKS --size value for adaptive gate: %s" % size_token)
+
+        value = int(match.group(1))
+        unit = match.group(2).upper()
+        factor = {
+            "": 1,
+            "K": 1024,
+            "M": 1024 * 1024,
+            "G": 1024 * 1024 * 1024,
+            "T": 1024 * 1024 * 1024 * 1024,
+        }[unit]
+        return value * factor
+
+    def resolve_wks_file(wks_name):
+        bbpath = d.getVar("BBPATH") or ""
+        for relpath in (wks_name, os.path.join("wic", wks_name)):
+            candidate = bb.utils.which(bbpath, relpath)
+            if candidate:
+                return candidate
+
+        search_paths = (d.getVar("WKS_SEARCH_PATH") or "").split(":")
+        for base in search_paths:
+            if not base:
+                continue
+            candidate = os.path.join(base, wks_name)
+            if os.path.isfile(candidate):
+                return candidate
+
+        return None
+
+    def collect_root_slot_sizes(wks_path):
+        root_sizes = {}
+        with open(wks_path, encoding="utf-8") as handle:
+            for lineno, line in enumerate(handle, 1):
+                stripped = line.strip()
+                if not stripped or stripped.startswith("#") or not stripped.startswith("part "):
+                    continue
+
+                label_match = re.search(r"--label\s+([^\s]+)", stripped)
+                if not label_match:
+                    continue
+
+                label = label_match.group(1)
+                if label not in ("rootA", "rootB"):
+                    continue
+
+                size_match = re.search(r"--(?:fixed-size|size)\s+([0-9]+\s*[KMGT]?)\b", stripped)
+                if not size_match:
+                    bb.fatal(
+                        "Adaptive alignment gate: missing --size/--fixed-size for %s in %s:%d"
+                        % (label, wks_path, lineno)
+                    )
+
+                size_token = size_match.group(1)
+                root_sizes[label] = (size_token, parse_size_to_bytes(size_token), lineno)
+
+        return root_sizes
+
+    # Keep guard deterministic across bundle contexts: discover IoT GW RAUC
+    # layouts from the layer's wic directory, instead of hardcoding filenames.
+    wks_paths = []
+
+    thisdir = d.getVar("THISDIR") or ""
+    layer_wic_dir = os.path.normpath(os.path.join(thisdir, "..", "wic"))
+    if os.path.isdir(layer_wic_dir):
+        for candidate in sorted(glob.glob(os.path.join(layer_wic_dir, "iot-gw-rauc*.wks.in"))):
+            wks_paths.append(candidate)
+
+    # Fallback for unusual parse contexts where THISDIR is not the class dir.
+    if not wks_paths:
+        bbpath = d.getVar("BBPATH") or ""
+        for base in bbpath.split(":"):
+            if not base:
+                continue
+            wic_dir = os.path.join(base, "wic")
+            if not os.path.isdir(wic_dir):
+                continue
+            for candidate in sorted(glob.glob(os.path.join(wic_dir, "iot-gw-rauc*.wks.in"))):
+                wks_paths.append(candidate)
+
+    # Deduplicate while preserving order.
+    unique_paths = []
+    for path in wks_paths:
+        if path not in unique_paths:
+            unique_paths.append(path)
+    wks_paths = unique_paths
+
+    if not wks_paths:
+        bb.fatal(
+            "Adaptive alignment gate could not find IoT GW RAUC WKS layouts to validate. "
+            "Checked layer wic/ directory and BBPATH fallback."
+        )
+
+    validated = []
+    for wks_path in wks_paths:
+        root_sizes = collect_root_slot_sizes(wks_path)
+        missing = [slot for slot in ("rootA", "rootB") if slot not in root_sizes]
+        if missing:
+            bb.fatal(
+                "Adaptive alignment gate failed: missing root slots in %s: %s"
+                % (wks_path, ", ".join(missing))
+            )
+
+        for label in ("rootA", "rootB"):
+            size_token, size_bytes, lineno = root_sizes[label]
+            if size_bytes % alignment != 0:
+                bb.fatal(
+                    "Adaptive alignment gate failed for %s in %s:%d: --size %s resolves to %d bytes "
+                    "(must be multiple of %d)"
+                    % (label, wks_path, lineno, size_token, size_bytes, alignment)
+                )
+
+        validated.append(os.path.basename(wks_path))
+
+    bb.note("Adaptive alignment gate passed for: %s" % ", ".join(validated))
+}
+
+addtask iotgw_rauc_alignment_check before do_configure after do_patch

--- a/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
@@ -47,3 +47,85 @@ iotgw_rauc_create_home_dirs() {
 IMAGE_INSTALL:append:desktop = " ${IOTGW_DESKTOP_PACKAGES}"
 
 ## Note: bootfiles are updated via RAUC bundle hooks (bootfiles.tar.gz)
+
+# Validate generated WIC geometry for adaptive updates.
+# This checks the final .direct artifact (not just WKS intent) and fails if
+# rootA/rootB partition byte sizes are not 4KiB aligned.
+python do_iotgw_validate_wic_alignment() {
+    import glob
+    import os
+
+    if d.getVar("IOTGW_RAUC_ADAPTIVE") != "1":
+        bb.note("WIC adaptive alignment check skipped (IOTGW_RAUC_ADAPTIVE != 1)")
+        return
+
+    alignment = 4096
+    build_wic_dir = os.path.join(d.getVar("WORKDIR"), "build-wic")
+    slot_sizes = {}
+    source_desc = ""
+
+    # Preferred path for current flow: split partition images .direct.pN.
+    part3 = sorted(glob.glob(os.path.join(build_wic_dir, "*.direct.p3")), key=os.path.getmtime)
+    part4 = sorted(glob.glob(os.path.join(build_wic_dir, "*.direct.p4")), key=os.path.getmtime)
+    if part3 and part4:
+        p3 = part3[-1]
+        p4 = part4[-1]
+        slot_sizes["rootA"] = os.path.getsize(p3)
+        slot_sizes["rootB"] = os.path.getsize(p4)
+        source_desc = "%s and %s" % (os.path.basename(p3), os.path.basename(p4))
+    else:
+        # Fallback for monolithic .direct image outputs.
+        direct_images = sorted(
+            glob.glob(os.path.join(build_wic_dir, "*.direct")),
+            key=os.path.getmtime
+        )
+        if not direct_images:
+            bb.fatal(
+                "WIC adaptive alignment check: no .direct or .direct.p3/.direct.p4 artifacts found in %s"
+                % build_wic_dir
+            )
+
+        direct_img = direct_images[-1]
+        source_desc = os.path.basename(direct_img)
+        out, _ = bb.process.run("sfdisk -d %s" % direct_img)
+
+        import re
+        for line in out.splitlines():
+            line = line.strip()
+            if not line.startswith("/dev/"):
+                continue
+
+            size_match = re.search(r"size=\s*([0-9]+)", line)
+            name_match = re.search(r'name=\"([^\"]+)\"', line)
+            if not size_match or not name_match:
+                continue
+
+            name = name_match.group(1)
+            if name not in ("rootA", "rootB"):
+                continue
+
+            sectors = int(size_match.group(1))
+            slot_sizes[name] = sectors * 512
+
+    missing = [slot for slot in ("rootA", "rootB") if slot not in slot_sizes]
+    if missing:
+        bb.fatal(
+            "WIC adaptive alignment check failed: missing root slot sizes from %s: %s"
+            % (source_desc, ", ".join(missing))
+        )
+
+    for slot in ("rootA", "rootB"):
+        size_bytes = slot_sizes[slot]
+        if size_bytes % alignment != 0:
+            bb.fatal(
+                "WIC adaptive alignment check failed for %s in %s: size=%d bytes (mod %d = %d)"
+                % (slot, direct_img, size_bytes, alignment, size_bytes % alignment)
+            )
+
+    bb.note(
+        "WIC adaptive alignment check passed for %s: rootA=%d rootB=%d"
+        % (source_desc, slot_sizes["rootA"], slot_sizes["rootB"])
+    )
+}
+
+addtask iotgw_validate_wic_alignment after do_image_wic before do_image_complete

--- a/meta-iot-gateway/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-iot-gateway/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -1,0 +1,7 @@
+# Ensure firmware-provided /chosen/bootargs uses the gateway serial console.
+# U-Boot inherits these args and appends RAUC slot root=PARTUUID at runtime.
+CMDLINE_SERIAL = "console=ttyAMA10,115200"
+
+# Avoid embedding a static root= token from firmware cmdline.
+# RAUC/U-Boot chooses the active slot and injects root=PARTUUID dynamically.
+CMDLINE_ROOTFS = ""

--- a/meta-iot-gateway/recipes-ota/bundles/iot-gw-bundle-common.inc
+++ b/meta-iot-gateway/recipes-ota/bundles/iot-gw-bundle-common.inc
@@ -3,7 +3,7 @@
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-inherit bundle
+inherit bundle iotgw-rauc-adaptive-guard
 
 # Bundle identity (matches device system.conf via rauc-conf)
 RAUC_BUNDLE_COMPATIBLE ?= "iot-gateway-${MACHINE}"
@@ -17,10 +17,8 @@ IOTGW_RAUC_BOOTFILES_BUNDLE_FILE ?= "bootfiles.tar.gz"
 
 # Slots included in the bundle
 RAUC_BUNDLE_SLOTS = "rootfs"
-# Keep adaptive updates disabled by default. Current slot image/partition size
-# in this project is not 4KiB-aligned, which triggers RAUC fallback warnings:
-# "Continuing after adaptive mode error ... not a multiple of 4096 bytes".
-# Re-enable when partition geometry is aligned for block-hash-index mode.
+# Keep adaptive updates opt-in by default. When enabled, a build-time guard
+# validates IoT GW RAUC rootA/rootB geometry is 4KiB aligned.
 IOTGW_RAUC_ADAPTIVE ?= "0"
 
 # Use the selected image for the rootfs slot (set BUNDLE_IMAGE in variants)

--- a/meta-iot-gateway/recipes-ota/rauc/files/grow-data-partition.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/grow-data-partition.sh
@@ -3,7 +3,7 @@
 
 set -Eeuo pipefail
 
-STAMP="/var/lib/rauc-grow-done"
+STAMP="/boot/.rauc-grow-done"
 LOG_TAG="rauc-grow"
 
 log() { printf '[%s] %s\n' "$LOG_TAG" "$*" >&2; }
@@ -36,11 +36,10 @@ run_parted_resize() {
         return 0
     fi
 
-    # Some platforms prompt even in script mode:
-    # 1) GPT backup header not at disk end ("Fix/Ignore")
-    # 2) partition in use ("Yes/No")
-    if printf 'Fix\nYes\n' | parted --pretend-input-tty "$disk" resizepart "$part_num" 100% \
-        > /dev/null 2>"$err_file"; then
+    # Retry once after re-reading partition table.
+    partprobe "$disk" 2>/dev/null || true
+    udevadm settle 2>/dev/null || true
+    if parted -s "$disk" resizepart "$part_num" 100% 2>"$err_file"; then
         return 0
     fi
 
@@ -59,6 +58,7 @@ main() {
     command -v lsblk >/dev/null 2>&1 || die "lsblk not installed"
     command -v partprobe >/dev/null 2>&1 || die "partprobe not installed"
     command -v udevadm >/dev/null 2>&1 || die "udevadm not installed"
+    command -v sgdisk >/dev/null 2>&1 || die "sgdisk not installed"
 
     DATA_PART=$(resolve_data_part) || die "could not resolve data partition by label 'data'"
     [ -b "$DATA_PART" ] || die "not a block device: $DATA_PART"
@@ -77,17 +77,17 @@ main() {
     # Best-effort rescan before resize
     partprobe "$DISK" 2>/dev/null || true
 
-    # Best-effort GPT backup table relocation (common when image is smaller than media).
-    if command -v sgdisk >/dev/null 2>&1; then
-        sgdisk -e "$DISK" >/dev/null 2>&1 || true
-    fi
+    # Relocate GPT backup table to disk end (required for larger media than image).
+    sgdisk -e "$DISK" >/dev/null 2>&1 || die "failed to relocate GPT backup header on $DISK"
+    partprobe "$DISK" 2>/dev/null || true
+    udevadm settle 2>/dev/null || true
 
     # Attempt to grow the partition to 100%. If already at max, just continue.
     RESIZE_ERR=$(mktemp)
     if run_parted_resize "$DISK" "$PART_NUM" "$RESIZE_ERR"; then
         log "📏 resized partition $PART_NUM to 100%"
     else
-        if grep -qi "cannot be grown\|already at maximum size\|out of range\|is being used\|not all of the space available" "$RESIZE_ERR" 2>/dev/null; then
+        if grep -qi "cannot be grown\|already at maximum size\|out of range" "$RESIZE_ERR" 2>/dev/null; then
             log "✓ partition appears already at maximum size; continuing"
         else
             cat "$RESIZE_ERR" >&2 || true

--- a/meta-iot-gateway/recipes-ota/rauc/files/rauc-grow-data-partition.service
+++ b/meta-iot-gateway/recipes-ota/rauc/files/rauc-grow-data-partition.service
@@ -2,10 +2,12 @@
 Description=Grow /data partition to fill SD card
 DefaultDependencies=no
 # Must run after block devices are available but before data.mount
-After=systemd-udev-settle.service
+Wants=systemd-udev-settle.service
+After=systemd-udev-settle.service boot.mount
 Before=data.mount local-fs.target
+RequiresMountsFor=/boot
 # Only run if we haven't already done it
-ConditionPathExists=!/var/lib/rauc-grow-done
+ConditionPathExists=!/boot/.rauc-grow-done
 
 [Service]
 Type=oneshot
@@ -17,5 +19,4 @@ TimeoutSec=2min
 RemainAfterExit=yes
 
 [Install]
-WantedBy=multi-user.target
-
+WantedBy=local-fs.target

--- a/meta-iot-gateway/recipes-ota/rauc/files/system.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/system.conf
@@ -16,6 +16,16 @@ tls-ca=/etc/ota/ca.crt
 # Send device info as HTTP headers
 send-headers=boot-id;machine-id;transaction-id
 
+[log.ota]
+# Relative path -> stored under data-directory (/data)
+filename=rauc-events.log
+# Keep focused OTA audit trail (install lifecycle + slot marking)
+events=install;mark
+format=json
+# Tight rotation to avoid unbounded growth on gateway storage
+max-size=512K
+max-files=3
+
 [slot.rootfs.0]
 device=/dev/disk/by-partlabel/rootA
 type=ext4

--- a/meta-iot-gateway/recipes-ota/rauc/rauc_%.bbappend
+++ b/meta-iot-gateway/recipes-ota/rauc/rauc_%.bbappend
@@ -9,9 +9,9 @@ SRC_URI:append = " \
     file://overlay-reconcile.py \
 "
 
-# grow-data-partition.sh requires bash/e2fsprogs plus util-linux (lsblk, partprobe)
-# and udev (udevadm).
-RDEPENDS:${PN}-grow-data-part:append = " bash e2fsprogs util-linux udev"
+# grow-data-partition.sh requires bash/e2fsprogs plus util-linux (lsblk, partprobe),
+# udev (udevadm), and sgdisk for GPT backup header relocation.
+RDEPENDS:${PN}-grow-data-part:append = " bash e2fsprogs util-linux udev gptfdisk"
 
 do_install:append() {
     # Override unit with our hardened version

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
@@ -58,11 +58,26 @@ for dir in ${OVERLAY_DIRS}; do
 done
 
 # Ensure persistent journald storage exists after /var overlay is mounted.
-if [ ! -d /var/log/journal ]; then
-    log "Creating /var/log/journal for persistent journald storage"
+# This is best-effort and must not break boot if local path shape differs.
+# Skip only when /var/log is unusable:
+# - dangling symlink (exists as symlink but does not resolve to a directory)
+# - existing non-directory node (regular file/device/etc.)
+if [ ! -d /var/log ] && { [ -L /var/log ] || [ -e /var/log ]; }; then
+    log "WARN: /var/log exists but is not a directory; skipping journald dir setup"
+else
+    if [ ! -d /var/log/journal ]; then
+        log "Creating /var/log/journal for persistent journald storage"
+    fi
+    if mkdir -p /var/log/journal; then
+        if getent group systemd-journal >/dev/null 2>&1; then
+            chown root:systemd-journal /var/log/journal || log "WARN: failed to chown /var/log/journal"
+            chmod 2755 /var/log/journal || log "WARN: failed to chmod /var/log/journal"
+        else
+            log "WARN: systemd-journal group not found; skipping ownership update"
+        fi
+    else
+        log "WARN: failed to create /var/log/journal; continuing"
+    fi
 fi
-mkdir -p /var/log/journal
-chown root:systemd-journal /var/log/journal
-chmod 2755 /var/log/journal
 
 log "Overlayfs setup complete"

--- a/meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-16g.wks.in
@@ -7,10 +7,10 @@ part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boo
 part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 3G --uuid rootA-uuid
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --fixed-size 4G --uuid rootA-uuid
 
 # Root filesystem - Slot B
-part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 3G --uuid rootB-uuid
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --fixed-size 4G --uuid rootB-uuid
 
 # Data partition (persistent)
 part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 2G --fsoptions "defaults" --no-fstab-update

--- a/meta-iot-gateway/wic/iot-gw-rauc-32g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-32g.wks.in
@@ -7,10 +7,10 @@ part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boo
 part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 6G --uuid rootA-uuid
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --fixed-size 6G --uuid rootA-uuid
 
 # Root filesystem - Slot B
-part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 6G --uuid rootB-uuid
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --fixed-size 6G --uuid rootB-uuid
 
 # Data partition (persistent)
 part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 12G --fsoptions "defaults" --no-fstab-update

--- a/meta-iot-gateway/wic/iot-gw-rauc-64g.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc-64g.wks.in
@@ -7,10 +7,10 @@ part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boo
 part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 8G --uuid rootA-uuid
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --fixed-size 8G --uuid rootA-uuid
 
 # Root filesystem - Slot B
-part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 8G --uuid rootB-uuid
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --fixed-size 8G --uuid rootB-uuid
 
 # Data partition (persistent)
 part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 36G --fsoptions "defaults" --no-fstab-update

--- a/meta-iot-gateway/wic/iot-gw-rauc.wks.in
+++ b/meta-iot-gateway/wic/iot-gw-rauc.wks.in
@@ -8,10 +8,10 @@ part /boot --source bootimg-partition --ondisk mmcblk0 --fstype=vfat --label boo
 part /uboot-env --ondisk mmcblk0 --fstype=vfat --label ubootenv --align 4096 --size 16M --use-uuid --no-fstab-update
 
 # Root filesystem - Slot A (initially active)
-part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --size 8G --uuid rootA-uuid
+part / --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootA --align 4096 --fixed-size 8G --uuid rootA-uuid
 
 # Root filesystem - Slot B (inactive, for updates)
-part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --size 8G --uuid rootB-uuid
+part --source rootfs --ondisk mmcblk0 --fstype=ext4 --label rootB --align 4096 --fixed-size 8G --uuid rootB-uuid
 
 # Data partition (persistent storage, survives updates)
 part /data --ondisk mmcblk0 --fstype=ext4 --label data --align 4096 --size 10G --fsoptions "defaults" --no-fstab-update


### PR DESCRIPTION
## Summary
- add adaptive alignment guard class to validate IoT GW RAUC WKS rootA/rootB geometry when `IOTGW_RAUC_ADAPTIVE=1`
- add generated WIC artifact alignment check in image class (`do_iotgw_validate_wic_alignment`)
- switch RAUC WKS root slots to `--fixed-size` for deterministic adaptive geometry
- fix fresh-flash bootargs source via `rpi-cmdline.bbappend` (`console=ttyAMA10,115200`, no static `root=/dev/mmcblk0p2`)
- harden first-boot data grow and overlay setup behavior
- update RAUC/PARTITIONS docs with streaming mTLS preflight + corrected layout/service notes

## Validation
- rebuilt and flashed image on SD after full wipe
- verified partition layout on target (`rootA=4G`, `rootB=4G`, `/data` grown)
- verified grow-data one-shot behavior (`/boot/.rauc-grow-done`, skip on subsequent boots)
- verified overlay persistence behavior and journald directory handling
- verified fresh-boot cmdline now resolves to `console=ttyAMA10,115200` with RAUC dynamic PARTUUID root
- executed adaptive RAUC HTTPS streaming install (mTLS)
  - RAUC logs show adaptive hash-index path (`Building new hash index for target_slot/active_slot`)
  - transfer reused source data (`downloaded 14.3% of full bundle`)
  - install succeeded and slot switched A -> B
- post-reboot checks:
  - `rauc status --detailed`: booted from `rootfs.1 (B)`
  - no adaptive misalignment/fallback warnings (`not a multiple of 4096`)
  - `/proc/cmdline` remains correct (`console=ttyAMA10,115200`, `rauc.slot=B`)

## Notes
- OTA server cert-chain mismatch and missing manifest/bundle were resolved during validation by re-provisioning `/etc/ota/*` from aligned CA/device certs and publishing the bundle URL from server manifest.
