### PR TITLE
Machine ID: persist on RO rootfs and add consumer fallbacks

### DIFF
--- a/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
@@ -16,6 +16,7 @@ IMAGE_INSTALL += " \
     rauc-service \
     virtual-rauc-conf \
     iotgw-rauc-install \
+    iotgw-machine-id \
     boot-backup-prune \
     overlayfs-setup \
     rauc-grow-data-part \

--- a/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
@@ -15,9 +15,8 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/etc/skel/.bashrc
     install -d ${D}/uboot-env
 
-    # Create uninitialized machine-id file
-    # This signals systemd to generate a unique ID on first boot
-    # The ID will be persisted via overlayfs on /data
+    # Create uninitialized machine-id file.
+    # Runtime persistence/bind behavior is handled by iotgw-machine-id service.
     touch ${D}${sysconfdir}/machine-id
     chmod 0444 ${D}${sysconfdir}/machine-id
 }

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/generate-dev-cert.sh
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/generate-dev-cert.sh
@@ -11,7 +11,21 @@ set -euo pipefail
 readonly DEV_CA_DIR_DEFAULT="/data/ota/dev-ca"
 readonly CERT_DIR="/etc/ota"
 
-device_id="${1:-$(head -c 8 /etc/machine-id 2>/dev/null || echo 'dev-device')}"
+detect_device_id() {
+    local mid=""
+    if [[ -s /etc/machine-id ]]; then
+        mid="$(head -c 8 /etc/machine-id 2>/dev/null || true)"
+    fi
+    if [[ -z "${mid}" && -s /run/machine-id ]]; then
+        mid="$(head -c 8 /run/machine-id 2>/dev/null || true)"
+    fi
+    if [[ -z "${mid}" ]]; then
+        mid="dev-device"
+    fi
+    printf '%s' "${mid}"
+}
+
+device_id="${1:-$(detect_device_id)}"
 
 echo "Generating development certificate for device: $device_id"
 

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
@@ -16,6 +16,31 @@ readonly BOOT_SRC="/boot/iotgw/ota"
 readonly DATA_SRC="/data/ota/certs"
 readonly DEV_CA_DIR_DEFAULT="/data/ota/dev-ca"
 readonly DEV_CA_SERIAL="/data/ota/dev-ca/dev-ca.srl"
+
+get_device_id() {
+    local mid=""
+    local mac=""
+
+    if [[ -s /etc/machine-id ]]; then
+        mid=$(head -c 8 /etc/machine-id 2>/dev/null || true)
+    fi
+    if [[ -z "${mid}" && -s /run/machine-id ]]; then
+        mid=$(head -c 8 /run/machine-id 2>/dev/null || true)
+    fi
+    if [[ -n "${mid}" ]]; then
+        printf '%s' "${mid}"
+        return 0
+    fi
+
+    mac=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':' | head -c 8 || true)
+    if [[ -n "${mac}" ]]; then
+        printf '%s' "${mac}"
+        return 0
+    fi
+
+    printf 'unknown'
+    return 0
+}
 readonly STAMP="/var/lib/ota-certs-provision.done"
 
 log_info()  { echo "[$(date -Iseconds)] [INFO]  $*"; }
@@ -139,11 +164,7 @@ generate_dev_certs() {
 
     # Get a unique device ID (prefer machine-id, fallback to MAC)
     local device_id
-    if [[ -f /etc/machine-id ]]; then
-        device_id=$(head -c 8 /etc/machine-id)
-    else
-        device_id=$(cat /sys/class/net/eth0/address 2>/dev/null | tr -d ':' | head -c 8 || echo "unknown")
-    fi
+    device_id="$(get_device_id)"
 
     log_info "Generating cert for device: $device_id"
 

--- a/meta-iot-gateway/recipes-support/iotgw-machine-id/files/iotgw-machine-id.service
+++ b/meta-iot-gateway/recipes-support/iotgw-machine-id/files/iotgw-machine-id.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Persist and bind machine-id for immutable rootfs
+DefaultDependencies=no
+After=data.mount overlayfs-setup.service
+Before=sysinit.target
+Wants=data.mount overlayfs-setup.service
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/iotgw-machine-id
+
+[Install]
+WantedBy=sysinit.target

--- a/meta-iot-gateway/recipes-support/iotgw-machine-id/files/iotgw-machine-id.sh
+++ b/meta-iot-gateway/recipes-support/iotgw-machine-id/files/iotgw-machine-id.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Persist machine-id under /data and bind it to /etc/machine-id for RO rootfs.
+
+set -euo pipefail
+
+PERSIST_PATH="/data/machine-id"
+ETC_PATH="/etc/machine-id"
+
+log() {
+    echo "[iotgw-machine-id] $*"
+}
+
+read_first_line() {
+    sed -n '1p' "$1" 2>/dev/null | tr -d '[:space:]'
+}
+
+is_valid_machine_id() {
+    [[ "$1" =~ ^[0-9a-f]{32}$ ]]
+}
+
+generate_machine_id() {
+    local mid
+    mid=""
+
+    if command -v systemd-machine-id-setup >/dev/null 2>&1; then
+        mid="$(systemd-machine-id-setup --print 2>/dev/null | tail -n1 | tr -d '[:space:]' || true)"
+    fi
+    if ! is_valid_machine_id "${mid}"; then
+        mid="$(cat /proc/sys/kernel/random/uuid 2>/dev/null | tr -d '-' | tr -d '[:space:]' || true)"
+    fi
+    if ! is_valid_machine_id "${mid}"; then
+        log "ERROR: unable to generate valid machine-id"
+        return 1
+    fi
+    printf '%s\n' "${mid}"
+}
+
+if ! mountpoint -q /data; then
+    log "ERROR: /data is not mounted"
+    exit 1
+fi
+
+mid=""
+if [ -r "${PERSIST_PATH}" ]; then
+    mid="$(read_first_line "${PERSIST_PATH}")"
+fi
+
+if ! is_valid_machine_id "${mid}"; then
+    mid="$(generate_machine_id)"
+    install -d -m 0755 /data
+    printf '%s\n' "${mid}" > "${PERSIST_PATH}"
+    chmod 0444 "${PERSIST_PATH}"
+    log "persisted machine-id at ${PERSIST_PATH}"
+else
+    log "using existing persisted machine-id"
+fi
+
+if [ "$(findmnt -n -o SOURCE "${ETC_PATH}" 2>/dev/null || true)" != "${PERSIST_PATH}" ]; then
+    mount --bind "${PERSIST_PATH}" "${ETC_PATH}"
+    mount -o remount,bind,ro "${ETC_PATH}" || true
+fi
+
+log "machine-id source: $(findmnt -n -o SOURCE "${ETC_PATH}" 2>/dev/null || echo unknown)"

--- a/meta-iot-gateway/recipes-support/iotgw-machine-id/iotgw-machine-id_1.0.0.bb
+++ b/meta-iot-gateway/recipes-support/iotgw-machine-id/iotgw-machine-id_1.0.0.bb
@@ -1,0 +1,29 @@
+SUMMARY = "Persistent machine-id setup for immutable rootfs deployments"
+DESCRIPTION = "Ensures machine-id is persisted under /data and bind-mounted to /etc/machine-id before regular services."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = "\
+    file://iotgw-machine-id.sh \
+    file://iotgw-machine-id.service \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "iotgw-machine-id.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/iotgw-machine-id.sh ${D}${sbindir}/iotgw-machine-id
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/iotgw-machine-id.service ${D}${systemd_system_unitdir}/
+}
+
+FILES:${PN} += " \
+    ${sbindir}/iotgw-machine-id \
+    ${systemd_system_unitdir}/iotgw-machine-id.service \
+"
+
+RDEPENDS:${PN} += "bash util-linux systemd"


### PR DESCRIPTION
## Summary
- add `iotgw-machine-id` recipe/service to persist machine-id in `/data/machine-id` and bind it to `/etc/machine-id`
- include `iotgw-machine-id` in RAUC images
- keep image-time `/etc/machine-id` uninitialized and document runtime ownership
- add `/run/machine-id` fallback in OTA cert scripts when `/etc/machine-id` is empty

## Validation
- target boot: `iotgw-machine-id.service` active (exited)
- `/etc/machine-id` equals `/data/machine-id`
- values remained stable across reboot
- no failed units reported
