### PR TITLE
OTA: integrate RAUC D-Bus in updater, install wrapper, and banner

### DIFF
--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
@@ -16,6 +16,9 @@ readonly CONFIG_FILE="${OTA_CONFIG:-/etc/ota/updater.conf}"
 readonly STATE_DIR="/data/ota"
 readonly STATE_FILE="${STATE_DIR}/last-check"
 readonly LOCK_FILE="/run/ota-updater.lock"
+readonly RAUC_DBUS_SERVICE="de.pengutronix.rauc"
+readonly RAUC_DBUS_PATH="/"
+readonly RAUC_DBUS_IFACE="de.pengutronix.rauc.Installer"
 
 # Logging helpers (all to stderr so stdout stays clean for data)
 log_info()  { echo "[$(date -Iseconds)] [INFO]  $*" >&2; }
@@ -25,6 +28,54 @@ die()       { log_error "$*"; exit 1; }
 
 on_err() { log_error "failed at line ${1:-?} (cmd: ${BASH_COMMAND:-sh})"; }
 trap 'on_err $LINENO' ERR
+
+rauc_dbus_available() {
+    command -v busctl >/dev/null 2>&1 || return 1
+    busctl --system call \
+        "$RAUC_DBUS_SERVICE" \
+        "$RAUC_DBUS_PATH" \
+        org.freedesktop.DBus.Peer \
+        Ping >/dev/null 2>&1
+}
+
+rauc_dbus_get_property_raw() {
+    local prop="$1"
+    busctl --system get-property \
+        "$RAUC_DBUS_SERVICE" \
+        "$RAUC_DBUS_PATH" \
+        "$RAUC_DBUS_IFACE" \
+        "$prop" 2>/dev/null
+}
+
+rauc_dbus_get_string_property() {
+    local prop="$1"
+    local raw
+    raw="$(rauc_dbus_get_property_raw "$prop")" || return 1
+    echo "$raw" | sed -nE 's/^[^ ]+ "(.*)"$/\1/p'
+}
+
+parse_rauc_progress() {
+    local raw="$1"
+    local pct msg depth
+    pct="$(echo "$raw" | awk '{print $2}')"
+    depth="$(echo "$raw" | awk '{print $NF}')"
+    msg="$(echo "$raw" | sed -nE 's/^\(isi\) [0-9-]+ "(.*)" [0-9-]+$/\1/p')"
+    [ -n "$pct" ] || pct=0
+    [ -n "$msg" ] || msg="unknown"
+    [ -n "$depth" ] || depth=0
+    echo "$pct|$msg|$depth"
+}
+
+get_system_compatible() {
+    local compat=""
+    if rauc_dbus_available; then
+        compat="$(rauc_dbus_get_string_property Compatible || true)"
+    fi
+    if [[ -z "$compat" ]]; then
+        compat=$(rauc status --output-format=json | jq -r '.compatible // empty')
+    fi
+    echo "$compat"
+}
 
 # Load configuration
 load_config() {
@@ -192,6 +243,17 @@ is_update_available() {
 install_update() {
     local bundle_url="$1"
     local version="$2"
+    local pre_last_error=""
+    local op=""
+    local progress_raw=""
+    local progress_parsed=""
+    local progress_pct=0
+    local progress_msg="unknown"
+    local progress_depth=0
+    local progress_msg_lc=""
+    local last_error=""
+    local timeout_sec=3600
+    local start_ts now_ts elapsed
 
     log_info "Installing update: version=$version url=$bundle_url"
 
@@ -200,23 +262,141 @@ install_update() {
         return 0
     fi
 
-    # RAUC handles download, verification, and installation
+    if rauc_dbus_available; then
+        log_info "Using RAUC D-Bus install path"
+        pre_last_error="$(rauc_dbus_get_string_property LastError || true)"
+        if ! busctl --system call \
+            "$RAUC_DBUS_SERVICE" \
+            "$RAUC_DBUS_PATH" \
+            "$RAUC_DBUS_IFACE" \
+            Install s "$bundle_url" >/dev/null 2>&1; then
+            log_warn "RAUC D-Bus Install call failed, falling back to CLI"
+        else
+            start_ts="$(date +%s)"
+            while true; do
+                op="$(rauc_dbus_get_string_property Operation || true)"
+                progress_raw="$(rauc_dbus_get_property_raw Progress || true)"
+                progress_parsed="$(parse_rauc_progress "$progress_raw")"
+                progress_pct="${progress_parsed%%|*}"
+                progress_msg="${progress_parsed#*|}"
+                progress_depth="${progress_msg##*|}"
+                progress_msg="${progress_msg%|*}"
+
+                log_info "RAUC D-Bus status: operation=${op:-unknown} progress=${progress_pct}% msg='${progress_msg}' depth=${progress_depth}"
+
+                if [[ "$op" == "idle" ]]; then
+                    last_error="$(rauc_dbus_get_string_property LastError || true)"
+                    progress_msg_lc="$(echo "$progress_msg" | tr '[:upper:]' '[:lower:]')"
+                    if [[ -n "$last_error" && "$last_error" != "$pre_last_error" ]]; then
+                        log_error "RAUC D-Bus install failed: $last_error"
+                        mkdir -p "$STATE_DIR"
+                        jq -n \
+                            --arg version "$version" \
+                            --arg timestamp "$(date -Iseconds)" \
+                            --arg error "$last_error" \
+                            --arg progress "$progress_msg" \
+                            '{version:$version,timestamp:$timestamp,status:"failed",method:"dbus",error:$error,progress:$progress}' \
+                            > "${STATE_DIR}/last-update"
+                        return 1
+                    fi
+                    if [[ "$progress_msg_lc" == *failed* || "$progress_msg_lc" == *error* ]]; then
+                        log_error "RAUC D-Bus install failed: progress='${progress_msg}'"
+                        mkdir -p "$STATE_DIR"
+                        jq -n \
+                            --arg version "$version" \
+                            --arg timestamp "$(date -Iseconds)" \
+                            --arg error "RAUC progress indicates failure: ${progress_msg}" \
+                            --arg progress "$progress_msg" \
+                            '{version:$version,timestamp:$timestamp,status:"failed",method:"dbus",error:$error,progress:$progress}' \
+                            > "${STATE_DIR}/last-update"
+                        return 1
+                    fi
+
+                    if [[ "$progress_msg_lc" == *done* || "$progress_msg_lc" == *complete* || "$progress_pct" == "100" ]]; then
+                        log_info "Update installed successfully. Reboot required."
+                        mkdir -p "$STATE_DIR"
+                        jq -n \
+                            --arg version "$version" \
+                            --arg timestamp "$(date -Iseconds)" \
+                            --arg progress "$progress_msg" \
+                            '{version:$version,timestamp:$timestamp,status:"installed",method:"dbus",progress:$progress}' \
+                            > "${STATE_DIR}/last-update"
+                        return 0
+                    fi
+
+                    log_warn "RAUC D-Bus idle without explicit completion marker; treating as success"
+                    mkdir -p "$STATE_DIR"
+                    jq -n \
+                        --arg version "$version" \
+                        --arg timestamp "$(date -Iseconds)" \
+                        --arg progress "$progress_msg" \
+                        '{version:$version,timestamp:$timestamp,status:"installed",method:"dbus",progress:$progress}' \
+                        > "${STATE_DIR}/last-update"
+                    return 0
+                fi
+
+                now_ts="$(date +%s)"
+                elapsed=$((now_ts - start_ts))
+                if [[ "$elapsed" -ge "$timeout_sec" ]]; then
+                    log_error "RAUC D-Bus install timed out after ${timeout_sec}s"
+                    return 1
+                fi
+
+                sleep 2
+            done
+        fi
+    fi
+
+    log_info "Using RAUC CLI install path"
     if rauc install "$bundle_url"; then
         log_info "Update installed successfully. Reboot required."
-        # Record successful update
-        echo "{\"version\":\"$version\",\"timestamp\":\"$(date -Iseconds)\",\"status\":\"installed\"}" \
+        mkdir -p "$STATE_DIR"
+        jq -n \
+            --arg version "$version" \
+            --arg timestamp "$(date -Iseconds)" \
+            '{version:$version,timestamp:$timestamp,status:"installed",method:"cli"}' \
             > "${STATE_DIR}/last-update"
         return 0
-    else
-        log_error "RAUC installation failed"
-        return 1
     fi
+    log_error "RAUC installation failed"
+    return 1
 }
 
 # Record check timestamp
 record_check() {
     mkdir -p "$STATE_DIR"
     echo "{\"timestamp\":\"$(date -Iseconds)\",\"server\":\"$SERVER_URL\"}" > "$STATE_FILE"
+}
+
+derive_manifest_version() {
+    local manifest_json="$1"
+    local v=""
+
+    v=$(echo "$manifest_json" | jq -r '.version // empty')
+    if [[ -n "$v" ]]; then
+        echo "$v"
+        return 0
+    fi
+
+    v=$(echo "$manifest_json" | jq -r '.released_at // empty')
+    if [[ -n "$v" ]]; then
+        echo "$v"
+        return 0
+    fi
+
+    v=$(echo "$manifest_json" | jq -r '.filename // empty')
+    if [[ -n "$v" ]]; then
+        echo "$v"
+        return 0
+    fi
+
+    v=$(echo "$manifest_json" | jq -r '.sha256 // empty')
+    if [[ -n "$v" ]]; then
+        echo "$v"
+        return 0
+    fi
+
+    echo "unknown"
 }
 
 # Main
@@ -241,20 +421,20 @@ main() {
 
     # Parse manifest
     local available_version bundle_url compatible
-    available_version=$(echo "$manifest" | jq -r '.version // empty')
+    available_version="$(derive_manifest_version "$manifest")"
     bundle_url=$(echo "$manifest" | jq -r '.bundle_url // empty')
     compatible=$(echo "$manifest" | jq -r '.compatible // empty')
 
-    if [[ -z "$available_version" || -z "$bundle_url" ]]; then
-        die "Invalid manifest: missing version or bundle_url"
+    if [[ -z "$bundle_url" ]]; then
+        die "Invalid manifest: missing bundle_url"
     fi
 
-    log_info "Available version: $available_version"
+    log_info "Available version/token: $available_version"
 
     # Check compatibility if specified in manifest
     if [[ -n "$compatible" ]]; then
         local system_compatible
-        system_compatible=$(rauc status --output-format=json | jq -r '.compatible // empty')
+        system_compatible="$(get_system_compatible)"
         if [[ "$compatible" != "$system_compatible" ]]; then
             die "Bundle not compatible: expected=$system_compatible got=$compatible"
         fi

--- a/meta-iot-gateway/recipes-ota/ota-updater/ota-updater_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-updater/ota-updater_1.0.0.bb
@@ -94,5 +94,6 @@ RDEPENDS:${PN} = " \
     curl \
     jq \
     rauc \
+    systemd \
     ca-certificates \
 "

--- a/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
@@ -42,6 +42,17 @@ audit() {
     fi
 }
 
+rauc_dbus_get_last_error() {
+    if ! command -v busctl >/dev/null 2>&1; then
+        return 1
+    fi
+    busctl --system get-property \
+        de.pengutronix.rauc \
+        / \
+        de.pengutronix.rauc.Installer \
+        LastError 2>/dev/null | sed -nE 's/^[^ ]+ "(.*)"$/\1/p'
+}
+
 usage() {
     cat >&2 <<'EOF'
 Usage: iotgw-rauc-install [wrapper options] <bundle|url> [rauc install args...]
@@ -503,6 +514,11 @@ if "${rauc_cmd[@]}"; then
     audit "rauc install succeeded"
 else
     INSTALL_RC=$?
+    if rauc_last_error="$(rauc_dbus_get_last_error || true)"; then
+        if [ -n "${rauc_last_error}" ]; then
+            audit "rauc dbus LastError='${rauc_last_error}'"
+        fi
+    fi
     audit "rauc install failed rc=${INSTALL_RC}"
     exit "${INSTALL_RC}"
 fi

--- a/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
@@ -7,7 +7,7 @@ SRC_URI = "file://iotgw-rauc-install.sh"
 
 S = "${WORKDIR}"
 
-RDEPENDS:${PN} = "bash curl rauc util-linux"
+RDEPENDS:${PN} = "bash curl rauc systemd util-linux"
 
 do_install() {
     install -d ${D}${sbindir}

--- a/meta-iot-gateway/recipes-support/iotgw-banner/files/iotgw-banner.sh
+++ b/meta-iot-gateway/recipes-support/iotgw-banner/files/iotgw-banner.sh
@@ -6,8 +6,20 @@
 DISTRO_NAME="@DISTRO_NAME@"
 DISTRO_VERSION="@DISTRO_VERSION@"
 MACHINE="@MACHINE@"
+ISSUE_FILE="${IOTGW_BANNER_ISSUE_FILE:-/etc/issue}"
+ISSUE_NET_FILE="${IOTGW_BANNER_ISSUE_NET_FILE:-/etc/issue.net}"
+MOTD_FILE="${IOTGW_BANNER_MOTD_FILE:-/etc/motd}"
 
 # Dynamic system info
+rauc_dbus_get_string_property() {
+    local prop="$1"
+    busctl --system get-property \
+        de.pengutronix.rauc \
+        / \
+        de.pengutronix.rauc.Installer \
+        "$prop" 2>/dev/null | sed -nE 's/^[^ ]+ "(.*)"$/\1/p'
+}
+
 get_system_info() {
     KERNEL=$(uname -r 2>/dev/null || echo "unknown")
     UPTIME=$(uptime -p 2>/dev/null | sed 's/up //' || echo "unknown")
@@ -25,7 +37,14 @@ get_system_info() {
     fi
     [ -n "$IP_ADDR" ] || IP_ADDR="N/A"
 
-    RAUC_SLOT=$(rauc status 2>/dev/null | grep "Booted from:" | awk '{print $3}' || echo "unknown")
+    if command -v busctl >/dev/null 2>&1; then
+        RAUC_SLOT="$(rauc_dbus_get_string_property BootSlot || true)"
+        RAUC_OP="$(rauc_dbus_get_string_property Operation || true)"
+        RAUC_LAST_ERROR="$(rauc_dbus_get_string_property LastError || true)"
+    fi
+    [ -n "${RAUC_SLOT:-}" ] || RAUC_SLOT=$(rauc status 2>/dev/null | grep "Booted from:" | awk '{print $3}' || echo "unknown")
+    [ -n "${RAUC_OP:-}" ] || RAUC_OP="unknown"
+    [ -n "${RAUC_LAST_ERROR:-}" ] || RAUC_LAST_ERROR="none"
 }
 
 # Generate /etc/issue (login screen) - simple version with legal warning
@@ -45,7 +64,7 @@ generate_issue() {
         printf "\033[1;36m%s\033[0m \033[0;37m%s\033[0m\n" "${DISTRO_NAME}" "${DISTRO_VERSION}"
         printf "\033[0;33mMachine:\033[0m %s | \033[0;33mTTY:\033[0m \\l\n" "${MACHINE}"
         printf "\n"
-    } > /etc/issue
+    } > "${ISSUE_FILE}"
 }
 
 # Generate /etc/issue.net (SSH/network pre-login banner)
@@ -64,7 +83,7 @@ generate_issue_net() {
         printf "%s %s\n" "${DISTRO_NAME}" "${DISTRO_VERSION}"
         printf "Machine: %s\n" "${MACHINE}"
         printf "\n"
-    } > /etc/issue.net
+    } > "${ISSUE_NET_FILE}"
 }
 
 # Generate /etc/motd (post-login message)
@@ -91,6 +110,10 @@ generate_motd() {
         printf "    \033[0;33mUptime:\033[0m       %s\n" "${UPTIME}"
         printf "    \033[0;33mIP Address:\033[0m   %s\n" "${IP_ADDR}"
         printf "    \033[0;33mActive Slot:\033[0m  %s\n" "${RAUC_SLOT}"
+        printf "    \033[0;33mOTA State:\033[0m    %s\n" "${RAUC_OP}"
+        if [ "${RAUC_LAST_ERROR}" != "none" ] && [ -n "${RAUC_LAST_ERROR}" ]; then
+            printf "    \033[0;33mOTA LastError:\033[0m %s\n" "${RAUC_LAST_ERROR}"
+        fi
         printf "    \033[0;36m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\033[0m\n"
         printf "\n"
 
@@ -98,7 +121,7 @@ generate_motd() {
         printf "    \033[0;36m📚 Documentation:\033[0m https://github.com/umair-uas/rpi5-iot-gateway\n"
         printf "    \033[0;36m💬 Support:\033[0m Umair A.S. \n"
         printf "\033[0m\n"
-    } > /etc/motd
+    } > "${MOTD_FILE}"
 }
 
 # Main execution

--- a/meta-iot-gateway/recipes-support/iotgw-banner/iotgw-banner.bb
+++ b/meta-iot-gateway/recipes-support/iotgw-banner/iotgw-banner.bb
@@ -35,4 +35,4 @@ FILES:${PN} += " \
 "
 
 # Ensure this runs after base-files to override static issue/motd
-RDEPENDS:${PN} = "bash iproute2"
+RDEPENDS:${PN} = "bash iproute2 rauc systemd"


### PR DESCRIPTION
## Summary
- integrate RAUC D-Bus into `ota-update-check.sh` for install control/status (`Install`, `Operation`, `Progress`, `LastError`, `Compatible`) with CLI fallback
- make updater manifest handling less coupled to server schema: require only `bundle_url`, derive version token from `version || released_at || filename || sha256`
- persist structured updater result to `/data/ota/last-update` via safe JSON encoding
- enrich `iotgw-rauc-install` failure logs with RAUC D-Bus `LastError`
- add D-Bus-backed RAUC slot/state/error fields in `iotgw-banner` with CLI fallback
- add runtime deps for `busctl` usage where needed

## Target validation
- `bash /data/ota-update-check.sh` executed full D-Bus install flow successfully
- `/data/ota/last-update` shows `{status:"installed", method:"dbus", progress:"Installing done."}`
- forced missing-bundle URL in wrapper logs D-Bus `LastError` (HTTP 404)
- banner test mode (`IOTGW_BANNER_*_FILE=/tmp/...`) shows `Active Slot`, `OTA State`, and `OTA LastError` when present
