### PR TITLE
edge-healthd: refactor recipe to inc+SRCREV pin and fix default monitoring targets

### DIFF
--- a/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd.inc
+++ b/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd.inc
@@ -6,14 +6,14 @@
 SUMMARY = "Edge device health monitoring daemon"
 DESCRIPTION = "Continuously monitors device health (boot, services, resources, \
 time sync, updates) and writes structured JSON status for fleet management integration."
-HOMEPAGE = "https://github.com/umair-uas/edge-healthd"
+HOMEPAGE = "https://github.com/umair-as/edge-healthd"
 RECIPE_MAINTAINER = "Umair A.S <umair-uas@users.noreply.github.com>"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=291c1ca2c1503b0e42022cd4bff87df5"
 
-#SRC_URI = "git://github.com/umair-uas/edge-healthd.git;branch=main;protocol=ssh"
-#SRCREV = "${AUTOREV}"
-#S = "${WORKDIR}/git"
+BRANCH ?= "main"
+SRC_URI = "git://github.com/umair-as/edge-healthd.git;branch=${BRANCH};protocol=https"
+S = "${WORKDIR}/git"
 
 # Platform-specific configuration and tmpfiles
 SRC_URI += " \
@@ -21,12 +21,13 @@ SRC_URI += " \
     file://edge-healthd.tmpfiles.conf \
 "
 
-inherit cmake systemd useradd  pkgconfig externalsrc
+inherit cmake systemd useradd pkgconfig externalsrc
 EXTERNALSRC ?= ""
 EXTERNALSRC_BUILD ?= "${WORKDIR}/build"
 PACKAGECONFIG ??= "systemd"
 PACKAGECONFIG[systemd] = "-DEDGE_HAS_SYSTEMD=ON,,systemd"
 PACKAGECONFIG[tests] = "-DEDGE_BUILD_TESTS=ON,-DEDGE_BUILD_TESTS=OFF"
+PACKAGECONFIG[web-ui] = "-DEDGE_WEB_UI=ON,-DEDGE_WEB_UI=OFF,go-native"
 DEPENDS += " \
     systemd \
     nlohmann-json \
@@ -66,6 +67,8 @@ EXTRA_OECMAKE = " \
     -DEDGE_BUILD_TESTS=OFF \
     -DEDGE_ENABLE_SANITIZERS=OFF \
     -DEDGE_ENABLE_LTO=ON \
+    -DEDGE_WEB_UI=OFF \
+    -DEDGE_FETCH_SDBUSCPP=OFF \
     -DEDGE_STATIC_LINK=OFF \
 "
 

--- a/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.4.0.bb
+++ b/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.4.0.bb
@@ -1,0 +1,4 @@
+require edge-healthd.inc
+
+# Pin upstream source for reproducible non-externalsrc builds.
+SRCREV = "522332a5defcdd15e604e2f4fbe4c6d2b87d87ad"

--- a/meta-iot-gateway/recipes-support/edge-healthd/files/healthd.conf
+++ b/meta-iot-gateway/recipes-support/edge-healthd/files/healthd.conf
@@ -5,7 +5,7 @@
   "sample_window_sec": 60,
 
   "monitored_services": [
-    "sshd.service",
+    "sshd.socket",
     "NetworkManager.service",
     "mosquitto.service"
   ],
@@ -15,10 +15,7 @@
     "/data"
   ],
 
-  "monitored_interfaces": [
-    "eth0",
-    "wlan0"
-  ],
+  "monitored_interfaces": [],
 
   "enable_ptp": false,
   "enable_ntp": true,


### PR DESCRIPTION
## Summary
- refactor edge-healthd recipe to `.inc + versioned .bb` pattern:
  - move common logic to `edge-healthd.inc`
  - add `edge-healthd_0.4.0.bb` with pinned `SRCREV`
- keep `EXTERNALSRC` dev flow intact while making non-externalsrc builds reproducible
- align default `healthd.conf` with target behavior:
  - monitor `sshd.socket` (socket-activated SSH)
  - set `monitored_interfaces` to `[]` (auto-discover non-loopback interfaces, including `br0`)

## Validation
- bitbake metadata:
  - `PV=0.4.0`
  - `SRCREV=522332a5defcdd15e604e2f4fbe4c6d2b87d87ad`
- build artifact check:
  - `/usr/bin/edge-healthd` reports `0.4.0` in latest rootfs artifact
- target after bundle install:
  - `jq -r '.services.units[].name' /run/health/state.json` -> `sshd.socket`, `NetworkManager.service`, `mosquitto.service`
  - `jq -r '.resources.network[].ifname' /run/health/state.json` -> `eth0`, `wlan0`, `br0`, `wpan0`
