### PR TITLE
RAUC: harden iotgw-rauc-install dispatch under hardened contexts

### DIFF
--- a/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
@@ -31,6 +31,7 @@ URL_SCHEME=""
 URL_PATH=""
 BUNDLE_INPUT=""
 EXTRA_ARGS=()
+SYSTEMD_DISPATCH_RW_PATHS=()
 
 log() { printf '[iotgw-rauc-install] %s\n' "$*" >&2; }
 die() { log "ERROR: $*"; exit 1; }
@@ -75,6 +76,40 @@ Wrapper options:
   --allow-missing-ota-user  Continue if streaming sandbox-user does not exist (requires --debug-unsafe)
 EOF
     exit 2
+}
+
+append_dispatch_rw_path() {
+    local path="$1"
+    local existing
+    [ -n "${path}" ] || return 0
+    for existing in "${SYSTEMD_DISPATCH_RW_PATHS[@]}"; do
+        [ "${existing}" = "${path}" ] && return 0
+    done
+    SYSTEMD_DISPATCH_RW_PATHS+=("${path}")
+}
+
+build_dispatch_rw_paths() {
+    local fw_env_dir=""
+    SYSTEMD_DISPATCH_RW_PATHS=()
+
+    # RAUC/runtime state and journald IPC can touch /run.
+    append_dispatch_rw_path "/run"
+
+    # Fallback download stores bundle in /tmp before local install.
+    if [ "${FALLBACK_DOWNLOAD}" -eq 1 ]; then
+        append_dispatch_rw_path "/tmp"
+    fi
+
+    if [ "${BOOT_RW_REQUIRED}" -eq 1 ]; then
+        append_dispatch_rw_path "${BOOT_MP}"
+    fi
+
+    case "${fw_env_target:-}" in
+        /boot/*|/uboot-env/*)
+            fw_env_dir="$(dirname "${fw_env_target}")"
+            append_dispatch_rw_path "${fw_env_dir}"
+            ;;
+    esac
 }
 
 detect_streaming_sandbox_user() {
@@ -399,12 +434,44 @@ if [ -r /etc/fw_env.config ]; then
     esac
 fi
 
+if [ "${DIRECT_MODE}" -eq 1 ]; then
+    audit "systemd-run dispatch bypassed: --direct"
+elif [ "${DISPATCHED_MODE}" -eq 1 ]; then
+    audit "systemd-run dispatch bypassed: --no-systemd-run"
+fi
+
 # Prefer executing from systemd manager context to avoid hardened SSH session
 # namespace/capability differences from rauc.service.
 if [ "${DIRECT_MODE}" -eq 0 ] && [ "${DISPATCHED_MODE}" -eq 0 ]; then
     if command -v systemd-run >/dev/null 2>&1; then
+        local_rw_paths=""
+        systemd_props=()
         unit="iotgw-rauc-install-${RUN_ID}"
         reexec=(/usr/sbin/iotgw-rauc-install --direct)
+        build_dispatch_rw_paths
+        for path in "${SYSTEMD_DISPATCH_RW_PATHS[@]}"; do
+            local_rw_paths="${local_rw_paths:+${local_rw_paths} }${path}"
+        done
+        systemd_props=(
+            "--property=NoNewPrivileges=yes"
+            "--property=PrivateTmp=yes"
+            "--property=PrivateMounts=no"
+            "--property=ProtectSystem=full"
+            "--property=ProtectHome=yes"
+            "--property=ProtectKernelTunables=yes"
+            "--property=ProtectKernelModules=yes"
+            "--property=ProtectKernelLogs=yes"
+            "--property=ProtectControlGroups=yes"
+            "--property=RestrictNamespaces=yes"
+            "--property=RestrictSUIDSGID=yes"
+            "--property=LockPersonality=yes"
+            "--property=MemoryDenyWriteExecute=yes"
+            "--property=PrivateUsers=no"
+            "--property=RestrictAddressFamilies=AF_UNIX AF_INET AF_INET6"
+        )
+        for path in "${SYSTEMD_DISPATCH_RW_PATHS[@]}"; do
+            systemd_props+=("--property=ReadWritePaths=${path}")
+        done
         [ "${DRY_RUN}" -eq 1 ] && reexec+=(--dry-run)
         [ "${TLS_PROFILE}" != "system" ] && reexec+=(--tls-profile "${TLS_PROFILE}")
         [ "${FALLBACK_DOWNLOAD}" -eq 1 ] && reexec+=(--fallback-download)
@@ -412,13 +479,14 @@ if [ "${DIRECT_MODE}" -eq 0 ] && [ "${DISPATCHED_MODE}" -eq 0 ]; then
         [ "${TLS_INSECURE}" -eq 1 ] && reexec+=(--tls-insecure)
         [ "${ALLOW_MISSING_OTA_USER}" -eq 1 ] && reexec+=(--allow-missing-ota-user)
         reexec+=("${BUNDLE_INPUT}" "${EXTRA_ARGS[@]}")
-        audit "dispatching via systemd-run unit=${unit}"
+        audit "dispatching via systemd-run unit=${unit} profile=namespace-hardened rw_paths='${local_rw_paths}'"
         if systemd-run \
             --quiet \
             --wait \
             --collect \
             --pipe \
             --unit "${unit}" \
+            "${systemd_props[@]}" \
             "${reexec[@]}"; then
             INSTALL_RC=0
             audit "systemd-run install succeeded"

--- a/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/rauc/iotgw-rauc-install_1.0.0.bb
@@ -3,7 +3,9 @@ DESCRIPTION = "Runs rauc install and remounts /boot rw only when fw_env.config t
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://iotgw-rauc-install.sh"
+SRC_URI = " \
+    file://iotgw-rauc-install.sh \
+"
 
 S = "${WORKDIR}"
 


### PR DESCRIPTION
## Summary
- Harden `iotgw-rauc-install` `systemd-run` dispatch with explicit transient-unit security properties.
- Make writable-path assumptions explicit and dynamic (`/run`, `/boot` or `/uboot-env`, and `/tmp` for fallback mode).
- Add wrapper audit markers for dispatch profile and bypass cases.

## Validation
- Built and deployed `bundle-dev-full-fit`.
- OTA install succeeded to inactive slot with hooks passing.
- Rebooted successfully into `rootfs.1 (B)`.
- `rauc-mark-good.service` succeeded.
- `systemctl --failed` returned `0`.
- Verified deployed wrapper includes hardening lines and dry-run dispatch output includes `profile=namespace-hardened` and `rw_paths`.
