### PR TITLE
FIT: add project-owned custom ITS toggle (Phase A parity)

### DIFF
--- a/docs/FIT_SIGNING.md
+++ b/docs/FIT_SIGNING.md
@@ -29,6 +29,22 @@ Expected FIT overrides (already in this project):
 - `KERNEL_CLASSES:fitflow = " kernel-fitimage "`
 - `KERNEL_BOOTCMD:fitflow = "bootm"`
 
+### Optional: Enable Project-Owned Custom ITS (Phase A)
+Default behavior remains Yocto auto-generated ITS. To opt in to project-owned
+single-config ITS parity mode:
+
+```yaml
+local_conf_header:
+  fit_custom_its: |
+    IOTGW_FIT_CUSTOM_ITS:fitflow = "1"
+```
+
+Notes:
+- Default is `0` (OFF).
+- Phase A template path:
+  `meta-iot-gateway/recipes-kernel/linux/files/iotgw-fit-single.its.in`
+- Current template targets `broadcom/bcm2712-rpi-5-b.dtb` by default.
+
 ## 2. Generate FIT Signing Keys (Manual)
 Use a dedicated keypair (do not reuse RAUC or mTLS keys):
 
@@ -120,6 +136,14 @@ Expected:
 - kernel and FDT entries present
 - hash nodes present (sha256)
 - signature-related fields present when signing is enabled
+
+If custom ITS mode is enabled, also inspect deployed ITS source:
+
+```bash
+ls build/tmp-glibc/deploy/images/raspberrypi5/fitImage-its-*.its
+grep -nE 'configurations|default =|conf-bcm2712-rpi-5-b.dtb' \
+  build/tmp-glibc/deploy/images/raspberrypi5/fitImage-its-*.its
+```
 
 Verify FIT bundle payload uses FIT bootfiles:
 

--- a/meta-iot-gateway/recipes-kernel/linux/files/iotgw-fit-single.its.in
+++ b/meta-iot-gateway/recipes-kernel/linux/files/iotgw-fit-single.its.in
@@ -1,0 +1,46 @@
+/dts-v1/;
+
+/ {
+    description = "@@FIT_DESC@@";
+    #address-cells = <@@FIT_ADDRESS_CELLS@@>;
+
+    images {
+        kernel-1 {
+            description = "Linux kernel";
+            data = /incbin/("@@KERNEL_PATH@@");
+            type = "@@UBOOT_MKIMAGE_KERNEL_TYPE@@";
+            arch = "@@UBOOT_ARCH@@";
+            os = "linux";
+            compression = "@@KERNEL_COMPRESSION@@";
+            load = <@@UBOOT_LOADADDRESS@@>;
+            entry = <@@UBOOT_ENTRYPOINT@@>;
+            hash-1 {
+                algo = "@@FIT_HASH_ALG@@";
+            };
+        };
+
+        @@FDT_NAME@@ {
+            description = "Flattened Device Tree blob";
+            data = /incbin/("@@DTB_PATH@@");
+            type = "flat_dt";
+            arch = "@@UBOOT_ARCH@@";
+            compression = "none";
+            hash-1 {
+                algo = "@@FIT_HASH_ALG@@";
+            };
+        };
+    };
+
+    configurations {
+        default = "@@CONF_NAME@@";
+        @@CONF_NAME@@ {
+            description = "Boot Linux kernel + FDT";
+            kernel = "kernel-1";
+            fdt = "@@FDT_NAME@@";
+            hash-1 {
+                algo = "@@FIT_HASH_ALG@@";
+            };
+__IOTGW_CONF_SIGNATURE__
+        };
+    };
+};

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
@@ -16,11 +16,107 @@ SRCPV = "${@bb.fetch2.get_srcrev(d)}"
 SRC_URI = " \
     git://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git;name=machine;branch=${BRANCH};protocol=https \
     git://git.yoctoproject.org/yocto-kernel-cache;type=kmeta;name=meta;branch=yocto-6.6;destsuffix=${KMETA};protocol=https \
+    file://iotgw-fit-single.its.in \
 "
 
 # FIT image variant: compile normal arm64 Image payload and package as fitImage.
 KERNEL_IMAGETYPE = "fitImage"
 KERNEL_CLASSES = " kernel-fitimage "
+
+# Phase A custom ITS path (default OFF): single kernel + single config parity.
+IOTGW_FIT_CUSTOM_ITS ?= "0"
+IOTGW_FIT_CUSTOM_ITS_TEMPLATE ?= "${WORKDIR}/iotgw-fit-single.its.in"
+IOTGW_FIT_CUSTOM_ITS_DEFAULT_DTB ?= "broadcom/bcm2712-rpi-5-b.dtb"
+
+do_assemble_fitimage:append() {
+    if [ "${IOTGW_FIT_CUSTOM_ITS}" != "1" ]; then
+        return
+    fi
+    if ! echo "${KERNEL_IMAGETYPES}" | grep -wq "fitImage"; then
+        return
+    fi
+
+    template="${IOTGW_FIT_CUSTOM_ITS_TEMPLATE}"
+    [ -r "${template}" ] || bbfatal "custom ITS template not found: ${template}"
+
+    cd "${B}"
+    linux_comp="$(uboot_prep_kimage)"
+    kernel_path="${B}/linux.bin"
+    [ -e "${kernel_path}" ] || bbfatal "custom ITS mode requires ${kernel_path}"
+
+    dtb_rel="${IOTGW_FIT_CUSTOM_ITS_DEFAULT_DTB}"
+    dtb_path="${B}/${KERNEL_OUTPUT_DIR}/dts/${dtb_rel}"
+    if [ ! -e "${dtb_path}" ]; then
+        dtb_path="${B}/${KERNEL_OUTPUT_DIR}/${dtb_rel}"
+    fi
+    if [ ! -e "${dtb_path}" ]; then
+        bbfatal "custom ITS mode could not find DTB '${dtb_rel}' under ${B}/${KERNEL_OUTPUT_DIR}"
+    fi
+
+    dtb_name="${dtb_rel##*/}"
+    conf_name="conf-${dtb_name}"
+    fdt_name="fdt-${dtb_name}"
+    entrypoint="${UBOOT_ENTRYPOINT}"
+    if [ -n "${UBOOT_ENTRYSYMBOL}" ]; then
+        entrypoint="$(${HOST_PREFIX}nm vmlinux | awk '$3=="${UBOOT_ENTRYSYMBOL}" {print "0x"$1; exit}')"
+    fi
+    [ -n "${entrypoint}" ] || entrypoint="${UBOOT_LOADADDRESS}"
+
+    conf_sig_key="${UBOOT_SIGN_KEYNAME}"
+    if [ -z "${conf_sig_key}" ]; then
+        conf_sig_key="${UBOOT_SIGN_IMG_KEYNAME}"
+    fi
+
+    its_path="${B}/fit-image.its"
+    conf_sig_fragment="${B}/fitimage-conf-signature.itsfrag"
+    cp "${template}" "${its_path}"
+
+    if [ "${UBOOT_SIGN_ENABLE}" = "1" ] && [ -n "${conf_sig_key}" ]; then
+        cat > "${conf_sig_fragment}" <<EOF
+                signature-1 {
+                        algo = "${FIT_HASH_ALG},${FIT_SIGN_ALG}";
+                        key-name-hint = "${conf_sig_key}";
+                        sign-images = "fdt", "kernel";
+                };
+EOF
+        sed -i "/__IOTGW_CONF_SIGNATURE__/r ${conf_sig_fragment}" "${its_path}"
+    fi
+    sed -i "s|__IOTGW_CONF_SIGNATURE__||" "${its_path}"
+
+    sed -i \
+        -e "s|@@FIT_DESC@@|${FIT_DESC}|g" \
+        -e "s|@@FIT_ADDRESS_CELLS@@|${FIT_ADDRESS_CELLS}|g" \
+        -e "s|@@UBOOT_ARCH@@|${UBOOT_ARCH}|g" \
+        -e "s|@@UBOOT_MKIMAGE_KERNEL_TYPE@@|${UBOOT_MKIMAGE_KERNEL_TYPE}|g" \
+        -e "s|@@UBOOT_LOADADDRESS@@|${UBOOT_LOADADDRESS}|g" \
+        -e "s|@@UBOOT_ENTRYPOINT@@|${entrypoint}|g" \
+        -e "s|@@FIT_HASH_ALG@@|${FIT_HASH_ALG}|g" \
+        -e "s|@@KERNEL_COMPRESSION@@|${linux_comp}|g" \
+        -e "s|@@CONF_NAME@@|${conf_name}|g" \
+        -e "s|@@FDT_NAME@@|${fdt_name}|g" \
+        -e "s|@@KERNEL_PATH@@|${kernel_path}|g" \
+        -e "s|@@DTB_PATH@@|${dtb_path}|g" \
+        "${its_path}"
+
+    bbnote "Assembling fitImage from project-owned ITS template (${template})"
+    if [ -n "${UBOOT_MKIMAGE_DTCOPTS}" ]; then
+        ${UBOOT_MKIMAGE} -D "${UBOOT_MKIMAGE_DTCOPTS}" -f "${its_path}" "${B}/${KERNEL_OUTPUT_DIR}/fitImage-none"
+    else
+        ${UBOOT_MKIMAGE} -f "${its_path}" "${B}/${KERNEL_OUTPUT_DIR}/fitImage-none"
+    fi
+
+    if [ "${UBOOT_SIGN_ENABLE}" = "1" ]; then
+        if [ -n "${UBOOT_MKIMAGE_DTCOPTS}" ]; then
+            ${UBOOT_MKIMAGE_SIGN} -D "${UBOOT_MKIMAGE_DTCOPTS}" -F -k "${UBOOT_SIGN_KEYDIR}" -r "${B}/${KERNEL_OUTPUT_DIR}/fitImage-none" ${UBOOT_MKIMAGE_SIGN_ARGS}
+        else
+            ${UBOOT_MKIMAGE_SIGN} -F -k "${UBOOT_SIGN_KEYDIR}" -r "${B}/${KERNEL_OUTPUT_DIR}/fitImage-none" ${UBOOT_MKIMAGE_SIGN_ARGS}
+        fi
+    fi
+
+    if [ "${INITRAMFS_IMAGE_BUNDLE}" != "1" ]; then
+        ln -sf fitImage-none "${B}/${KERNEL_OUTPUT_DIR}/fitImage"
+    fi
+}
 
 # Raspberry Pi firmware passes a runtime-prepared DTB to U-Boot. Inject FIT
 # public keys into deployed firmware DTBs so U-Boot control FDT can expose


### PR DESCRIPTION
## Summary
- Add project-owned FIT ITS template for single-kernel/single-config parity mode.
- Add `IOTGW_FIT_CUSTOM_ITS` toggle (default OFF) in `linux-iotgw-mainline-fit_6.18.bb`.
- When enabled, assemble/sign `fitImage` from template while preserving default auto-ITS path when disabled.
- Align kernel compression behavior with upstream `uboot_prep_kimage` flow.
- Document custom ITS enable/verification steps in `docs/FIT_SIGNING.md`.

## Validation
- Host build/test with custom ITS enabled (`IOTGW_FIT_CUSTOM_ITS:fitflow = "1"`).
- Generated ITS validated:
  - `kernel-1`
  - `fdt-bcm2712-rpi-5-b.dtb`
  - default `conf-bcm2712-rpi-5-b.dtb`
  - config signature includes `sign-images = "fdt", "kernel"`
- `dumpimage -l fitImage` validated hash/signature and expected node layout.
- Bundle built (`bundle-dev-full-fit`) and deployed successfully.
- Target reboot validation passed:
  - `rauc status` booted/active slot switched successfully
  - `systemctl --failed` returned 0
  - `/boot/boot.scr` confirms FIT `bootm` path
