### PR TITLE
bsp: disable unused EFI bootmeths and include edge-healthd dbus policy

### DIFF
--- a/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot.cfg
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot.cfg
@@ -38,3 +38,11 @@ CONFIG_ENV_FAT_DEVICE_AND_PART="0:2"
 
 # Remove built-in U-Boot logo to avoid brief 'boat' flicker
 CONFIG_VIDEO_LOGO=n
+
+# Disable EFI boot manager and EFI loader bootmeths.
+# This gateway boots exclusively via U-Boot script; no EFI boot entries exist.
+# BOOTMETH_EFI_BOOTMGR runs as a global bootmeth (before any device-specific method)
+# and wastes ~0.5s on every boot probing non-existent EFI Boot#### variables.
+# BOOTMETH_EFILOADER scans each device for /EFI/BOOT/bootaa64.efi — also unused.
+CONFIG_BOOTMETH_EFI_BOOTMGR=n
+CONFIG_BOOTMETH_EFILOADER=n

--- a/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd.inc
+++ b/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd.inc
@@ -110,6 +110,7 @@ FILES:${PN} += " \
     ${systemd_system_unitdir}/edge-healthd.service \
     ${sysconfdir}/edge/healthd.conf \
     ${sysconfdir}/tmpfiles.d/edge-healthd.conf \
+    ${datadir}/dbus-1/system.d/edge-healthd-dbus.conf \
 "
 
 CONFFILES:${PN} += " \


### PR DESCRIPTION
## Summary
- disable unused U-Boot EFI boot methods for script-only boot flow
- include edge-healthd D-Bus policy file in package FILES

## Validation
- Verified boot log shows script boot flow and no EFI bootmeth probing behavior
- Verified /usr/share/dbus-1/system.d/edge-healthd-dbus.conf exists on target
- Verified edge-healthd.service active and D-Bus name present
