### PR TITLE
feat(u-boot): TPM SLB9672 U-Boot integration — research and safe Kconfig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,5 @@ scripts/kernel-hardening-check-build.sh
 scripts/kernel-hardening-check-target.sh
 scripts/generate-splash.py
 scripts/tpm-validate.sh
+scripts/
 docs/infineon-optiga-tpm-rpi-quickstarter-user-guide-usermanual-en.pdf

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help base dev prod desktop \
-        bundle-dev-full bundle-dev-full-fit bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        bundle-dev bundle-dev-full bundle-dev-full-fit bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
         layers parse clean-lock
 
 KAS ?= kas
@@ -25,6 +25,7 @@ help:
 	@echo "  make bundle-prod-full     # Bundle from prod image"
 	@echo "  make bundle-desktop-full  # Bundle from desktop image"
 	@echo "  -- Bundles (rootfs-only) --"
+	@echo "  make bundle-dev           # Rootfs-only bundle from dev image (safe for U-Boot bring-up)"
 	@echo "  make bundle-desktop       # Rootfs-only bundle from desktop image"
 	@echo "  -- Utilities --"
 	@echo "  make layers               # Show layers for RAUC stack"
@@ -50,6 +51,9 @@ define bundle_cmd
                    IOTGW_ENABLE_OTBR=$$IOTGW_ENABLE_OTBR \
                    bitbake $(2)' $(BASE)
 endef
+
+bundle-dev:
+	$(call bundle_cmd,iot-gw-image-dev,iot-gw-bundle)
 
 bundle-dev-full:
 	$(call bundle_cmd,iot-gw-image-dev,iot-gw-bundle-full)

--- a/docs/UBOOT_TPM_SLB9672.md
+++ b/docs/UBOOT_TPM_SLB9672.md
@@ -1,0 +1,95 @@
+# U-Boot TPM Enablement (RPi5 + SLB9672)
+
+## Status: Parked (2026-04-01)
+
+U-Boot TPM on RPi5 is **not viable with current upstream**.
+TPM operations are deferred to Linux (`tpm_tis_spi` + `tpm-ops` CLI).
+
+## Goal
+- U-Boot detects and binds TPM on SPI via PCIe → RP1 → SPI path.
+- `tpm2` commands work in U-Boot shell (`init`, `startup`, `get_capability`).
+- FIT measured-boot can build on a working TPM device path.
+
+## Implementation in This Repo
+- Kconfig fragment: `meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot-tpm.cfg`
+- Conditional wiring: `meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend`
+- Gate variable: `IOTGW_ENABLE_TPM_SLB9672 = "1"` (via `kas/tpm.yml`)
+
+## Kconfig Symbols
+```
+CONFIG_PCI_INIT_R=n          # Crashes on BCM2712 — see findings below
+CONFIG_USB_XHCI_PCI=n        # Also triggers PCIe probe crash
+CONFIG_SPI=y
+CONFIG_DM_SPI=y
+CONFIG_DESIGNWARE_SPI=y
+CONFIG_TPM=y / CONFIG_TPM_V2=y
+CONFIG_CMD_TPM=y / CONFIG_CMD_TPM_V2=y
+CONFIG_TPM2_TIS_SPI=y
+```
+
+`CONFIG_PCI=y` and `CONFIG_PCI_BRCMSTB=y` come from `rpi_arm64_defconfig`.
+
+## Build & Deploy
+```bash
+kas shell kas/local.yml:kas/tpm.yml -c "bitbake u-boot"
+# Verify
+grep -E 'PCI_INIT_R|USB_XHCI_PCI|TPM2_TIS_SPI' \
+  build/tmp-glibc/work/raspberrypi5-oe-linux/u-boot/2025.04/build/.config
+```
+
+## Findings
+
+### DT Confirmed Correct
+Both control FDT (`fdtcontroladdr`) and firmware FDT (`fdt_addr`) contain:
+```
+/axi/pcie@1000120000             compatible = "brcm,bcm2712-pcie"
+  /rp1_nexus                     compatible = "pci1de4,1"
+    /pci-ep-bus@1                compatible = "simple-bus"
+      /spi@40050000              compatible = "snps,dw-apb-ssi"  status = "okay"
+        /tpm@1                   compatible = "infineon,slb9670", "tcg,tpm_tis-spi"
+                                 reg = <1>  spi-max-frequency = 32MHz  status = "okay"
+```
+
+### DM Never Reaches TPM
+- `axi` simple_bus: bound but **not probed** — zero children in `dm tree`
+- `pcie_brcm`, `dw_spi`, `tpm_tis_spi` drivers compiled in but 0 devices bound
+- `pci enum` at U-Boot prompt has no effect
+- `tpm2 init` → `Couldn't set TPM 0 (rc = 1)`
+
+### CONFIG_PCI_INIT_R Crash
+Enabling auto PCI init causes SError abort during boot:
+```
+"Error" handler, esr 0xbe000011    # asynchronous external abort
+```
+`CONFIG_USB_XHCI_PCI=y` triggers the same crash via USB init probing PCI.
+
+### Root Cause: Missing U-Boot Driver Chain
+`pcie_brcmstb` already has `brcm,bcm2712-pcie` compatible (upstream 2025.04,
+line 559), but treats BCM2712 identically to BCM2711.  BCM2712 requires:
+
+| Missing Piece | Detail |
+|---------------|--------|
+| BCM2712 PCIe init | PHY PLL for 54MHz xosc, BCM7712 register offsets, PERST# 7278-variant, RESCAL quirk |
+| RP1 MFD driver | No U-Boot driver for `pci1de4,1` (RP1 PCI endpoint) |
+| RP1 SPI driver | No driver to expose DesignWare SPI behind RP1 BAR |
+
+## Upstream Patch Status
+- **EPAM / xen-troops** (Oleksii Moisieiev, Feb 2025): 20-patch RFC —
+  PCIe + RP1 MFD + GPIO + clocks + Ethernet.  BAR ordering HACK.
+  No SPI.  Not merged.  Fork: `xen-troops/u-boot` branch `2024.04-xt`.
+  https://lists.denx.de/pipermail/u-boot/2025-February/579540.html
+- **SUSE** (Torsten Duwe, Oct 2025): 3-part series, only Part 1 (fixes)
+  posted.  Parts 2-3 (PCIe + RP1) not yet submitted.  No SPI.
+  https://lore.kernel.org/u-boot/20251010161442.410C4227AAE@verein.lst.de/
+- **Neither series includes an RP1 SPI driver.**
+
+## Recommended Alternative
+1. **Linux TPM** — kernel `tpm_tis_spi` + `tpm-ops` CLI works today.
+2. **BCM2712 OTP secure boot** — closes EEPROM → U-Boot trust gap
+   via signed `boot.img` verified by silicon BootROM.
+3. **Initramfs TPM** — PCR extend, LUKS unseal, attestation from initramfs.
+
+## When to Revisit
+- SUSE parts 2+3 merged upstream (PCIe + RP1)
+- Any U-Boot fork gains RP1 SPI support
+- Monitor `lore.kernel.org/u-boot` for `bcm2712` or `rp1`

--- a/kas/uboot-next.yml
+++ b/kas/uboot-next.yml
@@ -1,0 +1,19 @@
+header:
+  version: 18
+
+local_conf_header:
+  uboot_source_override: |
+    # Optional U-Boot source override used by:
+    #   meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
+    #
+    # Usage:
+    #   kas shell kas/local.yml:kas/uboot-next.yml -c "bitbake u-boot"
+    #
+    # Pin both URI and SRCREV for reproducibility.
+    # Example upstream master test:
+    # IOTGW_UBOOT_ALT_URI = "git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master"
+    # IOTGW_UBOOT_ALT_SRCREV = "REPLACE_WITH_PINNED_COMMIT"
+
+    # Keep disabled by default until explicitly set.
+    IOTGW_UBOOT_ALT_URI ?= ""
+    IOTGW_UBOOT_ALT_SRCREV ?= ""

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot-tpm.cfg
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot-tpm.cfg
@@ -1,0 +1,21 @@
+# TPM 2.0 over SPI (Infineon SLB9672 profile for Raspberry Pi 5).
+#
+# Enables U-Boot TPM commands and TPM2 TIS SPI transport driver.
+# On RPi5, RP1 peripherals (SPI/ETH/USB) sit behind PCIe.  Upstream U-Boot
+# (as of 2025.04 / 2026.04-rc4) lacks RP1 MFD + RP1 SPI drivers, so the
+# full PCIe → RP1 → SPI → TPM path is NOT yet functional.
+# TPM operations are deferred to Linux (kernel tpm_tis_spi + tpm-ops CLI).
+#
+# CONFIG_PCI=y and CONFIG_PCI_BRCMSTB=y come from rpi_arm64_defconfig.
+# Do NOT enable CONFIG_PCI_INIT_R — pcie_brcmstb probe on BCM2712 triggers
+# SError abort (ESR 0xbe000011).  CONFIG_USB_XHCI_PCI also triggers it.
+CONFIG_PCI_INIT_R=n
+CONFIG_USB_XHCI_PCI=n
+CONFIG_SPI=y
+CONFIG_DM_SPI=y
+CONFIG_DESIGNWARE_SPI=y
+CONFIG_TPM=y
+CONFIG_TPM_V2=y
+CONFIG_CMD_TPM=y
+CONFIG_CMD_TPM_V2=y
+CONFIG_TPM2_TIS_SPI=y

--- a/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -1,7 +1,24 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
+# Optional U-Boot source override for bring-up testing.
+# Set these in kas/local.yml (or a dedicated kas include) when needed:
+#   IOTGW_UBOOT_ALT_URI = "git://source.denx.de/u-boot/u-boot.git;protocol=https;branch=master"
+#   IOTGW_UBOOT_ALT_SRCREV = "<pinned-commit>"
+IOTGW_UBOOT_ALT_URI ?= ""
+IOTGW_UBOOT_ALT_SRCREV ?= ""
+
+python () {
+    alt_uri = (d.getVar("IOTGW_UBOOT_ALT_URI") or "").strip()
+    alt_srcrev = (d.getVar("IOTGW_UBOOT_ALT_SRCREV") or "").strip()
+    if alt_uri:
+        d.setVar("SRC_URI", alt_uri)
+    if alt_srcrev:
+        d.setVar("SRCREV", alt_srcrev)
+}
+
 # Add IoT GW hardening and RAUC-friendly settings via Kconfig fragment
 SRC_URI:append = " file://iotgw-uboot.cfg file://fw_env.config"
+SRC_URI:append = "${@' file://iotgw-uboot-tpm.cfg' if d.getVar('IOTGW_ENABLE_TPM_SLB9672') == '1' else ''}"
 
 # Keep boot delay minimal; allow keyed interrupt only
 # Note: Further hardening (FIT signatures) will be added separately per-prod build

--- a/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.1.0.bb
+++ b/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.1.0.bb
@@ -9,7 +9,12 @@ SRCREV = "e6fdda8eff836f2e819a3cb6f907ca1d3f4a3793"
 
 S = "${WORKDIR}/git"
 
-inherit cargo_bin
+inherit cargo_bin externalsrc
+
+# Local externalsrc override (set in kas/local.yml) keeps remote git fetch path
+# as default when EXTERNALSRC is not provided.
+EXTERNALSRC ?= ""
+EXTERNALSRC_BUILD ?= "${WORKDIR}/build"
 
 # tss-esapi links against libtss2 via pkg-config
 DEPENDS = "tpm2-tss"


### PR DESCRIPTION
## Summary

Adds U-Boot TPM Kconfig fragment and supporting infrastructure for Infineon SLB9672 TPM2 over SPI on RPi5. **The U-Boot TPM path is parked** — this PR documents the investigation and lands the safe, non-breaking pieces.

- U-Boot TPM Kconfig fragment (`iotgw-uboot-tpm.cfg`) gated behind `IOTGW_ENABLE_TPM_SLB9672`
- U-Boot alt source override (`IOTGW_UBOOT_ALT_URI`) for bring-up testing
- `kas/uboot-next.yml` include for upstream U-Boot experiments
- `bundle-dev` Makefile target for rootfs-only bundles
- `externalsrc` support for `tpm-ops` recipe
- Research doc: `docs/UBOOT_TPM_SLB9672.md`

## Findings: U-Boot TPM on RPi5 Not Viable (2026-04)

On RPi5, the TPM sits behind **PCIe → RP1 → SPI**. Hardware bring-up on target revealed three blockers in U-Boot 2025.04:

1. **BCM2712 PCIe probe crashes** — `pcie_brcmstb` triggers SError abort (ESR `0xbe000011`). The driver has `brcm,bcm2712-pcie` compatible but uses BCM2711 init paths. BCM2712 requires different PHY PLL setup (54MHz xosc), BCM7712 register offsets, and RESCAL bridge shutdown quirk.

2. **No RP1 MFD driver** — the RP1 PCI endpoint (`pci1de4,1`) needs a driver to map its BAR and expose child buses. Linux has `drivers/misc/rp1.c`; U-Boot has nothing equivalent.

3. **No RP1 SPI driver** — even with PCIe + RP1 working, no U-Boot driver exists to expose the DesignWare SPI controller behind the RP1 BAR.

`CONFIG_PCI_INIT_R` and `CONFIG_USB_XHCI_PCI` are disabled in the fragment to prevent boot crashes.

### Upstream status
- **EPAM** (20-patch RFC, Feb 2025): PCIe + RP1 MFD + GPIO + clocks + Ethernet. No SPI. Not merged.
- **SUSE** (Oct 2025): 3-part series, only fixes posted. PCIe + RP1 parts not yet submitted. No SPI.
- Neither series includes an RP1 SPI driver.

### Recommended path forward
TPM deferred to Linux (`tpm_tis_spi` kernel driver + `tpm-ops` CLI). BCM2712 OTP secure boot can close the EEPROM → U-Boot trust gap. Revisit U-Boot TPM when upstream gains RP1 SPI support.


