### PR TITLE
chore(build): add rootfs-only dev bundle target and refresh TPM refs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help base dev prod desktop \
-        bundle-dev-full bundle-dev-full-fit bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        bundle-dev bundle-dev-full bundle-dev-full-fit bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
         layers parse clean-lock
 
 KAS ?= kas
@@ -25,6 +25,7 @@ help:
 	@echo "  make bundle-prod-full     # Bundle from prod image"
 	@echo "  make bundle-desktop-full  # Bundle from desktop image"
 	@echo "  -- Bundles (rootfs-only) --"
+	@echo "  make bundle-dev           # Rootfs-only bundle from dev image"
 	@echo "  make bundle-desktop       # Rootfs-only bundle from desktop image"
 	@echo "  -- Utilities --"
 	@echo "  make layers               # Show layers for RAUC stack"
@@ -50,6 +51,9 @@ define bundle_cmd
                    IOTGW_ENABLE_OTBR=$$IOTGW_ENABLE_OTBR \
                    bitbake $(2)' $(BASE)
 endef
+
+bundle-dev:
+	$(call bundle_cmd,iot-gw-image-dev,iot-gw-bundle)
 
 bundle-dev-full:
 	$(call bundle_cmd,iot-gw-image-dev,iot-gw-bundle-full)

--- a/kas/tpm.yml
+++ b/kas/tpm.yml
@@ -3,7 +3,8 @@ header:
 
 repos:
   meta-secure-core:
-    path: /home/umair/yocto_resource/layers/meta-secure-core
+    url: https://github.com/Wind-River/meta-secure-core.git
+    refspec: scarthgap
     layers:
       meta-secure-core-common:
       meta-signing-key:

--- a/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.1.0.bb
+++ b/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.1.0.bb
@@ -5,7 +5,7 @@ LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=bf72105a69d303b78352c6a39239bc69"
 
 SRC_URI = "git://github.com/umair-as/tpm-ops.git;protocol=https;branch=main"
-SRCREV = "e6fdda8eff836f2e819a3cb6f907ca1d3f4a3793"
+SRCREV = "7be8a903d967cac9872468497359a5d7a9a47d7b"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
## Summary
- add `make bundle-dev` rootfs-only target
- update `kas/tpm.yml` meta-secure-core source to upstream URL+ref
- bump `tpm-ops` recipe SRCREV to latest pinned commit

## Notes
- U-Boot TPM work remains parked.