### PR TITLE
feat(kernel): reduce EFI attack surface for non-UEFI RPi5 boot

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -141,6 +141,22 @@ tpm2_startup -c
 
 ---
 
+### `igw_no_efi`
+
+Opt-in kernel EFI surface reduction for non-UEFI Raspberry Pi boot flow.
+
+**Features:** disables EFI runtime/stub/efivar paths in the kernel build.
+
+**Use for:** appliance deployments that boot via Raspberry Pi firmware + U-Boot
+`bootm` flow and do not require kernel EFI interfaces.
+
+**Important:** this feature intentionally does **not** disable
+`CONFIG_EFI_PARTITION`, since GPT partition parsing relies on it.
+
+**Layer gate:** `IOTGW_ENABLE_KERNEL_NO_EFI` (defaults to `1`).
+
+---
+
 ## Enabling Feature Sets
 
 ### Via KAS Overlay
@@ -179,6 +195,16 @@ local_conf_header:
     IOTGW_ENABLE_TPM_SLB9672 = "1"
     # Optional override (default "tpm-slb9670")
     # IOTGW_TPM_DTO_OVERLAY = "tpm-slb9670"
+```
+
+### Kernel EFI Surface Gate
+
+Enable/disable EFI surface reduction fragment:
+
+```yaml
+local_conf_header:
+  kernel_efi_gate: |
+    IOTGW_ENABLE_KERNEL_NO_EFI = "1"   # set to "0" to keep kernel EFI options enabled
 ```
 
 ## DTB Selection

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -20,6 +20,7 @@ SRC_URI:append = "${@' file://fragments/networking-iot.cfg' if 'igw_networking_i
 SRC_URI:append = "${@' file://fragments/observability-dev.cfg' if 'igw_observability_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 SRC_URI:append = "${@' file://fragments/security-prod.cfg' if 'igw_security_prod' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 SRC_URI:append = "${@' file://fragments/tpm-slb9672.cfg' if 'igw_tpm_slb9672' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+SRC_URI:append = "${@' file://fragments/efi-surface-reduction.cfg' if 'igw_no_efi' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 
 # Merge present fragments into the active kernel .config.
 do_configure:append() {

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -100,7 +100,7 @@ ROOT_HOME ?= "/root"
 # Allow injecting Wi-Fi credentials from the shell environment without committing them
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
-BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY IOTGW_ENABLE_KERNEL_NO_EFI"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
@@ -136,6 +136,7 @@ IOTGW_DESKTOP_PACKAGES ?= "weston wayland-utils mesa libdrm"
 #   igw_containers         - namespaces, cgroups (for podman/docker)
 #   igw_compute_media      - GPU/V4L2/cameras/hugepages (for desktop/ML)
 #   igw_observability_dev  - eBPF/ftrace/kprobes (dev builds only)
+#   igw_no_efi             - disable kernel EFI runtime/stub surface (opt-in)
 IOTGW_KERNEL_FEATURES ?= "igw_networking_iot igw_security_prod"
 
 # Optional TPM2 over SPI profile for Infineon SLB9672-class modules.
@@ -144,6 +145,11 @@ IOTGW_KERNEL_FEATURES ?= "igw_networking_iot igw_security_prod"
 IOTGW_ENABLE_TPM_SLB9672 ?= "0"
 IOTGW_TPM_DTO_OVERLAY ?= "tpm-slb9670"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672', '1', ' igw_tpm_slb9672', '', d)}"
+
+# Optional kernel EFI surface reduction profile for non-UEFI RPi5 boot flow.
+# Enable to append igw_no_efi fragment set.
+IOTGW_ENABLE_KERNEL_NO_EFI ?= "1"
+IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_KERNEL_NO_EFI', '1', ' igw_no_efi', '', d)}"
 # Mainline RPi5 DTB note:
 # - Firmware `dtparam=` keys must exist in DTB `__overrides__`.
 # - Current mainline bcm2712-rpi-5-b path exports rtc/rtc_bbat_vchg, but not

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/efi-surface-reduction.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/efi-surface-reduction.cfg
@@ -1,0 +1,25 @@
+# Optional kernel EFI surface reduction for non-UEFI Raspberry Pi boot flow.
+# Keep this opt-in via IOTGW_KERNEL_FEATURES += "igw_no_efi".
+#
+# Note: Do not disable CONFIG_EFI_PARTITION here; GPT partition parsing depends on it.
+
+# Core EFI interfaces
+# CONFIG_EFI is not set
+# CONFIG_EFI_STUB is not set
+# CONFIG_EFIVAR_FS is not set
+
+# EFI ancillary/runtime paths (disabled via EFI=n, listed for clarity)
+# CONFIG_EFI_ESRT is not set
+# CONFIG_EFI_VARS_PSTORE is not set
+# CONFIG_EFI_SOFT_RESERVE is not set
+# CONFIG_EFI_PARAMS_FROM_FDT is not set
+# CONFIG_EFI_RUNTIME_WRAPPERS is not set
+# CONFIG_EFI_GENERIC_STUB is not set
+# CONFIG_EFI_ARMSTUB_DTB_LOADER is not set
+# CONFIG_EFI_CAPSULE_LOADER is not set
+# CONFIG_EFI_EARLYCON is not set
+# CONFIG_EFI_CUSTOM_SSDT_OVERLAYS is not set
+
+# UEFI CPER (depends on EFI paths)
+# CONFIG_UEFI_CPER is not set
+# CONFIG_UEFI_CPER_ARM is not set


### PR DESCRIPTION
## Summary
- add `igw_no_efi` kernel feature fragment to disable EFI runtime/stub/efivar surface for non-UEFI Raspberry Pi boot flow
- wire `igw_no_efi` in `iotgw-kernel-fragments.bbclass`
- add distro gate `IOTGW_ENABLE_KERNEL_NO_EFI` (default `1`) in `iotgw-common.inc`
- document feature and gate usage in `docs/KERNEL.md`

## Why
This appliance boots via Raspberry Pi firmware + U-Boot `bootm` path, not UEFI. Keeping EFI interfaces enabled in kernel is unnecessary surface.

## Validation
- built and installed bundle on target
- runtime verification after reboot:
  - `/sys/firmware/efi` is absent
  - `zcat /proc/config.gz | grep -E 'CONFIG_EFI=|CONFIG_EFI_STUB|CONFIG_EFIVAR_FS|CONFIG_EFI_RUNTIME_WRAPPERS|CONFIG_EFI_GENERIC_STUB|CONFIG_EFI_PARAMS_FROM_FDT'` returns no matches
- normal boot/RAUC flow still works

## Notes
- `CONFIG_EFI_PARTITION` intentionally not touched (GPT parsing dependency)
