### PR TITLE
systemd/observability hardening: NM-only boot path, runtime netmode overrides, TPM dev store

### DIFF
--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -76,28 +76,50 @@ local_conf_header:
 Runtime override (no rebuild) on deployed gateway:
 
 ```sh
-# enable strict network-online mode for full stack
-install -d /etc/systemd/system/telegraf.service.d
-install -d /etc/systemd/system/mosquitto.service.d
-install -d /etc/systemd/system/influxdb.service.d
+# Ephemeral (current boot only): use /run/systemd/system
+install -d /run/systemd/system/telegraf.service.d
+install -d /run/systemd/system/mosquitto.service.d
+install -d /run/systemd/system/influxdb.service.d
 
 ln -snf /usr/share/iotgw-observability/netmode/telegraf-online.conf \
-  /etc/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+  /run/systemd/system/telegraf.service.d/99-runtime-netmode.conf
 ln -snf /usr/share/iotgw-observability/netmode/mosquitto-online.conf \
-  /etc/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+  /run/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
 ln -snf /usr/share/iotgw-observability/netmode/influxdb-online.conf \
-  /etc/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+  /run/systemd/system/influxdb.service.d/99-runtime-netmode.conf
 
 systemctl daemon-reload
 systemctl restart mosquitto.service influxdb.service telegraf.service
 ```
 
-Revert to local-first mode (default):
+Persistent override on RO-rootfs images (survives reboot/OTA): place the same
+links in overlay upper:
 
 ```sh
-rm -f /etc/systemd/system/telegraf.service.d/99-runtime-netmode.conf
-rm -f /etc/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
-rm -f /etc/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+install -d /data/overlays/etc/upper/systemd/system/telegraf.service.d
+install -d /data/overlays/etc/upper/systemd/system/mosquitto.service.d
+install -d /data/overlays/etc/upper/systemd/system/influxdb.service.d
+
+ln -snf /usr/share/iotgw-observability/netmode/telegraf-online.conf \
+  /data/overlays/etc/upper/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+ln -snf /usr/share/iotgw-observability/netmode/mosquitto-online.conf \
+  /data/overlays/etc/upper/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+ln -snf /usr/share/iotgw-observability/netmode/influxdb-online.conf \
+  /data/overlays/etc/upper/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+
+systemctl daemon-reload
+systemctl restart mosquitto.service influxdb.service telegraf.service
+```
+
+Revert to local-first mode:
+
+```sh
+rm -f /run/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+rm -f /run/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+rm -f /run/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+rm -f /data/overlays/etc/upper/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+rm -f /data/overlays/etc/upper/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+rm -f /data/overlays/etc/upper/systemd/system/influxdb.service.d/99-runtime-netmode.conf
 systemctl daemon-reload
 systemctl restart mosquitto.service influxdb.service telegraf.service
 ```

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -54,6 +54,57 @@ local_conf_header:
     IMAGE_INSTALL:append = " iotgw-observability-stack"
 ```
 
+## Startup Dependency Mode
+
+Telegraf supports two build-time startup modes:
+
+- default (`IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE = "0"`):
+  `network.target` ordering, no hard wait on `network-online.target`.
+  Recommended for local broker/DB and robust boot on unstable links.
+- strict (`IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE = "1"`):
+  install a Telegraf systemd drop-in that switches ordering to
+  `network-online.target`. Use for remote broker/DB startup gating.
+
+Set in `kas/local.yml`:
+
+```yaml
+local_conf_header:
+  observability_netmode: |
+    IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE = "1"
+```
+
+Runtime override (no rebuild) on deployed gateway:
+
+```sh
+# enable strict network-online mode for full stack
+install -d /etc/systemd/system/telegraf.service.d
+install -d /etc/systemd/system/mosquitto.service.d
+install -d /etc/systemd/system/influxdb.service.d
+
+ln -snf /usr/share/iotgw-observability/netmode/telegraf-online.conf \
+  /etc/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+ln -snf /usr/share/iotgw-observability/netmode/mosquitto-online.conf \
+  /etc/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+ln -snf /usr/share/iotgw-observability/netmode/influxdb-online.conf \
+  /etc/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+
+systemctl daemon-reload
+systemctl restart mosquitto.service influxdb.service telegraf.service
+```
+
+Revert to local-first mode (default):
+
+```sh
+rm -f /etc/systemd/system/telegraf.service.d/99-runtime-netmode.conf
+rm -f /etc/systemd/system/mosquitto.service.d/99-runtime-netmode.conf
+rm -f /etc/systemd/system/influxdb.service.d/99-runtime-netmode.conf
+systemctl daemon-reload
+systemctl restart mosquitto.service influxdb.service telegraf.service
+```
+
+OTA behavior: these runtime drop-ins are marked `preserve` in overlay
+reconciliation, so operator-selected mode survives slot switches.
+
 ## Credential Flow
 
 Secrets (MQTT and InfluxDB passwords) are never stored in the Telegraf config,
@@ -174,13 +225,16 @@ All three services run with systemd security sandboxing:
 | `ProtectSystem` | — | strict | — |
 | `CapabilityBoundingSet` | `CAP_NET_BIND_SERVICE` | _(empty)_ | — |
 | `RestrictAddressFamilies` | — | `AF_UNIX AF_NETLINK AF_INET AF_INET6` | — |
-| `StartLimitIntervalSec` | 0 (retry forever) | 0 (retry forever) | 0 (retry forever) |
-| `RestartSec` | 5s | 10s | 10s |
+| `StartLimitIntervalSec` | 0 (retry forever) | 5m (burst-limited) | 0 (retry forever) |
+| `StartLimitBurst` | — | 3 | — |
+| `RestartSec` | 5s | 30s | 10s |
 
-Retry-forever (`StartLimitIntervalSec=0`) is intentional: these are critical
-infrastructure services. edge-healthd monitors restart counts and raises alerts
-when `service_restart_warn` (3) or `service_restart_crit` (10) thresholds are
-exceeded — providing bounded alerting without forcing systemd to give up.
+For Telegraf, startup is gated by systemd `ExecCondition` checks that require
+non-empty credential files under `/etc/credstore/`. This prevents crash loops
+before provisioning has applied credentials.
+
+Telegraf network dependency mode is controlled by
+`IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE` (see "Startup Dependency Mode").
 
 ## OTA Behaviour
 

--- a/docs/RAUC_UPDATE.md
+++ b/docs/RAUC_UPDATE.md
@@ -18,6 +18,26 @@ Current defaults:
 - cleanup: `boot-backup-prune.service` runs after mark-good
 - cleanup prunes old `/boot/*.bak*` artifacts and keeps recent backups
 
+## Overlay Policy for systemd Masks
+
+For unit disable/mask policy on this gateway OS, use a two-layer approach:
+
+1. Build-time rootfs masks in `iotgw-rootfs.bbclass` establish desired state in
+   each slot image (`/etc/systemd/system/*.service -> /dev/null` symlinks).
+2. RAUC overlay reconciliation enforces the same paths in `/etc` upper layer so
+   stale runtime overlay entries cannot override the new slot policy.
+
+Rationale:
+
+- `/etc` is overlay-backed at runtime.
+- A/B slot content alone is not sufficient if upper-layer entries from older
+  slots still exist.
+- Preset-based `disable` rules are not deterministic in this Yocto flow
+  (`preset-all --preset-mode=enable-only`).
+
+This policy is used for NetworkManager-only networking mode to keep
+`systemd-networkd*` and wait-online units from reappearing after OTA.
+
 ## Install Bundle
 
 Manual install workflow (recommended):

--- a/meta-iot-gateway/classes/iotgw-rootfs.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rootfs.bbclass
@@ -104,6 +104,25 @@ iotgw_rootfs_mask_nm_wait_online() {
 }
 ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_mask_nm_wait_online;"
 
+###### Disable systemd-network-generator for NetworkManager-only gateway profile
+# We do not use systemd-networkd units in this distro profile. Keep boot path
+# lean by masking the generator that emits networkd units from kernel cmdline.
+iotgw_rootfs_mask_network_generator() {
+    install -d ${IMAGE_ROOTFS}/etc/systemd/system
+    ln -snf /dev/null ${IMAGE_ROOTFS}/etc/systemd/system/systemd-network-generator.service
+}
+ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_mask_network_generator;"
+
+###### Disable systemd-networkd stack for NetworkManager-only gateway profile
+iotgw_rootfs_mask_networkd_stack() {
+    install -d ${IMAGE_ROOTFS}/etc/systemd/system
+    ln -snf /dev/null ${IMAGE_ROOTFS}/etc/systemd/system/systemd-networkd.service
+    ln -snf /dev/null ${IMAGE_ROOTFS}/etc/systemd/system/systemd-networkd.socket
+    ln -snf /dev/null ${IMAGE_ROOTFS}/etc/systemd/system/systemd-networkd-wait-online.service
+    rm -f ${IMAGE_ROOTFS}/etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
+}
+ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_mask_networkd_stack;"
+
 ###### Optional vconsole setup masking (headless/serial-focused images)
 iotgw_rootfs_mask_vconsole_setup() {
     if [ "${IOTGW_DISABLE_VCONSOLE_SETUP}" = "1" ]; then
@@ -158,3 +177,16 @@ iotgw_rootfs_version_finalize() {
     echo "${IMAGE_NAME}" > ${IMAGE_ROOTFS}/etc/version
 }
 do_rootfs[postfuncs] += "iotgw_rootfs_version_finalize"
+
+# Ensure interactive shell defaults are present for operator users.
+# Some user-creation flows may skip /etc/skel materialization for devel.
+iotgw_rootfs_seed_bashrc() {
+    if [ -f ${IMAGE_ROOTFS}/etc/skel/.bashrc ]; then
+        if [ -d ${IMAGE_ROOTFS}/home/devel ] && [ ! -f ${IMAGE_ROOTFS}/home/devel/.bashrc ]; then
+            install -m 0644 ${IMAGE_ROOTFS}/etc/skel/.bashrc ${IMAGE_ROOTFS}/home/devel/.bashrc
+        fi
+        install -d ${IMAGE_ROOTFS}/root
+        install -m 0644 ${IMAGE_ROOTFS}/etc/skel/.bashrc ${IMAGE_ROOTFS}/root/.bashrc
+    fi
+}
+do_rootfs[postfuncs] += "iotgw_rootfs_seed_bashrc"

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -101,7 +101,7 @@ ROOT_HOME ?= "/root"
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY IOTGW_ENABLE_KERNEL_NO_EFI"
-BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYPTED_STORE_DEV IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_BUILD_ID IOTGW_VERSION_MAJOR IOTGW_VERSION_MINOR IOTGW_VERSION_PATCH"
@@ -163,6 +163,14 @@ RPI_EXTRA_CONFIG:append = "${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672', '1',
 # Containerized observability is paused on Scarthgap due to Rust toolchain skew
 # in netavark/aardvark-dns and will be revisited on the next Yocto LTS rebase.
 IOTGW_ENABLE_OBSERVABILITY ?= "0"
+# Telegraf dependency mode:
+#   0: local-first startup (network.target) with runtime retries (default)
+#   1: strict startup ordering via network-online.target (remote endpoints)
+IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE ?= "0"
+
+# Optional dev TPM/LUKS loopback store (/data/encstore). Keep opt-in to avoid
+# boot-time/setup overhead on images where encrypted-store testing is not active.
+IOTGW_ENABLE_ENCRYPTED_STORE_DEV ?= "0"
 
 # Raspberry Pi 5 DTB policy by kernel provider:
 # - Default to Model B only (smallest artifact set for rpi5 deployments).

--- a/meta-iot-gateway/recipes-connectivity/openssh/files/openssh-hostkeys.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-connectivity/openssh/files/openssh-hostkeys.tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/lib/ssh 0700 root root -

--- a/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,0 +1,32 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append = " file://openssh-hostkeys.tmpfiles.conf"
+
+do_install:append() {
+    # For read-only-rootfs profile, OE-Core points sshd_config_readonly HostKey
+    # to /var/run/ssh (volatile), forcing key regeneration every boot.
+    # Move host keys to /var/lib/ssh so sshdgenkeys is one-time.
+    if [ -f ${D}${sysconfdir}/ssh/sshd_config_readonly ]; then
+        sed -i '/^HostKey /d' ${D}${sysconfdir}/ssh/sshd_config_readonly
+        {
+            echo "HostKey /var/lib/ssh/ssh_host_rsa_key"
+            echo "HostKey /var/lib/ssh/ssh_host_ecdsa_key"
+            echo "HostKey /var/lib/ssh/ssh_host_ed25519_key"
+        } >> ${D}${sysconfdir}/ssh/sshd_config_readonly
+    fi
+
+    # Keep sshd_check_keys target directory aligned with readonly sshd config.
+    if [ -f ${D}${sysconfdir}/default/ssh ]; then
+        # Upstream default points to volatile /var/run/ssh on RO rootfs setups.
+        # Rewrite to persistent /var/lib/ssh so key generation is one-time.
+        sed -i -e 's#/var/run/ssh#/var/lib/ssh#g' -e 's#/run/ssh#/var/lib/ssh#g' \
+            ${D}${sysconfdir}/default/ssh
+    fi
+
+    # Ensure persistent host key directory exists with strict permissions.
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/openssh-hostkeys.tmpfiles.conf \
+        ${D}${sysconfdir}/tmpfiles.d/openssh-hostkeys.conf
+}
+
+FILES:${PN}-sshd:append = " ${sysconfdir}/tmpfiles.d/openssh-hostkeys.conf"

--- a/meta-iot-gateway/recipes-core/base-files/base-files/skel/.bashrc
+++ b/meta-iot-gateway/recipes-core/base-files/base-files/skel/.bashrc
@@ -28,6 +28,15 @@ alias jx='journalctl -xe'
 alias nm='nmcli'
 alias k='kubectl 2>/dev/null || true'
 
+# Persistent tmux socket for remote agent/operator collaboration.
+if [ -d /data ] && mkdir -p /data/tmux 2>/dev/null; then
+    alias tmux='tmux -S /data/tmux/gateway.sock'
+fi
+
+alias t='tmux'
+alias ta='tmux attach -t main || tmux new -s main'
+alias tn='tmux new -s main'
+
 # Prompt: user@host:cwd$
 PS1='\u@\h:\w\$ '
 

--- a/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
@@ -13,6 +13,8 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/profile.d/10-iotgw-path.sh ${D}${sysconfdir}/profile.d/10-iotgw-path.sh
     install -d ${D}/etc/skel
     install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/etc/skel/.bashrc
+    install -d ${D}/root
+    install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/root/.bashrc
     install -d ${D}/uboot-env
 
     # Create uninitialized machine-id file.

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-base.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-base.bb
@@ -17,6 +17,7 @@ RDEPENDS:${PN} = " \
     ota-certs \
     ${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672','1',' cryptsetup','',d)} \
     ${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672','1',' iotgw-tpm-policy tpm-ops iotgw-tpm-health','',d)} \
+    ${@bb.utils.contains('IOTGW_ENABLE_ENCRYPTED_STORE_DEV','1',' iotgw-encrypted-store','',d)} \
     ${@bb.utils.contains('IOTGW_ENABLE_OBSERVABILITY','1',' packagegroup-iot-gw-observability','',d)} \
 "
 

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-devtools.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-devtools.bb
@@ -14,7 +14,10 @@ RDEPENDS:${PN} = " \
     bpftool \
     keyutils \
     libseccomp \
+    fio \
+    iotop \
     lsof \
+    stress-ng \
     ethtool \
     vim \
     nano \

--- a/meta-iot-gateway/recipes-devtools/stress-ng/stress-ng_0.20.01.bb
+++ b/meta-iot-gateway/recipes-devtools/stress-ng/stress-ng_0.20.01.bb
@@ -1,0 +1,35 @@
+SUMMARY = "System load testing utility"
+DESCRIPTION = "Deliberately simple workload generator for POSIX systems. It \
+imposes a configurable amount of CPU, memory, I/O, and disk stress on the system."
+HOMEPAGE = "https://github.com/ColinIanKing/stress-ng#readme"
+LICENSE = "GPL-2.0-only"
+LIC_FILES_CHKSUM = "file://COPYING;md5=b234ee4d69f5fce4486a80fdaf4a4263"
+
+SRC_URI = "git://github.com/ColinIanKing/stress-ng.git;protocol=https;branch=master"
+SRCREV = "00559dcb1bae3ef12295a1420683094a7d1389e0"
+S = "${WORKDIR}/git"
+
+DEPENDS = "coreutils-native libbsd"
+
+PROVIDES = "stress"
+RPROVIDES:${PN} = "stress"
+RREPLACES:${PN} = "stress"
+RCONFLICTS:${PN} = "stress"
+
+inherit bash-completion
+
+EXTRA_OEMAKE = "VERBOSE=1"
+
+do_configure() {
+    mkdir -p configs
+    touch configs/HAVE_APPARMOR
+    oe_runmake makeconfig
+}
+
+do_install() {
+    oe_runmake DESTDIR=${D} BINDIR=${bindir} install
+    ln -s stress-ng ${D}${bindir}/stress
+}
+
+# upstream issue: https://github.com/ColinIanKing/stress-ng/issues/315
+DEBUG_BUILD = "0"

--- a/meta-iot-gateway/recipes-devtools/tmux/files/tmux.conf
+++ b/meta-iot-gateway/recipes-devtools/tmux/files/tmux.conf
@@ -1,0 +1,72 @@
+# tmux.conf — edge gateway target
+# Deployed to /etc/tmux.conf via Yocto
+
+# ── Prefix ────────────────────────────────────────────────────────────────────
+unbind C-b
+set-option -g prefix C-a
+bind-key C-a send-prefix
+
+# ── Terminal ──────────────────────────────────────────────────────────────────
+set-option -g default-terminal "screen-256color"
+set-option -sg escape-time 10
+set-option -g display-time 3000
+
+# ── Windows & panes ───────────────────────────────────────────────────────────
+set -g base-index 1
+set -g pane-base-index 1
+set -g renumber-windows on
+set -g history-limit 50000
+setw -g aggressive-resize on
+set -g display-panes-time 2000
+
+bind | split-window -h -c "#{pane_current_path}"
+bind - split-window -v -c "#{pane_current_path}"
+unbind '"'
+unbind %
+
+bind v select-layout even-vertical
+bind h select-layout even-horizontal
+bind t select-layout tiled
+bind o select-layout main-horizontal
+
+# ── Pane navigation (Alt+arrows and vim-style) ────────────────────────────────
+bind -n M-Left  select-pane -L
+bind -n M-Right select-pane -R
+bind -n M-Up    select-pane -U
+bind -n M-Down  select-pane -D
+
+bind -n M-h select-pane -L
+bind -n M-j select-pane -D
+bind -n M-k select-pane -U
+bind -n M-l select-pane -R
+
+# ── Mouse & focus ─────────────────────────────────────────────────────────────
+set -g mouse on
+set -g focus-events on
+setw -g monitor-activity on
+set -g visual-activity off
+
+# ── Vi copy-mode ──────────────────────────────────────────────────────────────
+setw -g mode-keys vi
+bind-key [ copy-mode
+bind-key ] paste-buffer
+bind-key -T copy-mode-vi v send -X begin-selection
+bind-key -T copy-mode-vi y send -X copy-selection-and-cancel
+set -g mode-style 'bg=blue,fg=white,bold'
+
+# ── Reload ────────────────────────────────────────────────────────────────────
+bind R source-file /etc/tmux.conf \; display-message "tmux.conf reloaded"
+
+# ── Status bar ────────────────────────────────────────────────────────────────
+set -g status-interval 10
+set -g status-style 'bg=colour235,fg=colour250'
+set -g status-left  '#[fg=colour39,bold] #S #[default] '
+set -g status-right '#[fg=colour245]%H:%M  #[fg=colour39]#h'
+set -g status-right-length 60
+
+set -g window-status-format         '#[fg=colour245] #I:#W '
+set -g window-status-current-format '#[fg=white,bold,bg=colour238] #I:#W '
+
+set -g pane-border-style        'fg=colour238'
+set -g pane-active-border-style 'fg=colour39'
+set -g message-style            'bg=colour235,fg=colour39'

--- a/meta-iot-gateway/recipes-devtools/tmux/tmux_%.bbappend
+++ b/meta-iot-gateway/recipes-devtools/tmux/tmux_%.bbappend
@@ -1,0 +1,8 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://tmux.conf"
+
+do_install:append() {
+    install -d ${D}${sysconfdir}
+    install -m 0644 ${WORKDIR}/tmux.conf ${D}${sysconfdir}/tmux.conf
+}

--- a/meta-iot-gateway/recipes-observability/influxdb/files/influxdb.service.d-10-iotgw-hardening.conf
+++ b/meta-iot-gateway/recipes-observability/influxdb/files/influxdb.service.d-10-iotgw-hardening.conf
@@ -1,5 +1,9 @@
 [Unit]
 StartLimitIntervalSec=0
+# InfluxDB listens on localhost in this profile; don't block on full
+# network-online synchronization (WiFi association/DHCP).
+After=
+After=network.target
 
 [Service]
 UMask=0027

--- a/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/influxdb-netmode-online.conf
+++ b/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/influxdb-netmode-online.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Runtime-selectable strict startup ordering for remote clients/dependencies.
+After=
+After=network-online.target
+Wants=
+Wants=network-online.target

--- a/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/mosquitto-netmode-online.conf
+++ b/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/mosquitto-netmode-online.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Runtime-selectable strict startup ordering for remote clients/dependencies.
+After=
+After=network-online.target
+Wants=
+Wants=network-online.target

--- a/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/telegraf-netmode-online.conf
+++ b/meta-iot-gateway/recipes-observability/iotgw-observability-stack/files/telegraf-netmode-online.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Runtime-selectable strict startup ordering for remote endpoints.
+After=
+After=network-online.target mosquitto.service
+Wants=
+Wants=network-online.target mosquitto.service

--- a/meta-iot-gateway/recipes-observability/iotgw-observability-stack/iotgw-observability-stack_1.0.0.bb
+++ b/meta-iot-gateway/recipes-observability/iotgw-observability-stack/iotgw-observability-stack_1.0.0.bb
@@ -5,6 +5,9 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 SRC_URI = " \
     file://iotgw-observability.env \
+    file://telegraf-netmode-online.conf \
+    file://mosquitto-netmode-online.conf \
+    file://influxdb-netmode-online.conf \
 "
 
 S = "${WORKDIR}"
@@ -12,6 +15,14 @@ S = "${WORKDIR}"
 do_install() {
     install -d ${D}${sysconfdir}/default
     install -m 0644 ${WORKDIR}/iotgw-observability.env ${D}${sysconfdir}/default/iotgw-observability
+
+    install -d ${D}${datadir}/iotgw-observability/netmode
+    install -m 0644 ${WORKDIR}/telegraf-netmode-online.conf \
+        ${D}${datadir}/iotgw-observability/netmode/telegraf-online.conf
+    install -m 0644 ${WORKDIR}/mosquitto-netmode-online.conf \
+        ${D}${datadir}/iotgw-observability/netmode/mosquitto-online.conf
+    install -m 0644 ${WORKDIR}/influxdb-netmode-online.conf \
+        ${D}${datadir}/iotgw-observability/netmode/influxdb-online.conf
 
     # systemd LoadCredential source files (intentionally empty defaults)
     install -d -m 0700 ${D}${sysconfdir}/credstore
@@ -23,6 +34,9 @@ do_install() {
 
 FILES:${PN} = " \
     ${sysconfdir}/default/iotgw-observability \
+    ${datadir}/iotgw-observability/netmode/telegraf-online.conf \
+    ${datadir}/iotgw-observability/netmode/mosquitto-online.conf \
+    ${datadir}/iotgw-observability/netmode/influxdb-online.conf \
     ${sysconfdir}/credstore/telegraf.service.mqtt_username \
     ${sysconfdir}/credstore/telegraf.service.mqtt_password \
     ${sysconfdir}/credstore/telegraf.service.influxdb_username \

--- a/meta-iot-gateway/recipes-observability/telegraf/files/telegraf-network-online.conf
+++ b/meta-iot-gateway/recipes-observability/telegraf/files/telegraf-network-online.conf
@@ -1,0 +1,6 @@
+[Unit]
+# Optional strict network-online mode for remote broker/DB deployments.
+After=
+After=network-online.target mosquitto.service
+Wants=
+Wants=network-online.target mosquitto.service

--- a/meta-iot-gateway/recipes-observability/telegraf/files/telegraf.service
+++ b/meta-iot-gateway/recipes-observability/telegraf/files/telegraf.service
@@ -1,9 +1,11 @@
 [Unit]
 Description=Telegraf metrics agent
 Documentation=https://github.com/influxdata/telegraf
-After=network-online.target mosquitto.service
-Wants=network-online.target mosquitto.service
-StartLimitIntervalSec=0
+After=network.target mosquitto.service
+Wants=mosquitto.service
+# Bound restart storms when credentials are missing or invalid.
+StartLimitIntervalSec=5min
+StartLimitBurst=3
 
 [Service]
 Type=simple
@@ -20,9 +22,14 @@ LoadCredential=mqtt_username:/etc/credstore/telegraf.service.mqtt_username
 LoadCredential=mqtt_password:/etc/credstore/telegraf.service.mqtt_password
 LoadCredential=influxdb_username:/etc/credstore/telegraf.service.influxdb_username
 LoadCredential=influxdb_password:/etc/credstore/telegraf.service.influxdb_password
+# Skip service start until required credentials are non-empty.
+ExecCondition=/bin/sh -c 'test -s /etc/credstore/telegraf.service.mqtt_username'
+ExecCondition=/bin/sh -c 'test -s /etc/credstore/telegraf.service.mqtt_password'
+ExecCondition=/bin/sh -c 'test -s /etc/credstore/telegraf.service.influxdb_username'
+ExecCondition=/bin/sh -c 'test -s /etc/credstore/telegraf.service.influxdb_password'
 ExecStart=/usr/bin/telegraf --config /etc/telegraf/telegraf.conf
 Restart=on-failure
-RestartSec=10
+RestartSec=30
 NoNewPrivileges=yes
 ProtectSystem=strict
 ProtectHome=yes

--- a/meta-iot-gateway/recipes-observability/telegraf/telegraf_1.31.0.bb
+++ b/meta-iot-gateway/recipes-observability/telegraf/telegraf_1.31.0.bb
@@ -11,6 +11,7 @@ SRCREV = "fbfaba054e62413b6a0a90372281e687d9ff1238"
 SRC_URI = " \
     git://github.com/influxdata/telegraf.git;protocol=https;nobranch=1;destsuffix=${BPN}-${PV}/src/${GO_IMPORT} \
     file://telegraf.service \
+    file://telegraf-network-online.conf \
     file://telegraf.conf \
     file://telegraf.tmpfiles \
 "
@@ -65,6 +66,11 @@ do_install:append() {
 
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/telegraf.service ${D}${systemd_system_unitdir}/telegraf.service
+    if [ "${IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE}" = "1" ]; then
+        install -d ${D}${systemd_system_unitdir}/telegraf.service.d
+        install -m 0644 ${WORKDIR}/telegraf-network-online.conf \
+            ${D}${systemd_system_unitdir}/telegraf.service.d/10-network-online.conf
+    fi
 
     install -d ${D}${nonarch_libdir}/tmpfiles.d
     install -m 0644 ${WORKDIR}/telegraf.tmpfiles ${D}${nonarch_libdir}/tmpfiles.d/telegraf.conf

--- a/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
@@ -25,6 +25,9 @@ enforce /etc/login.defs
 enforce /etc/sysctl.d/90-iotgw.conf
 enforce /etc/systemd/journald.conf.d/iotgw.conf
 enforce /etc/systemd/system/sshd@.service optional
+# OpenSSH baselines: accept OTA recipe fixes unless operator modified locally.
+replace_if_unmodified /etc/default/ssh optional
+replace_if_unmodified /etc/ssh/sshd_config_readonly optional
 enforce /etc/tmux.conf optional
 # Network stack policy: NetworkManager-only profile. Keep explicit masks in
 # /etc/systemd/system resilient across OTA slot changes.

--- a/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
@@ -25,6 +25,20 @@ enforce /etc/login.defs
 enforce /etc/sysctl.d/90-iotgw.conf
 enforce /etc/systemd/journald.conf.d/iotgw.conf
 enforce /etc/systemd/system/sshd@.service optional
+enforce /etc/tmux.conf optional
+# Network stack policy: NetworkManager-only profile. Keep explicit masks in
+# /etc/systemd/system resilient across OTA slot changes.
+enforce /etc/systemd/system/NetworkManager-wait-online.service optional
+enforce /etc/systemd/system/systemd-network-generator.service optional
+enforce /etc/systemd/system/systemd-networkd.service optional
+enforce /etc/systemd/system/systemd-networkd.socket optional
+enforce /etc/systemd/system/systemd-networkd-wait-online.service optional
+absent /etc/systemd/system/network-online.target.wants/NetworkManager-wait-online.service
+absent /etc/systemd/system/network-online.target.wants/systemd-networkd-wait-online.service
+# Runtime observability netmode drop-ins are operator-controlled.
+preserve /etc/systemd/system/telegraf.service.d/99-runtime-netmode.conf optional
+preserve /etc/systemd/system/mosquitto.service.d/99-runtime-netmode.conf optional
+preserve /etc/systemd/system/influxdb.service.d/99-runtime-netmode.conf optional
 # TPM policy files (present when TPM profile is enabled).
 enforce /etc/environment.d/50-iotgw-tpm.conf optional
 enforce /etc/profile.d/iotgw-tpm-env.sh optional

--- a/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.d/observability.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.d/observability.conf
@@ -4,3 +4,4 @@
 replace_if_unmodified /etc/default/iotgw-observability optional
 replace_if_unmodified /etc/influxdb/influxdb.conf optional
 replace_if_unmodified /etc/telegraf/telegraf.conf optional
+replace_if_unmodified /etc/edge/healthd.conf optional

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/data-encstore.mount
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/data-encstore.mount
@@ -1,0 +1,14 @@
+[Unit]
+Description=Mount IoT Gateway encrypted store
+After=iotgw-encrypted-store-setup.service
+Requires=iotgw-encrypted-store-setup.service
+ConditionPathExists=/dev/mapper/igwencstore
+
+[Mount]
+What=/dev/mapper/igwencstore
+Where=/data/encstore
+Type=ext4
+Options=defaults,noatime,nodiratime
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store-setup.service
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store-setup.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=IoT Gateway encrypted-store setup (LUKS2 + TPM token)
+After=data.mount
+Requires=data.mount
+Before=data-encstore.mount
+ConditionPathExists=/data
+ConditionPathExists=/dev/tpmrm0
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/iotgw-encrypted-store-setup
+StandardOutput=journal
+StandardError=journal
+TimeoutSec=180
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store-setup.sh
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store-setup.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+LOG_TAG="iotgw-encstore"
+
+log() { printf '[%s] %s\n' "$LOG_TAG" "$*" >&2; }
+die() { log "ERROR: $*"; exit 1; }
+
+on_err() { die "failed at line ${1:-?} (cmd: ${BASH_COMMAND:-sh})"; }
+trap 'on_err $LINENO' ERR
+
+# shellcheck disable=SC1091
+[ -f /etc/default/iotgw-encrypted-store ] && . /etc/default/iotgw-encrypted-store
+
+STORE_DIR="${STORE_DIR:-/data/encrypted-store}"
+IMAGE_PATH="${IMAGE_PATH:-${STORE_DIR}/store.luks2.img}"
+MAPPER_NAME="${MAPPER_NAME:-igwencstore}"
+SIZE_MIB="${SIZE_MIB:-1024}"
+RECOVERY_KEY_FILE="${RECOVERY_KEY_FILE:-${STORE_DIR}/recovery.key}"
+TPM2_DEVICE="${TPM2_DEVICE:-auto}"
+TPM2_PCRS="${TPM2_PCRS:-7}"
+MAPPER_PATH="/dev/mapper/${MAPPER_NAME}"
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
+}
+
+is_mapped() {
+    [ -e "$MAPPER_PATH" ]
+}
+
+is_luks() {
+    cryptsetup isLuks "$IMAGE_PATH" >/dev/null 2>&1
+}
+
+has_tpm_token() {
+    cryptsetup luksDump "$IMAGE_PATH" 2>/dev/null | grep -q 'systemd-tpm2'
+}
+
+ensure_recovery_key() {
+    if [ -f "$RECOVERY_KEY_FILE" ]; then
+        return 0
+    fi
+    umask 077
+    head -c 48 /dev/urandom | base64 > "$RECOVERY_KEY_FILE"
+    chmod 600 "$RECOVERY_KEY_FILE"
+    log "created recovery key ${RECOVERY_KEY_FILE}"
+}
+
+ensure_luks_image() {
+    if [ ! -f "$IMAGE_PATH" ]; then
+        log "creating sparse image ${IMAGE_PATH} (${SIZE_MIB} MiB)"
+        truncate -s "${SIZE_MIB}M" "$IMAGE_PATH"
+    fi
+
+    if ! is_luks; then
+        log "formatting image as LUKS2"
+        cryptsetup luksFormat --type luks2 --batch-mode --key-file "$RECOVERY_KEY_FILE" "$IMAGE_PATH"
+    fi
+}
+
+ensure_tpm_token() {
+    if has_tpm_token; then
+        return 0
+    fi
+
+    log "enrolling TPM token (device=${TPM2_DEVICE}, pcrs=${TPM2_PCRS})"
+    systemd-cryptenroll "$IMAGE_PATH" \
+        --unlock-key-file="$RECOVERY_KEY_FILE" \
+        --tpm2-device="$TPM2_DEVICE" \
+        --tpm2-pcrs="$TPM2_PCRS"
+}
+
+ensure_mapper() {
+    if is_mapped; then
+        return 0
+    fi
+    cryptsetup open "$IMAGE_PATH" "$MAPPER_NAME" --key-file "$RECOVERY_KEY_FILE"
+    log "opened mapper ${MAPPER_PATH}"
+}
+
+ensure_ext4() {
+    if blkid "$MAPPER_PATH" | grep -q 'TYPE="ext4"'; then
+        return 0
+    fi
+    mkfs.ext4 -F -L dataenc "$MAPPER_PATH" >/dev/null
+    log "created ext4 filesystem on ${MAPPER_PATH}"
+}
+
+main() {
+    [ "$(id -u)" -eq 0 ] || die "must run as root"
+    [ -d /data ] || die "/data is not available"
+    [ -c /dev/tpmrm0 ] || die "/dev/tpmrm0 not found"
+
+    need_cmd cryptsetup
+    need_cmd systemd-cryptenroll
+    need_cmd mkfs.ext4
+    need_cmd blkid
+    need_cmd base64
+    need_cmd head
+    need_cmd truncate
+
+    mkdir -p "$STORE_DIR"
+    chmod 0700 "$STORE_DIR" || true
+
+    ensure_recovery_key
+    ensure_luks_image
+    ensure_tpm_token
+    ensure_mapper
+    ensure_ext4
+
+    log "setup complete for ${IMAGE_PATH} -> ${MAPPER_PATH}"
+}
+
+main "$@"

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store.default
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store.default
@@ -1,0 +1,12 @@
+# IoT GW encrypted-store defaults (dev profile)
+# Override via /etc/default/iotgw-encrypted-store if needed.
+
+STORE_DIR=/data/encrypted-store
+IMAGE_PATH=/data/encrypted-store/store.luks2.img
+MAPPER_NAME=igwencstore
+SIZE_MIB=1024
+RECOVERY_KEY_FILE=/data/encrypted-store/recovery.key
+TPM2_DEVICE=auto
+# Keep default PCR 7 for now. On current RPi5 flow PCR policy is effectively
+# unenforced because PCR values are all-zero; revisit after measured-boot policy.
+TPM2_PCRS=7

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/files/iotgw-encrypted-store.tmpfiles.conf
@@ -1,0 +1,2 @@
+d /data/encrypted-store 0700 root root -
+d /data/encstore 0755 root root -

--- a/meta-iot-gateway/recipes-security/iotgw-encrypted-store/iotgw-encrypted-store_0.1.0.bb
+++ b/meta-iot-gateway/recipes-security/iotgw-encrypted-store/iotgw-encrypted-store_0.1.0.bb
@@ -1,0 +1,51 @@
+SUMMARY = "IoT GW dev encrypted store (LUKS2 + TPM token)"
+DESCRIPTION = "Creates and mounts a loopback LUKS2 encrypted store under /data for TPM/cryptsetup integration testing."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://iotgw-encrypted-store-setup.sh \
+    file://iotgw-encrypted-store-setup.service \
+    file://data-encstore.mount \
+    file://iotgw-encrypted-store.tmpfiles.conf \
+    file://iotgw-encrypted-store.default \
+"
+
+inherit systemd
+
+SYSTEMD_SERVICE:${PN} = "iotgw-encrypted-store-setup.service data-encstore.mount"
+# Enable at image build time so boot graph sees units on read-only rootfs setups
+# with /etc overlay, where runtime `systemctl enable` can be non-deterministic.
+SYSTEMD_AUTO_ENABLE:${PN} = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/iotgw-encrypted-store-setup.sh ${D}${sbindir}/iotgw-encrypted-store-setup
+
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/iotgw-encrypted-store.default ${D}${sysconfdir}/default/iotgw-encrypted-store
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/iotgw-encrypted-store-setup.service ${D}${systemd_system_unitdir}/
+    install -m 0644 ${WORKDIR}/data-encstore.mount ${D}${systemd_system_unitdir}/
+
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${WORKDIR}/iotgw-encrypted-store.tmpfiles.conf ${D}${sysconfdir}/tmpfiles.d/iotgw-encrypted-store.conf
+}
+
+FILES:${PN} += " \
+    ${sbindir}/iotgw-encrypted-store-setup \
+    ${sysconfdir}/default/iotgw-encrypted-store \
+    ${systemd_system_unitdir}/iotgw-encrypted-store-setup.service \
+    ${systemd_system_unitdir}/data-encstore.mount \
+    ${sysconfdir}/tmpfiles.d/iotgw-encrypted-store.conf \
+"
+
+RDEPENDS:${PN} += " \
+    bash \
+    cryptsetup \
+    e2fsprogs-mke2fs \
+    e2fsprogs-tune2fs \
+    util-linux \
+    systemd \
+"

--- a/meta-iot-gateway/recipes-security/iotgw-hardening/files/service-hardening-mosquitto.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-hardening/files/service-hardening-mosquitto.conf
@@ -1,5 +1,10 @@
 [Unit]
 StartLimitIntervalSec=0
+# Broker is localhost-only in this profile; avoid blocking boot on
+# network-online wait services.
+After=
+After=network.target
+Wants=
 
 [Service]
 # Upstream unit creates /var/log/mosquitto in ExecStartPre.

--- a/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.5.0.bb
+++ b/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.5.0.bb
@@ -1,4 +1,4 @@
 require edge-healthd.inc
 
 # Pin upstream source for reproducible non-externalsrc builds.
-SRCREV = "26b8e3a6663671226d598d6d6d2709edc6cd4a56"
+SRCREV = "c5f3e504aeabe38940c50d656c08fffc93dc1675"

--- a/meta-iot-gateway/recipes-support/edge-healthd/files/healthd.conf
+++ b/meta-iot-gateway/recipes-support/edge-healthd/files/healthd.conf
@@ -1,8 +1,13 @@
+// edge-healthd configuration — Raspberry Pi 5 / iot-gateway
+//
+// Platform-specific overrides only. All available options and their defaults:
+//   https://github.com/umair-as/edge-healthd/blob/main/config/healthd.conf.example
+//
+// When bumping SRCREV in the recipe, check healthd.conf.example in the new
+// commit for new fields and add platform overrides here if needed.
+
 {
-  "device_id": "",
   "platform": "rpi5",
-  "collect_interval_sec": 60,
-  "sample_window_sec": 60,
 
   "monitored_services": [
     "sshd.socket",
@@ -15,29 +20,17 @@
   "monitored_mounts": [
     "/",
     "/data"
-  ],
+  ]
 
-  "monitored_interfaces": [],
-
-  "enable_ptp": false,
-  "enable_ntp": true,
-  "enable_thermal": true,
-  "enable_update_tracking": true,
-
-  "thresholds": {
-    "cpu_load_warn": 80,
-    "cpu_load_crit": 95,
-    "mem_used_warn": 80,
-    "mem_used_crit": 95,
-    "disk_used_warn": 80,
-    "disk_used_crit": 95,
-    "temp_warn_c": 70.0,
-    "temp_crit_c": 85.0,
-    "ptp_offset_warn_ns": 10000,
-    "ptp_offset_crit_ns": 100000,
-    "service_restart_warn": 3,
-    "service_restart_crit": 10,
-    "boot_fail_warn": 1,
-    "boot_fail_crit": 3
-  }
+  // All other settings use compiled-in defaults.
+  // Uncomment and adjust as needed:
+  //"collect_interval_sec": 60,
+  //"time_sync_interval_sec": 300,
+  //"update_check_interval_sec": 1800,
+  //"enable_rtc": true,
+  //"rtc_device": "/sys/class/rtc/rtc0",
+  //"thresholds": {
+  //  "temp_warn_c": 70.0,
+  //  "temp_crit_c": 85.0
+  //}
 }

--- a/meta-iot-gateway/recipes-support/iotgw-systemd-presets/files/90-iotgw.preset
+++ b/meta-iot-gateway/recipes-support/iotgw-systemd-presets/files/90-iotgw.preset
@@ -1,11 +1,11 @@
 # Enable baseline services on first boot
 enable iotgw-nftables.service
 
-# Disable wait-online services — NM manages connectivity, blocking boot is unnecessary
-disable NetworkManager-wait-online.service
-disable systemd-networkd-wait-online.service
-disable systemd-networkd.service
-disable systemd-networkd.socket
+# NOTE:
+# In this Yocto flow, preset processing is effectively enable-only, so
+# `disable ...` lines are not deterministic. Keep this file for positive
+# enables only. Mandatory disables/masks are handled in iotgw-rootfs.bbclass.
+
 enable avahi-daemon.service
 enable iotgw-provision.service
 enable systemd-timesyncd.service

--- a/scripts/tpm-encrypted-store-dev.sh
+++ b/scripts/tpm-encrypted-store-dev.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dev helper: create a loopback LUKS2 "encrypted store" under /data and enroll
+# a TPM2 token via systemd-cryptenroll.
+#
+# Default behavior uses PCR 7 (systemd default), but current RPi5 TPM PCR
+# measurements are all-zero in this project, so this policy is effectively
+# unenforced until measured-boot policy is finalized.
+#
+# Example:
+#   sudo bash scripts/tpm-encrypted-store-dev.sh
+#   sudo bash scripts/tpm-encrypted-store-dev.sh --size-mib 512
+#   sudo TPM2_PCRS="7" bash scripts/tpm-encrypted-store-dev.sh
+
+STORE_DIR="${STORE_DIR:-/data/encrypted-store}"
+IMAGE_PATH="${IMAGE_PATH:-$STORE_DIR/store.luks2.img}"
+MAP_NAME="${MAP_NAME:-igwencstore}"
+MOUNT_POINT="${MOUNT_POINT:-$STORE_DIR/mnt}"
+SIZE_MIB="${SIZE_MIB:-1024}"
+RECOVERY_KEY_FILE="${RECOVERY_KEY_FILE:-$STORE_DIR/recovery.key}"
+TPM2_DEVICE="${TPM2_DEVICE:-auto}"
+TPM2_PCRS="${TPM2_PCRS:-7}"
+FORCE_RECREATE=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [--size-mib N] [--force-recreate]
+
+Options:
+  --size-mib N        Image size in MiB (default: ${SIZE_MIB})
+  --force-recreate    Delete existing image/mapping and recreate from scratch
+
+Environment overrides:
+  STORE_DIR, IMAGE_PATH, MAP_NAME, MOUNT_POINT, RECOVERY_KEY_FILE,
+  TPM2_DEVICE, TPM2_PCRS
+EOF
+}
+
+log() { printf '[enc-store] %s\n' "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+require_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --size-mib)
+                shift
+                [ "${1:-}" ] || die "--size-mib requires a value"
+                SIZE_MIB="$1"
+                ;;
+            --force-recreate)
+                FORCE_RECREATE=1
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
+}
+
+cleanup_mount_if_needed() {
+    if findmnt -rn "$MOUNT_POINT" >/dev/null 2>&1; then
+        log "unmounting existing mount: $MOUNT_POINT"
+        umount "$MOUNT_POINT"
+    fi
+}
+
+close_mapper_if_needed() {
+    if [ -e "/dev/mapper/$MAP_NAME" ]; then
+        log "closing existing mapper: $MAP_NAME"
+        cryptsetup close "$MAP_NAME"
+    fi
+}
+
+create_recovery_key() {
+    if [ -f "$RECOVERY_KEY_FILE" ]; then
+        log "recovery key already exists: $RECOVERY_KEY_FILE"
+        return 0
+    fi
+    umask 077
+    head -c 48 /dev/urandom | base64 > "$RECOVERY_KEY_FILE"
+    chmod 600 "$RECOVERY_KEY_FILE"
+    log "created recovery key: $RECOVERY_KEY_FILE"
+}
+
+format_if_needed() {
+    if cryptsetup isLuks "$IMAGE_PATH" >/dev/null 2>&1; then
+        log "existing LUKS container detected: $IMAGE_PATH"
+        return 0
+    fi
+    log "formatting LUKS2 image"
+    cryptsetup luksFormat --type luks2 --batch-mode --key-file "$RECOVERY_KEY_FILE" "$IMAGE_PATH"
+}
+
+enroll_tpm_if_needed() {
+    if cryptsetup luksDump "$IMAGE_PATH" | grep -q 'systemd-tpm2'; then
+        log "TPM token already present in LUKS header"
+        return 0
+    fi
+
+    log "enrolling TPM token (device=${TPM2_DEVICE}, pcrs='${TPM2_PCRS}')"
+    enroll_args=(
+        "$IMAGE_PATH"
+        "--unlock-key-file=$RECOVERY_KEY_FILE"
+        "--tpm2-device=$TPM2_DEVICE"
+    )
+    if [ -n "$TPM2_PCRS" ]; then
+        enroll_args+=("--tpm2-pcrs=$TPM2_PCRS")
+    fi
+
+    systemd-cryptenroll "${enroll_args[@]}"
+}
+
+open_mapper() {
+    if [ ! -e "/dev/mapper/$MAP_NAME" ]; then
+        log "opening mapper: $MAP_NAME"
+        cryptsetup open "$IMAGE_PATH" "$MAP_NAME" --key-file "$RECOVERY_KEY_FILE"
+    fi
+}
+
+make_fs_if_needed() {
+    if blkid "/dev/mapper/$MAP_NAME" | grep -q 'TYPE="ext4"'; then
+        log "ext4 already present on mapper"
+        return 0
+    fi
+    log "creating ext4 filesystem on mapper"
+    mkfs.ext4 -F -L dataenc "/dev/mapper/$MAP_NAME" >/dev/null
+}
+
+mount_store() {
+    mkdir -p "$MOUNT_POINT"
+    if findmnt -rn "$MOUNT_POINT" >/dev/null 2>&1; then
+        log "already mounted: $MOUNT_POINT"
+        return 0
+    fi
+    log "mounting encrypted store"
+    mount "/dev/mapper/$MAP_NAME" "$MOUNT_POINT"
+}
+
+write_marker() {
+    local marker="$MOUNT_POINT/README.encrypted-store.txt"
+    if [ ! -f "$marker" ]; then
+        cat > "$marker" <<EOF
+IoT Gateway dev encrypted store
+image: $IMAGE_PATH
+mapper: /dev/mapper/$MAP_NAME
+created_utc: $(date -u +"%Y-%m-%dT%H:%M:%SZ")
+EOF
+    fi
+}
+
+main() {
+    parse_args "$@"
+
+    [ "$(id -u)" -eq 0 ] || die "run as root"
+    require_cmd cryptsetup
+    require_cmd systemd-cryptenroll
+    require_cmd mkfs.ext4
+    require_cmd mount
+    require_cmd findmnt
+    require_cmd blkid
+    require_cmd head
+    require_cmd base64
+
+    mkdir -p "$STORE_DIR"
+
+    if [ "$FORCE_RECREATE" -eq 1 ]; then
+        cleanup_mount_if_needed
+        close_mapper_if_needed
+        rm -f "$IMAGE_PATH"
+        log "removed existing image (force mode)"
+    fi
+
+    if [ ! -f "$IMAGE_PATH" ]; then
+        log "creating sparse image: $IMAGE_PATH (${SIZE_MIB} MiB)"
+        truncate -s "${SIZE_MIB}M" "$IMAGE_PATH"
+    fi
+
+    create_recovery_key
+    format_if_needed
+    enroll_tpm_if_needed
+    open_mapper
+    make_fs_if_needed
+    mount_store
+    write_marker
+
+    log "done"
+    log "image: $IMAGE_PATH"
+    log "mapper: /dev/mapper/$MAP_NAME"
+    log "mount : $MOUNT_POINT"
+    log "key   : $RECOVERY_KEY_FILE (dev-only; back it up before experiments)"
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
This PR packages the recent gateway hardening and observability work into reproducible layer changes and docs updates.

### 1) NM-only systemd boot path hardening
- mask `systemd-networkd*` and `systemd-network-generator` in rootfs postprocess
- keep `NetworkManager-wait-online` masked
- remove reliance on preset `disable` semantics (enable-only in current Yocto flow)
- add OpenSSH host key persistence fix (`/var/lib/ssh`) to avoid expensive key regen loops

### 2) Observability startup and runtime mode control
- local-first defaults for mosquitto/telegraf/influxdb to avoid boot stalls on `network-online.target`
- Telegraf `ExecCondition` guard for non-empty credentials + bounded restart policy
- add shipped runtime override templates for strict `network-online` mode:
  - `/usr/share/iotgw-observability/netmode/{telegraf,mosquitto,influxdb}-online.conf`
- document runtime activation/revert for RO-rootfs (`/run/systemd/system` ephemeral and `/data/overlays/etc/upper/...` persistent)

### 3) OTA overlay policy alignment
- enforce mask paths in `managed-paths.conf` so stale overlay entries cannot re-enable networkd/wait-online after slot switch
- preserve runtime netmode drop-ins across OTA
- document policy rationale in `docs/RAUC_UPDATE.md`

### 4) TPM encrypted-store dev path
- add `iotgw-encrypted-store` recipe (LUKS2 + TPM enrollment helper + mount unit)
- make inclusion opt-in via `IOTGW_ENABLE_ENCRYPTED_STORE_DEV`
- add host helper script for manual TPM/LUKS dev testing

### 5) Dev tooling and operator UX
- add tmux config/aliases + skel/root bashrc seeding
- add stress/perf packages (`stress-ng`, `fio`, `iotop`)

### 6) edge-healthd refresh
- bump pinned SRCREV and align `healthd.conf` with upstream example shape

## Validation performed
- RAUC bundle install/reboot on target
- confirmed no failed units
- confirmed `systemd-networkd*`/generator masked + inactive
- confirmed removal of prior `network-online` wait stall (~2min)
- confirmed runtime netmode override templates present and effective via `systemctl show ... -p After -p Wants`

## Notes
- `.codex` remains untracked and is not part of this PR.
