### PR TITLE
feat(rpi5): add LSM/IMA gates and EEPROM/VCIO enablement

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -195,6 +195,17 @@ local_conf_header:
     IOTGW_ENABLE_RPI_RTC = "1"   # set to "0" to disable rtc-rpi patch/fragment
 ```
 
+### Raspberry Pi EEPROM / VCIO Gate
+
+Enable/disable EEPROM maintenance tooling and VCIO carry patch:
+
+```yaml
+local_conf_header:
+  rpi_eeprom_gate: |
+    IOTGW_ENABLE_RPI_EEPROM = "1"  # set to "0" to exclude rpi-eeprom tooling packages
+    IOTGW_ENABLE_VCIO = "1"        # default follows IOTGW_ENABLE_RPI_EEPROM
+```
+
 ### TPM SPI Gate
 
 Enable TPM2-over-SPI profile and firmware overlay:

--- a/docs/LSM_IMA_EXPLORATION.md
+++ b/docs/LSM_IMA_EXPLORATION.md
@@ -1,0 +1,738 @@
+# LSM and IMA Exploration Notes
+
+Practical field notes from bringing up SELinux, AppArmor, and IMA on the RPi5 IoT Gateway.
+Covers concepts, observed behaviour on target, and annotated commands with their actual output.
+
+**Branch:** `feat/selinux-ima-apparmor`
+**Kernel:** `6.18.13-v8-16k-igw` (RPi5 downstream, Scarthgap build)
+**Date:** 2026-04-10
+
+---
+
+## Table of Contents
+
+1. [LSM — Linux Security Modules](#1-lsm--linux-security-modules)
+2. [AppArmor](#2-apparmor)
+3. [SELinux](#3-selinux)
+4. [IMA — Integrity Measurement Architecture](#4-ima--integrity-measurement-architecture)
+5. [TPM Interaction with IMA](#5-tpm-interaction-with-ima)
+6. [Target Command Reference](#6-target-command-reference)
+7. [Known Issues / Open Items](#7-known-issues--open-items)
+
+---
+
+## 1. LSM — Linux Security Modules
+
+### What it is
+
+The Linux kernel has a hook-based framework called LSM (Linux Security Modules) that allows
+security subsystems to intercept kernel operations — file open, process exec, socket connect,
+capability checks — and apply their own policy. Multiple LSMs can be compiled in, but only
+one "major" MAC (Mandatory Access Control) LSM can be active as the enforcing system at a time.
+
+Two categories:
+
+| Category | LSMs | Notes |
+|----------|------|-------|
+| Always-on (minor) | `capability`, `lockdown`, `yama`, `ima` | Always initialised, not exclusive |
+| MAC (exclusive) | `apparmor`, `selinux`, `smack`, `tomoyo` | Only one can hold the exclusive slot |
+
+### CONFIG_LSM — the critical string
+
+`CONFIG_SECURITY_SELINUX=y` compiles SELinux into the kernel but does **not** initialise it.
+`CONFIG_LSM` controls which LSMs are initialised at boot and in what order:
+
+```
+CONFIG_LSM="lockdown,yama,apparmor,selinux"
+```
+
+Without an LSM in this string it is compiled in but completely dormant.
+
+### LSM_FLAG_EXCLUSIVE — why only one MAC runs
+
+Both AppArmor and SELinux carry `LSM_FLAG_EXCLUSIVE` in their kernel registration. The kernel's
+`ordered_lsm_init()` enforces a single exclusive slot:
+
+1. Processes `CONFIG_LSM` left to right
+2. First exclusive LSM encountered claims the slot → initialised
+3. Second exclusive LSM → slot already taken → **silently skipped**
+
+With `CONFIG_LSM="lockdown,yama,apparmor,selinux"`:
+
+```
+lockdown  → not exclusive → initialised
+yama      → not exclusive → initialised
+apparmor  → EXCLUSIVE → claims slot → initialised  ✓
+selinux   → EXCLUSIVE → slot taken  → skipped       ✗
+```
+
+This is **by design** — both are compiled in, AppArmor is the default because it is listed first.
+SELinux is dormant but ready: switch it on at runtime via the `lsm=` cmdline parameter, which
+replaces `CONFIG_LSM` entirely for that boot.
+
+### Actual boot output (kernel dmesg)
+
+```
+[    0.000201] LSM: initializing lsm=capability,lockdown,yama,apparmor,ima
+[    0.000323] AppArmor: AppArmor initialized
+[    0.076758] AppArmor: AppArmor Filesystem Enabled
+[    0.168083] ima: No TPM chip found, activating TPM-bypass!
+[    0.168085] ima: Allocated hash algorithm: sha256
+[    0.168100] ima: No architecture policies found
+```
+
+Note: `ima` appears in the runtime list even though it is not in `CONFIG_LSM` — IMA is a
+minor LSM added to the init list automatically by the kernel regardless of that string.
+`selinux` does not appear because it lost the exclusive slot to AppArmor.
+
+### Verifying the active LSM stack at runtime
+
+```bash
+# Active LSMs (what actually initialised)
+cat /sys/kernel/security/lsm
+# Actual output on our target:
+# capability,lockdown,yama,apparmor,ima
+
+# LSM-specific sysfs directories (only present when active)
+ls /sys/kernel/security/
+# Output: apparmor  ima  lockdown
+
+# SELinux filesystem — only mounted if SELinux is the active MAC
+ls /sys/fs/selinux/
+# Output: ls: cannot access '/sys/fs/selinux': No such file or directory
+# (expected — AppArmor is the active MAC, not SELinux)
+```
+
+### Switching the MAC LSM at runtime (without rebuild)
+
+`lsm=` on the kernel cmdline replaces `CONFIG_LSM` for that boot. Non-exclusive LSMs
+(capability, yama, lockdown, ima) are still loaded via the unordered path.
+
+```bash
+# Activate SELinux as the MAC at next boot:
+fw_setenv EXTRA_KERNEL_ARGS 'lsm=selinux'
+
+# Revert to AppArmor (default):
+fw_setenv EXTRA_KERNEL_ARGS ''
+
+# Verify current cmdline:
+cat /proc/cmdline
+```
+
+**Prerequisite before switching to SELinux:** SELinux userspace must be present —
+`policycoreutils`, `libselinux`, and a base policy (`meta-selinux` layer). Without a
+policy loaded, SELinux will operate in enforcing mode with no rules and will likely
+block everything.
+
+---
+
+## 2. AppArmor
+
+### What it does
+
+AppArmor is a path-based MAC system. It confines processes using *profiles* — each profile
+specifies what files, capabilities, and network operations a process is allowed. A process
+running under a profile that does not permit an operation gets denied; without a profile,
+the process runs *unconfined* (no restriction from AppArmor).
+
+### What we observed on target
+
+```bash
+aa-status
+# apparmor module is loaded.
+# 60 profiles are loaded.
+# 60 profiles are in complain mode.
+# 0 profiles are in enforce mode.
+# 0 processes have profiles defined.
+# 0 processes are in enforce mode.
+# 0 processes are in complain mode.
+# 0 processes are unconfined but have a profile defined.
+```
+
+All 60 profiles are upstream defaults for services like apache2, dovecot, cups, php-fpm —
+none of which run on this gateway. All IoT gateway processes are **unconfined**.
+
+In dmesg these load as:
+```
+[    2.525053] audit: type=1400 ... apparmor="STATUS" operation="profile_load" name="lsb_release"
+[    2.573291] audit: type=1400 ... apparmor="STATUS" operation="profile_load" name="ping"
+[    2.603419] audit: type=1400 ... apparmor="STATUS" operation="profile_load" name="nvidia_modprobe"
+[    2.643125] audit: type=1400 ... apparmor="STATUS" operation="profile_load" name="samba-bgqd"
+...
+```
+
+**Key insight:** AppArmor provides no protection until custom profiles exist for the
+binaries you care about. Loading 60 irrelevant profiles in `complain` mode is pure overhead.
+
+### Boot overhead
+
+```
+apparmor.service  ~2.5s
+```
+
+Cost of loading 60 upstream profiles. Purpose-built minimal profiles would be much lighter
+but require significant policy authoring effort.
+
+### Checking individual process confinement
+
+```bash
+# Check confinement of a running process
+cat /proc/$(pgrep NetworkManager)/attr/current
+# "unconfined" means no AppArmor profile applied
+
+# Via aa-status (lists all confined processes)
+aa-status
+```
+
+### AppArmor kernel config — fragment comment vs kconfig directive
+
+Our `security-prod.cfg` contains:
+```
+# CONFIG_SECURITY_APPARMOR=y
+# CONFIG_DEFAULT_SECURITY_APPARMOR=y
+```
+
+These are **comments**, not kconfig directives. The RPi base kernel config has AppArmor
+enabled, and our fragment comments do not disable it. To actually disable a config option
+via a `.cfg` fragment the syntax must be:
+
+```
+# CONFIG_SECURITY_APPARMOR is not set
+```
+
+AppArmor is enabled on this build (`CONFIG_SECURITY_APPARMOR=y` visible in `/proc/config.gz`).
+This is intentional — AppArmor is the current default MAC while SELinux userspace is pending.
+
+Confirmed on target:
+```bash
+zcat /proc/config.gz | grep CONFIG_SECURITY_APPARMOR
+# CONFIG_SECURITY_APPARMOR=y
+# CONFIG_SECURITY_APPARMOR_INTROSPECT_POLICY=y
+# CONFIG_SECURITY_APPARMOR_HASH=y
+# CONFIG_SECURITY_APPARMOR_HASH_DEFAULT=y
+# CONFIG_SECURITY_APPARMOR_EXPORT_BINARY=y
+# CONFIG_SECURITY_APPARMOR_PARANOID_LOAD=y
+```
+
+---
+
+## 3. SELinux
+
+### What it does
+
+SELinux is a label-based MAC system. Every object (file, socket, process, device) gets a
+*security context* (`user:role:type:level`). Policy rules define what types can interact.
+More expressive than path-based AppArmor, but also significantly more complex to write
+policy for.
+
+**Two enforcement modes:**
+- `permissive` — logs all denials, enforces nothing. Safe for policy development.
+- `enforcing` — denials are blocked. Production mode.
+
+**Per-domain permissive** (`CONFIG_SECURITY_SELINUX_DEVELOP=y`): individual domains can
+be set permissive while the rest enforce. Useful for incremental policy bring-up.
+
+### Current state after rebuild (2026-04-10)
+
+```bash
+zcat /proc/config.gz | grep -E 'CONFIG_LSM=|CONFIG_SECURITY_SELINUX'
+# CONFIG_SECURITY_SELINUX=y
+# # CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
+# CONFIG_SECURITY_SELINUX_DEVELOP=y
+# CONFIG_SECURITY_SELINUX_AVC_STATS=y
+# CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9
+# CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
+# CONFIG_LSM="lockdown,yama,apparmor,selinux"
+```
+
+SELinux is compiled in — confirmed by kernel symbol count:
+```bash
+grep -c selinux /proc/kallsyms
+# 273
+```
+
+But it is **not initialised** because AppArmor claimed the exclusive MAC slot first
+(see section 1). No SELinux messages in dmesg. `/sys/fs/selinux` does not exist.
+
+Also note: `systemd` on this image is built without SELinux or AppArmor userspace bindings:
+```
+systemd[1]: systemd 255.21 running in system mode (-PAM +AUDIT -SELINUX -APPARMOR +IMA ...)
+```
+The `-SELINUX -APPARMOR` flags are **systemd compile-time flags**, not kernel state.
+They indicate systemd was not linked against `libselinux` or `libapparmor`. The kernel
+AppArmor LSM is still active and functional — systemd just doesn't call the library hooks.
+
+### SELinux kernel config (`selinux.cfg`)
+
+```
+CONFIG_SECURITY_SELINUX=y
+# CONFIG_SECURITY_SELINUX_BOOTPARAM is not set   ← no selinux=0 cmdline escape
+CONFIG_SECURITY_SELINUX_DEVELOP=y                 ← per-domain permissive for policy dev
+CONFIG_SECURITY_SELINUX_AVC_STATS=y               ← AVC cache hit/miss stats
+CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9        ← SID table size (512 buckets)
+CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256    ← label string cache entries
+CONFIG_LSM="lockdown,yama,apparmor,selinux"       ← adds selinux to the candidate list
+```
+
+### Why `BOOTPARAM` is disabled
+
+`CONFIG_SECURITY_SELINUX_BOOTPARAM=y` would allow `selinux=0` on the kernel cmdline to
+disable SELinux at boot. Kept off so the compiled-in state is deterministic and cannot be
+silently bypassed. Since SELinux is not currently the active MAC anyway, this is moot
+for now but is the right posture for when it becomes the default.
+
+### Path to activating SELinux
+
+Prerequisites before using `lsm=selinux`:
+1. `meta-selinux` layer integrated (provides `policycoreutils`, `libselinux`, `checkpolicy`)
+2. Base SELinux policy compiled and installed to `/etc/selinux/`
+3. Filesystem labelling run at first boot or during image build (`fixfiles` / `setfiles`)
+4. Start with `enforcing=0` (permissive) to collect AVC denials before enforcing
+
+```bash
+# Once prerequisites are met, activate SELinux at next boot:
+fw_setenv EXTRA_KERNEL_ARGS 'lsm=selinux enforcing=0'
+
+# Check AVC denials:
+ausearch -m AVC -ts recent
+
+# getenforce/setenforce (requires policycoreutils):
+getenforce
+setenforce 0   # permissive
+setenforce 1   # enforcing
+```
+
+---
+
+## 4. IMA — Integrity Measurement Architecture
+
+### What it is
+
+IMA (Integrity Measurement Architecture) is a kernel subsystem that creates a cryptographic
+log of every file opened for execution or reading by a privileged process. This log can be:
+
+1. **Extended into a TPM PCR** (PCR10 by default) — the accumulated hash of everything that
+   ran is sealed in hardware. Tampering with files that executed since boot changes PCR10
+   and will fail a TPM policy sealing to that PCR.
+
+2. **Queried from userspace** — via the measurement log at
+   `/sys/kernel/security/ima/ascii_runtime_measurements`.
+
+### Two modes: measure vs appraise
+
+| Mode | What it does | Requires |
+|------|-------------|---------|
+| **measure** | SHA256 of executed files logged to IMA + extends PCR10 | Nothing — any binary works |
+| **appraise** | Verifies `security.ima` xattr on each file before exec | Signed xattrs set at build time with `evmctl` |
+
+**Our current config is measure-only** (`CONFIG_IMA_APPRAISE` is not set).
+
+In measure-only mode:
+- Every binary executed is hashed and logged
+- Nothing is blocked — a tampered binary still runs
+- PCR10 accumulates the measurement log hash (blocked on RPi5 by SPI ordering — see section 5)
+- `ima_inspect` returns "No such attribute" — correct, no xattrs are set in measure-only mode
+
+In appraise mode:
+- Kernel reads `security.ima` xattr before executing any file
+- Xattr contains a signed hash of the file's content from build time
+- Hash mismatch or missing xattr → exec blocked (with `imasig` policy)
+- **This is what actually prevents tampered binaries from running**
+
+Measure-only is safe to enable with zero build preparation, provides audit trail, but does
+not block anything. Appraise requires all shipped binaries to carry signed xattrs — a
+significant investment in build infrastructure (signing keys, recipe integration, evmctl).
+
+### IMA policy — TCB
+
+IMA behaviour is controlled by a *policy* specifying which files to measure/appraise.
+
+**Built-in policies (kernel cmdline):**
+
+| Policy | Effect |
+|--------|--------|
+| `ima_policy=tcb` | Measure all exec, kernel modules, firmware, and root reads |
+| `ima_policy=appraise_tcb` | Same as tcb but also appraises (requires xattrs) |
+| `ima_policy=secure_boot` | Module and firmware appraisal only |
+
+**`ima_policy=exec` is not valid** — caused `ima: policy "exec" not found` at boot.
+Valid names are `tcb`, `appraise_tcb`, `secure_boot` (kernel version-dependent).
+
+**Active on our target** (`ima_policy=tcb` set via U-Boot env):
+
+```bash
+cat /sys/kernel/security/ima/policy
+# dont_measure fsmagic=0x9fa0        ← procfs
+# dont_measure fsmagic=0x62656572    ← selinuxfs
+# dont_measure fsmagic=0x64626720    ← debugfs
+# dont_measure func=FILE_CHECK fsmagic=0x1021994  ← tmpfs
+# dont_measure fsmagic=0x1cd1        ← binfmt_misc
+# dont_measure fsmagic=0x42494e4d    ← binfmtfs
+# dont_measure fsmagic=0x73636673    ← securityfs
+# dont_measure fsmagic=0xf97cff8c    ← sockfs
+# dont_measure fsmagic=0x43415d53    ← tracefs
+# dont_measure fsmagic=0x27e0eb      ← cgroupfs
+# ... (measures everything else)
+```
+
+The `dont_measure` rules exclude pseudo-filesystems from the log. Everything on real
+storage (rootfs, /data, kernel modules) is measured.
+
+### Confirmed working on target
+
+```bash
+wc -l /sys/kernel/security/ima/ascii_runtime_measurements
+# 895 /sys/kernel/security/ima/ascii_runtime_measurements
+```
+
+895 files measured since boot. IMA is actively logging all executed files.
+
+### IMA kernel config (`ima.cfg`)
+
+```
+CONFIG_IMA=y
+CONFIG_IMA_MEASURE_PCR_IDX=10          ← standard IMA PCR slot (do not change)
+CONFIG_IMA_LSM_RULES=y                  ← IMA policy can reference LSM labels
+CONFIG_IMA_NG_TEMPLATE=y               ← modern template (filename + hash in log)
+CONFIG_IMA_DEFAULT_TEMPLATE="ima-ng"   ← use ng template
+CONFIG_IMA_DEFAULT_HASH_SHA256=y       ← SHA256 (not SHA1)
+CONFIG_IMA_DEFAULT_HASH="sha256"
+CONFIG_IMA_READ_POLICY=y               ← userspace can read active policy
+# CONFIG_IMA_APPRAISE is not set       ← measure-only; no xattr verification
+CONFIG_IMA_MEASURE_ASYMMETRIC_KEYS=y  ← key loads affect measurement log
+CONFIG_IMA_QUEUE_EARLY_BOOT_KEYS=y    ← queue key ops before IMA ready
+CONFIG_CRYPTO_SHA1=y                   ← required for IMA internals even with SHA256
+```
+
+### IMA log entry format
+
+```
+10 <pcr-template-hash> ima-ng sha256:<file-hash> <filename>
+│                               │                 │
+│                               │                 file path measured
+│                               SHA256 of file content
+PCR index (always 10)
+```
+
+### `ima_inspect` — checking appraisal xattrs
+
+`ima_inspect` (binary name uses underscore: `ima_inspect`) reads `security.ima` extended
+attributes. Only relevant in appraise mode.
+
+```bash
+ima_inspect /usr/bin/tpm-ops
+# ima_inspect: security.ima: No such attribute
+```
+
+This is correct in measure-only mode — no xattrs are set, so there is nothing to inspect.
+The file is still being *measured* (hashed and logged on exec); it is just not *appraised*
+(signature-verified before exec).
+
+### `evmctl` — reading the measurement log
+
+`evmctl` (from `ima-evm-utils`) is the main IMA/EVM userspace tool:
+
+```bash
+evmctl ima_measurement /sys/kernel/security/ima/binary_runtime_measurements
+# error: tsspcrread: command not found
+```
+
+`evmctl` uses `tsspcrread` from the IBM TSS library to read PCR values. Our image
+uses `tpm2-tools` / `tpm-ops` (TSS2), not IBM TSS. Use `tpm2_pcrread` instead:
+
+```bash
+tpm2_pcrread sha256:10
+# sha256:
+#   10: 0x0000000000000000000000000000000000000000000000000000000000000000
+```
+
+---
+
+## 5. TPM Interaction with IMA
+
+### How it is supposed to work
+
+1. Kernel boots, IMA subsystem initialises early
+2. IMA measures every file it is configured to measure (exec, module loads, etc.)
+3. Each measurement calls `tpm_pcr_extend(10, sha256(event))` → PCR10 accumulates
+4. By userspace, PCR10 = hash of everything that ran since boot
+5. Attestation: TPM quote on PCR10 proves what ran on this device
+
+### What actually happens on RPi5
+
+The SLB9672 TPM is connected via SPI over the RP1 south-bridge. The RP1 SPI controller
+comes up *after* IMA initialises early in boot:
+
+```
+[early boot] IMA init → tries tpm_pcr_extend → TPM not ready → BYPASS activated
+[later boot] RP1 SPI ready → /dev/tpm0, /dev/tpmrm0 appear → IMA already finished
+```
+
+Confirmed in dmesg:
+```
+[    0.168083] ima: No TPM chip found, activating TPM-bypass!
+```
+
+Result: IMA log is populated (895 entries), but PCR10 is all zeros. Remote attestation
+based on PCR10 is not feasible in the current boot topology.
+
+### All PCRs on target
+
+```bash
+tpm2_pcrread sha256
+# sha256:
+#   0 : 0x000000000000...  ← no UEFI measured boot (U-Boot → FIT → kernel)
+#   1 : 0x000000000000...
+#   ...
+#   10: 0x000000000000...  ← IMA TPM-bypass (SPI not ready at IMA init)
+#   11-23: 0x000000000000...
+```
+
+All zero. RPi5 has no UEFI firmware measured boot chain, so PCR 0–7 are never extended
+by firmware. PCR10 is never extended due to the SPI ordering constraint.
+
+### Path forward for PCR sealing
+
+None implemented. Options for future work:
+
+1. **Initramfs extend** — early-boot script reads IMA log and manually extends a PCR after
+   TPM becomes reachable. Requires custom initramfs with tpm2-tools inside.
+2. **U-Boot TPM extend** — U-Boot extends PCRs for FIT blob hashes. RP1 SPI problem exists
+   at U-Boot stage too (parked — see WORKBOARD).
+3. **OS-managed PCR** — Seal keys to a PCR the OS controls (e.g. PCR7), rather than relying
+   on firmware measured boot.
+4. **Software-only audit** — Use IMA log for forensics without TPM sealing. Tamper-evident
+   (you can detect tampering post-incident) but not tamper-proof at runtime.
+
+---
+
+## 6. Target Command Reference
+
+All commands run as root on `iotgw` via SSH after the second OTA on `feat/selinux-ima-apparmor`.
+
+### LSM stack
+
+```bash
+# What LSMs are actually initialised
+cat /sys/kernel/security/lsm
+# capability,lockdown,yama,apparmor,ima
+
+# LSM sysfs directories (one per active LSM)
+ls /sys/kernel/security/
+# apparmor  ima  lockdown
+
+# Is SELinux filesystem mounted?
+ls /sys/fs/selinux/
+# ls: cannot access '/sys/fs/selinux': No such file or directory
+# (expected — AppArmor holds the exclusive MAC slot)
+
+# Verify what CONFIG_LSM was compiled with
+zcat /proc/config.gz | grep CONFIG_LSM=
+# CONFIG_LSM="lockdown,yama,apparmor,selinux"
+
+# Count SELinux symbols (proves code is compiled in even though not initialised)
+grep -c selinux /proc/kallsyms
+# 273
+```
+
+### SELinux and AppArmor config on target
+
+```bash
+zcat /proc/config.gz | grep -E 'CONFIG_LSM=|CONFIG_SECURITY_SELINUX|CONFIG_SECURITY_APPARMOR|SELINUX_DISABLE|DEFAULT_SECURITY|NETLABEL|NETWORK_SECMARK'
+# # CONFIG_NETLABEL is not set           ← NETLABEL not set (SELinux network labelling)
+# CONFIG_NETWORK_SECMARK=y
+# # CONFIG_DEFAULT_SECURITY_SELINUX is not set
+# CONFIG_DEFAULT_SECURITY_APPARMOR=y
+# CONFIG_LSM="lockdown,yama,apparmor,selinux"
+# CONFIG_SECURITY_SELINUX=y
+# # CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
+# CONFIG_SECURITY_SELINUX_DEVELOP=y
+# CONFIG_SECURITY_SELINUX_AVC_STATS=y
+# CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9
+# CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
+# CONFIG_SECURITY_APPARMOR=y
+```
+
+### AppArmor
+
+```bash
+# Status summary
+aa-status
+# apparmor module is loaded.
+# 60 profiles are loaded.
+# 60 profiles are in complain mode.
+# 0 profiles are in enforce mode.
+# 0 processes have profiles defined.
+
+# Check confinement status of a specific process
+cat /proc/$(pgrep NetworkManager)/attr/current
+# "unconfined"
+```
+
+### IMA measurement log
+
+```bash
+# IMA sysfs directory
+ls /sys/kernel/security/ima/
+# ascii_runtime_measurements  binary_runtime_measurements  policy  violations
+
+# How many files measured since boot
+wc -l /sys/kernel/security/ima/ascii_runtime_measurements
+# 895
+
+# Active policy (tcb rules — dont_measure pseudo-fs, measure everything else)
+cat /sys/kernel/security/ima/policy
+# dont_measure fsmagic=0x9fa0
+# dont_measure fsmagic=0x62656572
+# ... (excludes pseudo-filesystems)
+
+# Last few measured entries
+tail -5 /sys/kernel/security/ima/ascii_runtime_measurements
+
+# Check if a specific binary was measured
+grep tpm-ops /sys/kernel/security/ima/ascii_runtime_measurements
+
+# Binary log size (non-zero confirms IMA is active)
+ls -lh /sys/kernel/security/ima/binary_runtime_measurements
+```
+
+### IMA appraisal xattrs
+
+```bash
+# Check for appraisal xattr (measure-only: always "No such attribute")
+ima_inspect /usr/bin/tpm-ops
+# ima_inspect: security.ima: No such attribute
+
+# Same check via getfattr
+getfattr -n security.ima /usr/bin/tpm-ops
+# No such attribute
+```
+
+### TPM / PCR state
+
+```bash
+# All PCRs — all zero on RPi5 (no measured boot chain)
+tpm2_pcrread sha256
+
+# PCR10 specifically (IMA PCR — zero due to TPM-bypass at IMA init)
+tpm2_pcrread sha256:10
+# sha256:
+#   10: 0x0000000000000000000000000000000000000000000000000000000000000000
+
+# TPM reachable?
+tpm-ops info
+tpm-ops pcr-read
+```
+
+### Kernel cmdline
+
+```bash
+# Current cmdline (shows ima_policy=tcb if set)
+cat /proc/cmdline
+# ... ima_policy=tcb
+
+# U-Boot env var driving extra kernel args
+fw_printenv EXTRA_KERNEL_ARGS
+# EXTRA_KERNEL_ARGS=ima_policy=tcb
+
+# Set IMA policy for next boot
+fw_setenv EXTRA_KERNEL_ARGS 'ima_policy=tcb'
+
+# Add SELinux activation alongside IMA policy
+fw_setenv EXTRA_KERNEL_ARGS 'ima_policy=tcb lsm=selinux enforcing=0'
+
+# Clear extra args
+fw_setenv EXTRA_KERNEL_ARGS ''
+```
+
+### Kernel config spot-checks
+
+```bash
+# IMA compiled in?
+zcat /proc/config.gz | grep 'CONFIG_IMA[^_]'
+# CONFIG_IMA=y
+
+# LSM init string
+zcat /proc/config.gz | grep CONFIG_LSM=
+# CONFIG_LSM="lockdown,yama,apparmor,selinux"
+
+# SELinux and its deps
+zcat /proc/config.gz | grep -E 'SELINUX|NETLABEL|SECURITY_NETWORK'
+```
+
+### Boot time (security units)
+
+```bash
+systemd-analyze blame | grep -E 'apparmor|audit|ima|selinux'
+# apparmor.service   ~2.5s  (loading 60 upstream profiles)
+```
+
+---
+
+## 7. Known Issues / Open Items
+
+### SELinux skipped by exclusive LSM slot (by design, not a bug)
+
+SELinux is compiled in and present in `CONFIG_LSM`. It does not initialise because AppArmor
+claims the exclusive MAC slot first (AppArmor is listed before selinux in the string).
+
+**To activate SELinux:** `fw_setenv EXTRA_KERNEL_ARGS 'lsm=selinux enforcing=0'`
+
+**Prerequisite:** `meta-selinux` layer + base policy must be integrated first.
+
+### IMA TPM PCR10 always zero (hardware constraint)
+
+SPI-attached SLB9672 comes up after IMA kernel subsystem initialises. TPM-bypass active.
+PCR10 remains zero. IMA log is populated and readable; TPM sealing is not.
+No fix in the current boot topology.
+
+### `CONFIG_NETLABEL` not auto-selected
+
+`CONFIG_SECURITY_SELINUX=y` + `CONFIG_NETWORK_SECMARK=y` should trigger
+`select NETLABEL` via Kconfig, but the built config shows `# CONFIG_NETLABEL is not set`.
+This is a fragment/Kconfig interaction issue. SELinux network labelling (`netlabel`) is
+not available; standard socket-based SELinux policy still works without it.
+
+### Fragment comment does not disable a config option
+
+In `security-prod.cfg`:
+```
+# CONFIG_SECURITY_APPARMOR=y      ← just a comment, does NOT disable AppArmor
+```
+
+To disable a config option via a `.cfg` fragment:
+```
+# CONFIG_SECURITY_APPARMOR is not set
+```
+
+AppArmor is intentionally left enabled (it is the current default MAC). This is noted
+here so the syntax distinction is clear for future fragment authors.
+
+### `systemd-machine-id-commit.service` failing (tracked in WORKBOARD)
+
+`iotgw-machine-id.service` writes a real file to overlayfs. The commit service fails because
+machine-id is not on a transient filesystem. Fix: mask the unit in the image.
+
+### AppArmor 60 upstream profiles, ~2.5s boot overhead
+
+All 60 profiles are irrelevant to the gateway workload. For production either write
+purpose-built profiles or switch to SELinux.
+
+### `evmctl ima_measurement` fails (IBM TSS missing)
+
+`evmctl` requires `tsspcrread` from IBM TSS. Image uses TSS2 (`tpm2-tools` / `tpm-ops`).
+Use `tpm2_pcrread sha256:10` as the equivalent PCR read command.
+
+---
+
+## References
+
+- [IMA kernel docs](https://www.kernel.org/doc/html/latest/security/IMA-templates.html)
+- [IMA Wiki](https://sourceforge.net/p/linux-ima/wiki/Home/)
+- [KSPP recommended settings](https://kspp.github.io/Recommended_Settings.html)
+- [SELinux Notebook](https://github.com/SELinuxProject/selinux-notebook)
+- Kernel source: `security/integrity/ima/`, `security/selinux/`, `security/apparmor/`
+- Project fragments: `meta-iot-gateway/recipes-kernel/linux/files/fragments/`
+  - `ima.cfg` — IMA measurement config
+  - `selinux.cfg` — SELinux compiled-in + `CONFIG_LSM` string
+  - `security-prod.cfg` — base KSPP hardening

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -18,6 +18,9 @@ The distribution implements defense-in-depth security across multiple layers:
 
 For FIT boot signing and verification chain setup, see the [FIT Boot and Signing Guide](FIT_BOOT_SIGNING.md).
 
+For hands-on IMA, AppArmor, and SELinux exploration notes (commands, observed behaviour,
+TPM PCR interaction, known issues), see [LSM and IMA Exploration](LSM_IMA_EXPLORATION.md).
+
 ---
 
 ## Device Identity and Build Metadata Policy

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -46,3 +46,18 @@ local_conf_header:
     # IOTGW_FIT_RECOVERY_KERNEL_PATH:fitflow = "${DEPLOY_DIR_IMAGE}/linux-recovery.bin"
     # Compression of the payload above: none|gzip|lzo
     # IOTGW_FIT_CUSTOM_ITS_KERNEL2_PATH_COMP_ALG:fitflow = "none"
+
+  buildhistory_downgrade_notes: |
+    # Developer note: for intentional downgrade/maintenance tests (for example
+    # switching kernel line 6.18 -> 6.12), package-history QA can trigger:
+    #   version-going-backwards
+    # Preferred temporary knob (demote to warning):
+    # ERROR_QA:remove = "version-going-backwards"
+    # WARN_QA:append = " version-going-backwards"
+    #
+    # Recipe-scoped alternative:
+    # ERROR_QA:remove:pn-perf = "version-going-backwards"
+    # WARN_QA:append:pn-perf = " version-going-backwards"
+    #
+    # Broader alternative (keeps image history but skips package history):
+    # BUILDHISTORY_FEATURES:remove = "package"

--- a/kas/rpi5-autofetch.yml
+++ b/kas/rpi5-autofetch.yml
@@ -40,6 +40,14 @@ repos:
     url: git://git.yoctoproject.org/meta-security
     refspec: scarthgap
 
+  meta-secure-core:
+    url: https://github.com/Wind-River/meta-secure-core
+    refspec: scarthgap
+    layers:
+      meta-tpm2:
+      meta-signing-key:
+      meta-integrity:
+
   meta-rauc:
     url: https://github.com/rauc/meta-rauc.git
     refspec: scarthgap

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -3,6 +3,13 @@
 # Gate Raspberry Pi firmware RTC support for providers that carry the backport.
 IOTGW_ENABLE_RPI_RTC ?= "1"
 
+# Gate Raspberry Pi EEPROM tooling stack (shared with packagegroup gating).
+IOTGW_ENABLE_RPI_EEPROM ?= "1"
+
+# Gate VCIO mailbox chardev (/dev/vcio) needed by vcgencmd and rpi-eeprom-update.
+# Default follows EEPROM tooling gate; developers can override independently.
+IOTGW_ENABLE_VCIO ?= "${IOTGW_ENABLE_RPI_EEPROM}"
+
 # Base fragments always applied.
 SRC_URI:append = " \
     file://fragments/branding.cfg \
@@ -12,6 +19,7 @@ SRC_URI:append = " \
     file://fragments/audit.cfg \
 "
 SRC_URI:append = "${@' file://fragments/rtc-rpi.cfg' if d.getVar('IOTGW_ENABLE_RPI_RTC') == '1' else ''}"
+SRC_URI:append = "${@' file://fragments/vcio-rpi.cfg' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
 
 # Optional fragments toggled via IOTGW_KERNEL_FEATURES (space/comma-separated).
 SRC_URI:append = "${@' file://fragments/compute-media.cfg' if 'igw_compute_media' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -21,6 +21,8 @@ SRC_URI:append = "${@' file://fragments/observability-dev.cfg' if 'igw_observabi
 SRC_URI:append = "${@' file://fragments/security-prod.cfg' if 'igw_security_prod' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 SRC_URI:append = "${@' file://fragments/tpm-slb9672.cfg' if 'igw_tpm_slb9672' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 SRC_URI:append = "${@' file://fragments/efi-surface-reduction.cfg' if 'igw_no_efi' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+SRC_URI:append = "${@' file://fragments/selinux.cfg' if 'igw_selinux' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+SRC_URI:append = "${@' file://fragments/ima.cfg' if 'igw_ima' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 
 # Merge present fragments into the active kernel .config.
 do_configure:append() {

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -104,6 +104,7 @@ ROOT_HOME ?= "/root"
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY IOTGW_ENABLE_KERNEL_NO_EFI"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_RPI_EEPROM IOTGW_ENABLE_VCIO"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_SELINUX IOTGW_ENABLE_IMA"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYPTED_STORE_DEV IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
@@ -167,6 +168,15 @@ IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_SELINUX', '1'
 # Measurement-only by default (no appraise) — safe without signed xattrs.
 IOTGW_ENABLE_IMA ?= "0"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_IMA', '1', ' igw_ima', '', d)}"
+
+# Optional Raspberry Pi EEPROM tooling stack (rpi-eeprom + policy wrapper).
+# Keep enabled by default for gateway fleet maintenance; developers can disable
+# it for lean bring-up images and when VCIO carry patches are not desired.
+IOTGW_ENABLE_RPI_EEPROM ?= "1"
+
+# VCIO (/dev/vcio) enables vcgencmd and full rpi-eeprom-update status path.
+# Default follows EEPROM tooling gate, but can be overridden explicitly.
+IOTGW_ENABLE_VCIO ?= "${IOTGW_ENABLE_RPI_EEPROM}"
 
 # Mainline RPi5 DTB note:
 # - Firmware `dtparam=` keys must exist in DTB `__overrides__`.

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -70,6 +70,9 @@ VIRTUAL-RUNTIME_init_manager ?= "systemd"
 # Journald-only policy: do not pull classic syslog daemons from packagegroups.
 VIRTUAL-RUNTIME_base-utils-syslog = ""
 DISTRO_FEATURES:append = " systemd bluetooth virtualization usrmerge security"
+# AppArmor distro feature kept for reference while LSM default decision is pending.
+# Remove once SELinux is confirmed as the production default LSM.
+# DISTRO_FEATURES:append = " apparmor"
 # RAUC is mandatory in this distro
 DISTRO_FEATURES:append = " rauc"
 DISTRO_FEATURES:append = " luks"
@@ -101,6 +104,7 @@ ROOT_HOME ?= "/root"
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY IOTGW_ENABLE_KERNEL_NO_EFI"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_SELINUX IOTGW_ENABLE_IMA"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYPTED_STORE_DEV IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
@@ -137,6 +141,8 @@ IOTGW_DESKTOP_PACKAGES ?= "weston wayland-utils mesa libdrm"
 #   igw_compute_media      - GPU/V4L2/cameras/hugepages (for desktop/ML)
 #   igw_observability_dev  - eBPF/ftrace/kprobes (dev builds only)
 #   igw_no_efi             - disable kernel EFI runtime/stub surface (opt-in)
+#   igw_selinux            - SELinux compiled in, AppArmor remains default LSM
+#   igw_ima                - IMA measurement (PCR10, SHA256, ima-ng template)
 IOTGW_KERNEL_FEATURES ?= "igw_networking_iot igw_security_prod"
 
 # Optional TPM2 over SPI profile for Infineon SLB9672-class modules.
@@ -150,6 +156,18 @@ IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672',
 # Enable to append igw_no_efi fragment set.
 IOTGW_ENABLE_KERNEL_NO_EFI ?= "1"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_KERNEL_NO_EFI', '1', ' igw_no_efi', '', d)}"
+
+# Optional SELinux kernel support. Compiled in alongside AppArmor; AppArmor
+# remains the default LSM until meta-selinux userspace is available and policy
+# is ready. Switch at runtime: lsm=selinux on the kernel cmdline.
+IOTGW_ENABLE_SELINUX ?= "0"
+IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_SELINUX', '1', ' igw_selinux', '', d)}"
+
+# Optional IMA measurement support. Requires TPM for replay-protected log.
+# Measurement-only by default (no appraise) — safe without signed xattrs.
+IOTGW_ENABLE_IMA ?= "0"
+IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_IMA', '1', ' igw_ima', '', d)}"
+
 # Mainline RPi5 DTB note:
 # - Firmware `dtparam=` keys must exist in DTB `__overrides__`.
 # - Current mainline bcm2712-rpi-5-b path exports rtc/rtc_bbat_vchg, but not

--- a/meta-iot-gateway/conf/layer.conf
+++ b/meta-iot-gateway/conf/layer.conf
@@ -13,6 +13,7 @@ BBFILES += " \
   ${LAYERDIR}/recipes-connectivity/*/*.bb \
   ${LAYERDIR}/recipes-devtools/*/*.bb \
   ${LAYERDIR}/recipes-kernel/*/*.bb \
+  ${LAYERDIR}/recipes-bsp/*/*.bb \
   ${LAYERDIR}/recipes-bsp/bootimage/*.bb \
   ${LAYERDIR}/recipes-bsp/bootlogo/*.bb \
   ${LAYERDIR}/recipes-support/*/*.bb \

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-update-allow-default-config-when-bootload.patch
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-update-allow-default-config-when-bootload.patch
@@ -1,0 +1,33 @@
+From 610cf0556cc4ac2940627ee1fd819a1a27b682c8 Mon Sep 17 00:00:00 2001
+From: IoT Gateway <iotgw@example.local>
+Date: Fri, 10 Apr 2026 13:38:57 +0200
+Subject: [PATCH] rpi-eeprom-update: allow -d when bootloader config cannot be
+ read
+
+---
+ rpi-eeprom-update | 9 +++++++--
+ 1 file changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/rpi-eeprom-update b/rpi-eeprom-update
+index cbb5f48..877f7a5 100755
+--- a/rpi-eeprom-update
++++ b/rpi-eeprom-update
+@@ -520,8 +520,13 @@ checkDependencies() {
+       FIRMWARE_IMAGE_DIR="${FIRMWARE_IMAGE_DIR}-${BOARD_INFO}"
+    fi
+ 
+-   if ! getBootloaderConfig > /dev/null; then
+-      die "Unable to get bootloader config, please update VC firmware and reboot."
++   if ! getBootloaderConfig > /dev/null 2>&1; then
++      if [ "${OVERWRITE_CONFIG}" = "1" ]; then
++         warn "WARNING: Unable to read current bootloader config."
++         warn "         Continuing with default config because -d is set."
++      else
++         die "Unable to get bootloader config, please update VC firmware and reboot."
++      fi
+    fi
+ 
+    if ! command -v sha256sum > /dev/null; then
+-- 
+2.43.0
+

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom
@@ -1,0 +1,122 @@
+#!/bin/sh
+set -eu
+
+DEFAULTS_FILE="/etc/default/iotgw-rpi-eeprom"
+
+IOTGW_RPI_EEPROM_POLICY_ENABLE=0
+IOTGW_RPI_EEPROM_POLICY_AUTO_STAGE=0
+IOTGW_RPI_EEPROM_POLICY_AUTO_REBOOT=0
+IOTGW_RPI_EEPROM_POLICY_RELEASE_STATUS=""
+IOTGW_RPI_EEPROM_USE_DEFAULT_CONFIG=1
+
+if [ -f "${DEFAULTS_FILE}" ]; then
+    # shellcheck disable=SC1090
+    . "${DEFAULTS_FILE}"
+fi
+
+if [ -n "${IOTGW_RPI_EEPROM_POLICY_RELEASE_STATUS}" ]; then
+    export FIRMWARE_RELEASE_STATUS="${IOTGW_RPI_EEPROM_POLICY_RELEASE_STATUS}"
+fi
+
+log() {
+    echo "[iotgw-rpi-eeprom] $*" >&2
+}
+
+need_root() {
+    if [ "$(id -u)" -ne 0 ]; then
+        log "must be run as root"
+        exit 1
+    fi
+}
+
+do_status() {
+    rc=0
+    if [ "${IOTGW_RPI_EEPROM_USE_DEFAULT_CONFIG}" = "1" ]; then
+        rpi-eeprom-update -d || rc=$?
+    else
+        rpi-eeprom-update || rc=$?
+    fi
+    return "${rc}"
+}
+
+do_stage() {
+    need_root
+    if [ "${IOTGW_RPI_EEPROM_USE_DEFAULT_CONFIG}" = "1" ]; then
+        rpi-eeprom-update -d -a
+    else
+        rpi-eeprom-update -a
+    fi
+}
+
+do_cancel() {
+    need_root
+    rpi-eeprom-update -r
+}
+
+do_policy() {
+    if [ "${IOTGW_RPI_EEPROM_POLICY_ENABLE}" != "1" ]; then
+        log "policy disabled (IOTGW_RPI_EEPROM_POLICY_ENABLE=0)"
+        exit 0
+    fi
+
+    rc=0
+    do_status || rc=$?
+
+    if [ "${rc}" -eq 0 ]; then
+        log "no EEPROM update required"
+        exit 0
+    fi
+
+    if [ "${rc}" -ne 1 ]; then
+        log "status check failed (exit ${rc})"
+        exit "${rc}"
+    fi
+
+    if [ "${IOTGW_RPI_EEPROM_POLICY_AUTO_STAGE}" != "1" ]; then
+        log "update available; auto stage disabled"
+        log "run manually: sudo iotgw-rpi-eeprom stage"
+        exit 0
+    fi
+
+    log "staging EEPROM update files to boot partition"
+    do_stage
+    log "staged successfully; update will apply on next reboot"
+
+    if [ "${IOTGW_RPI_EEPROM_POLICY_AUTO_REBOOT}" = "1" ]; then
+        log "auto reboot enabled; rebooting now"
+        sync || true
+        systemctl reboot
+    fi
+}
+
+usage() {
+    cat <<'EOF'
+Usage: iotgw-rpi-eeprom <command>
+
+Commands:
+  status   Show EEPROM update status (passes through rpi-eeprom-update output)
+  stage    Stage available EEPROM update files for next reboot
+  cancel   Remove any staged EEPROM update files
+  policy   Run policy from /etc/default/iotgw-rpi-eeprom
+EOF
+}
+
+cmd="${1:-}"
+case "${cmd}" in
+    status)
+        do_status
+        ;;
+    stage)
+        do_stage
+        ;;
+    cancel)
+        do_cancel
+        ;;
+    policy)
+        do_policy
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom.default
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom.default
@@ -1,0 +1,21 @@
+# IoT Gateway policy for Raspberry Pi EEPROM updates.
+# 0 = disabled (default, safest)
+# 1 = enabled
+IOTGW_RPI_EEPROM_POLICY_ENABLE=0
+
+# If enabled, stage updates automatically when an update is available.
+# Equivalent to: rpi-eeprom-update -a
+IOTGW_RPI_EEPROM_POLICY_AUTO_STAGE=0
+
+# If enabled with AUTO_STAGE=1, reboot immediately after staging.
+IOTGW_RPI_EEPROM_POLICY_AUTO_REBOOT=0
+
+# Optional release channel override for rpi-eeprom-update.
+# Leave empty to use recipe defaults.
+# Typical values: default, latest
+IOTGW_RPI_EEPROM_POLICY_RELEASE_STATUS=
+
+# Mainline-kernel compatibility mode:
+# 1 = use rpi-eeprom-update -d (default EEPROM config) for status/stage.
+# 0 = preserve current EEPROM config when tooling can read it.
+IOTGW_RPI_EEPROM_USE_DEFAULT_CONFIG=1

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom.service
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/iotgw-rpi-eeprom.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=IoT Gateway Raspberry Pi EEPROM Update Policy
+After=local-fs.target
+Wants=local-fs.target
+ConditionPathExists=/usr/sbin/rpi-eeprom-update
+ConditionPathExists=/usr/sbin/iotgw-rpi-eeprom
+
+[Service]
+Type=oneshot
+ExecStart=/usr/sbin/iotgw-rpi-eeprom policy
+NoNewPrivileges=true
+ProtectSystem=full
+ProtectHome=true
+PrivateTmp=true
+ProtectKernelTunables=true
+ProtectKernelModules=true
+ProtectKernelLogs=true
+ProtectControlGroups=true
+RestrictNamespaces=true
+RestrictRealtime=true
+RestrictSUIDSGID=true
+LockPersonality=true
+ReadWritePaths=/boot /var/lib/raspberrypi/bootloader
+
+[Install]
+WantedBy=multi-user.target

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/iotgw-rpi-eeprom_1.0.0.bb
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/iotgw-rpi-eeprom_1.0.0.bb
@@ -1,0 +1,41 @@
+SUMMARY = "IoT Gateway policy wrapper for Raspberry Pi EEPROM updates"
+DESCRIPTION = "Installs a controlled wrapper and optional systemd policy service for rpi-eeprom-update."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+inherit systemd
+
+SRC_URI = " \
+    file://iotgw-rpi-eeprom \
+    file://iotgw-rpi-eeprom.service \
+    file://iotgw-rpi-eeprom.default \
+"
+
+S = "${WORKDIR}"
+
+SYSTEMD_PACKAGES = "${PN}"
+SYSTEMD_SERVICE:${PN} = "iotgw-rpi-eeprom.service"
+SYSTEMD_AUTO_ENABLE = "disable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${WORKDIR}/iotgw-rpi-eeprom ${D}${sbindir}/iotgw-rpi-eeprom
+
+    install -d ${D}${sysconfdir}/default
+    install -m 0644 ${WORKDIR}/iotgw-rpi-eeprom.default ${D}${sysconfdir}/default/iotgw-rpi-eeprom
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${WORKDIR}/iotgw-rpi-eeprom.service ${D}${systemd_system_unitdir}/iotgw-rpi-eeprom.service
+}
+
+FILES:${PN} += " \
+    ${sbindir}/iotgw-rpi-eeprom \
+    ${sysconfdir}/default/iotgw-rpi-eeprom \
+    ${systemd_system_unitdir}/iotgw-rpi-eeprom.service \
+"
+
+RDEPENDS:${PN} = " \
+    rpi-eeprom \
+    raspi-utils \
+    coreutils \
+"

--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/rpi-eeprom_%.bbappend
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/rpi-eeprom_%.bbappend
@@ -1,0 +1,21 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# Pin newer Raspberry Pi EEPROM payloads for Pi5 secure-boot/partition-walk fixes.
+IOTGW_RPI_EEPROM_SRCREV ?= "a34ba1bcc4f46a2f4c7f3b1e806a238fdacd3698"
+SRCREV = "${IOTGW_RPI_EEPROM_SRCREV}"
+PV = "v2026.02.23-2712"
+
+# Fleet policy knob for updater channel on target.
+# Recommended production default is "default"; use "latest" only for controlled rollout.
+IOTGW_RPI_EEPROM_RELEASE_STATUS ?= "default"
+
+SRC_URI:append = " \
+    file://0001-rpi-eeprom-update-allow-default-config-when-bootload.patch \
+"
+
+do_install:append() {
+    cfg="${D}${sysconfdir}/default/rpi-eeprom-update"
+    if [ -f "$cfg" ]; then
+        sed -i -e "s|^FIRMWARE_RELEASE_STATUS=.*|FIRMWARE_RELEASE_STATUS=\"${IOTGW_RPI_EEPROM_RELEASE_STATUS}\"|" "$cfg"
+    fi
+}

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-devtools.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-devtools.bb
@@ -11,7 +11,6 @@ RDEPENDS:${PN} = " \
     packagegroup-iot-gw-utils \
     tcpdump \
     strace \
-    bpftool \
     keyutils \
     libseccomp \
     fio \
@@ -26,3 +25,7 @@ RDEPENDS:${PN} = " \
     systemd-dev \
     pkgconfig \
 "
+
+# bpftool from kernel tools is reliable in our mainline flow; skip it for
+# linux-raspberrypi maintenance builds where kernel tools layout differs.
+RDEPENDS:${PN}:append = "${@'' if (d.getVar('PREFERRED_PROVIDER_virtual/kernel') or '').strip() == 'linux-raspberrypi' else ' bpftool'}"

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-hwtools.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-hwtools.bb
@@ -14,5 +14,5 @@ RDEPENDS:${PN} = " \
     spidev-test \
     libgpiod-tools \
     raspi-gpio \
+    ${@bb.utils.contains('IOTGW_ENABLE_RPI_EEPROM', '1', 'rpi-eeprom iotgw-rpi-eeprom', '', d)} \
 "
-

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-security.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-security.bb
@@ -5,15 +5,13 @@ LICENSE = "MIT"
 
 inherit packagegroup
 
+# apparmor userspace pulled in when DISTRO_FEATURES includes 'apparmor'.
+# Currently commented out in iotgw-common.inc pending LSM default decision.
 RDEPENDS:${PN} = " \
     iotgw-hardening \
     iotgw-audit \
     audit \
     auditd \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'apparmor', 'apparmor', '', d)} \
+    ${@bb.utils.contains('IOTGW_ENABLE_IMA', '1', 'ima-evm-utils ima-inspect ima-policy', '', d)} \
 "
-
-# Optional: Add these for enhanced security monitoring
-# RRECOMMENDS:${PN} = " \
-#     aide \
-#     tripwire \
-# "

--- a/meta-iot-gateway/recipes-kernel/linux/files/0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch
@@ -1,0 +1,288 @@
+From cd559e56a758d19ae68ea222b5c1ed6d96555d78 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Fri, 10 Apr 2026 22:18:16 +0200
+Subject: [PATCH] drivers: char: broadcom: add VCIO mailbox userspace driver
+
+---
+ .../dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts  |   4 +
+ drivers/char/Kconfig                          |   2 +
+ drivers/char/Makefile                         |   2 +
+ drivers/char/broadcom/Kconfig                 |  20 ++
+ drivers/char/broadcom/Makefile                |   3 +
+ drivers/char/broadcom/vcio.c                  | 190 ++++++++++++++++++
+ 6 files changed, 221 insertions(+)
+ create mode 100644 drivers/char/broadcom/Kconfig
+ create mode 100644 drivers/char/broadcom/Makefile
+ create mode 100644 drivers/char/broadcom/vcio.c
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts
+index 27fbf4eab30f..1cb6440e0e61 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts
++++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts
+@@ -211,6 +211,10 @@ firmware_clocks: clocks {
+ 		reset: reset {
+ 			compatible = "raspberrypi,firmware-reset";
+ 			#reset-cells = <1>;
+ 		};
++
++		vcio: vcio {
++			compatible = "raspberrypi,vcio";
++		};
+ 	};
+ 
+diff --git a/drivers/char/Kconfig b/drivers/char/Kconfig
+index d2cfc584e202..94e52dc5ff11 100644
+--- a/drivers/char/Kconfig
++++ b/drivers/char/Kconfig
+@@ -4,6 +4,8 @@
+ #
+ 
+ menu "Character devices"
++source "drivers/char/broadcom/Kconfig"
++
+ 
+ source "drivers/tty/Kconfig"
+ 
+diff --git a/drivers/char/Makefile b/drivers/char/Makefile
+index 1291369b9126..9aedec1e01fd 100644
+--- a/drivers/char/Makefile
++++ b/drivers/char/Makefile
+@@ -44,3 +44,5 @@ obj-$(CONFIG_PS3_FLASH)		+= ps3flash.o
+ obj-$(CONFIG_XILLYBUS_CLASS)	+= xillybus/
+ obj-$(CONFIG_POWERNV_OP_PANEL)	+= powernv-op-panel.o
+ obj-$(CONFIG_ADI)		+= adi.o
++
++obj-$(CONFIG_BRCM_CHAR_DRIVERS)	+= broadcom/
+diff --git a/drivers/char/broadcom/Kconfig b/drivers/char/broadcom/Kconfig
+new file mode 100644
+index 000000000000..6f6cc7f2a38e
+--- /dev/null
++++ b/drivers/char/broadcom/Kconfig
+@@ -0,0 +1,20 @@
++# SPDX-License-Identifier: GPL-2.0
++#
++# Broadcom char driver config
++#
++
++menuconfig BRCM_CHAR_DRIVERS
++	bool "Broadcom Char Drivers"
++	help
++	  Broadcom's char drivers for Raspberry Pi.
++
++if BRCM_CHAR_DRIVERS
++
++config BCM_VCIO
++	tristate "Mailbox userspace access"
++	depends on BCM2835_MBOX
++	help
++	  Gives access to the mailbox property channel from userspace.
++	  Required by vcgencmd and rpi-eeprom-update.
++
++endif
+diff --git a/drivers/char/broadcom/Makefile b/drivers/char/broadcom/Makefile
+new file mode 100644
+index 000000000000..dc4d68b49a81
+--- /dev/null
++++ b/drivers/char/broadcom/Makefile
+@@ -0,0 +1,3 @@
++# SPDX-License-Identifier: GPL-2.0
++
++obj-$(CONFIG_BCM_VCIO)		+= vcio.o
+diff --git a/drivers/char/broadcom/vcio.c b/drivers/char/broadcom/vcio.c
+new file mode 100644
+index 000000000000..9cdfb068b631
+--- /dev/null
++++ b/drivers/char/broadcom/vcio.c
+@@ -0,0 +1,190 @@
++/*
++ *  Copyright (C) 2010 Broadcom
++ *  Copyright (C) 2015 Noralf Trønnes
++ *  Copyright (C) 2021 Raspberry Pi (Trading) Ltd.
++ *
++ * This program is free software; you can redistribute it and/or modify
++ * it under the terms of the GNU General Public License version 2 as
++ * published by the Free Software Foundation.
++ */
++
++#include <linux/cdev.h>
++#include <linux/device.h>
++#include <linux/fs.h>
++#include <linux/init.h>
++#include <linux/ioctl.h>
++#include <linux/module.h>
++#include <linux/slab.h>
++#include <linux/sizes.h>
++#include <linux/uaccess.h>
++#include <linux/compat.h>
++#include <linux/miscdevice.h>
++#include <linux/of.h>
++#include <linux/platform_device.h>
++#include <soc/bcm2835/raspberrypi-firmware.h>
++
++#define MODULE_NAME "vcio"
++#define VCIO_IOC_MAGIC 100
++#define IOCTL_MBOX_PROPERTY _IOWR(VCIO_IOC_MAGIC, 0, char *)
++#ifdef CONFIG_COMPAT
++#define IOCTL_MBOX_PROPERTY32 _IOWR(VCIO_IOC_MAGIC, 0, compat_uptr_t)
++#endif
++
++struct vcio_data {
++	struct rpi_firmware *fw;
++	struct miscdevice misc_dev;
++};
++
++static int vcio_user_property_list(struct vcio_data *vcio, void *user)
++{
++	u32 *buf, size;
++	int ret;
++
++	if (copy_from_user(&size, user, sizeof(size)))
++		return -EFAULT;
++
++	/*
++	 * Buffer format is: [size][code][tags...][end].
++	 * We need at least header+trailer (12 bytes), and size is user-controlled.
++	 */
++	if (size < 12 || size > SZ_1M || (size & 0x3))
++		return -EINVAL;
++
++	buf = kmalloc(size, GFP_KERNEL);
++	if (!buf)
++		return -ENOMEM;
++
++	if (copy_from_user(buf, user, size)) {
++		kfree(buf);
++		return -EFAULT;
++	}
++
++	ret = rpi_firmware_property_list(vcio->fw, &buf[2], size - 12);
++	if (ret) {
++		kfree(buf);
++		return ret;
++	}
++
++	buf[1] = RPI_FIRMWARE_STATUS_SUCCESS;
++	if (copy_to_user(user, buf, size))
++		ret = -EFAULT;
++
++	kfree(buf);
++	return ret;
++}
++
++static int vcio_device_open(struct inode *inode, struct file *file)
++{
++	try_module_get(THIS_MODULE);
++	return 0;
++}
++
++static int vcio_device_release(struct inode *inode, struct file *file)
++{
++	module_put(THIS_MODULE);
++	return 0;
++}
++
++static long vcio_device_ioctl(struct file *file, unsigned int ioctl_num,
++			      unsigned long ioctl_param)
++{
++	struct vcio_data *vcio = container_of(file->private_data,
++					      struct vcio_data, misc_dev);
++	switch (ioctl_num) {
++	case IOCTL_MBOX_PROPERTY:
++		return vcio_user_property_list(vcio, (void *)ioctl_param);
++	default:
++		pr_err("unknown ioctl: %x\n", ioctl_num);
++		return -EINVAL;
++	}
++}
++
++#ifdef CONFIG_COMPAT
++static long vcio_device_compat_ioctl(struct file *file, unsigned int ioctl_num,
++				     unsigned long ioctl_param)
++{
++	struct vcio_data *vcio = container_of(file->private_data,
++					      struct vcio_data, misc_dev);
++	switch (ioctl_num) {
++	case IOCTL_MBOX_PROPERTY32:
++		return vcio_user_property_list(vcio, compat_ptr(ioctl_param));
++	default:
++		pr_err("unknown ioctl: %x\n", ioctl_num);
++		return -EINVAL;
++	}
++}
++#endif
++
++static const struct file_operations vcio_fops = {
++	.unlocked_ioctl = vcio_device_ioctl,
++#ifdef CONFIG_COMPAT
++	.compat_ioctl = vcio_device_compat_ioctl,
++#endif
++	.open = vcio_device_open,
++	.release = vcio_device_release,
++};
++
++static int vcio_probe(struct platform_device *pdev)
++{
++	struct device *dev = &pdev->dev;
++	struct device_node *np = dev->of_node;
++	struct device_node *fw_node;
++	struct rpi_firmware *fw;
++	struct vcio_data *vcio;
++
++	fw_node = of_get_parent(np);
++	if (!fw_node) {
++		dev_err(dev, "Missing firmware node\n");
++		return -ENOENT;
++	}
++
++	fw = rpi_firmware_get(fw_node);
++	of_node_put(fw_node);
++	if (!fw)
++		return -EPROBE_DEFER;
++
++	vcio = devm_kzalloc(dev, sizeof(struct vcio_data), GFP_KERNEL);
++	if (!vcio)
++		return -ENOMEM;
++
++	vcio->fw = fw;
++	vcio->misc_dev.fops = &vcio_fops;
++	vcio->misc_dev.minor = MISC_DYNAMIC_MINOR;
++	vcio->misc_dev.name = "vcio";
++	vcio->misc_dev.parent = dev;
++
++	platform_set_drvdata(pdev, &vcio->misc_dev);
++
++	return misc_register(&vcio->misc_dev);
++}
++
++static void vcio_remove(struct platform_device *pdev)
++{
++	struct miscdevice *misc = platform_get_drvdata(pdev);
++
++	if (misc)
++		misc_deregister(misc);
++}
++
++static const struct of_device_id vcio_ids[] = {
++	{ .compatible = "raspberrypi,vcio" },
++	{ }
++};
++MODULE_DEVICE_TABLE(of, vcio_ids);
++
++static struct platform_driver vcio_driver = {
++	.driver = {
++		.name		= MODULE_NAME,
++		.of_match_table	= of_match_ptr(vcio_ids),
++	},
++	.probe	= vcio_probe,
++	.remove = vcio_remove,
++};
++
++module_platform_driver(vcio_driver);
++
++MODULE_AUTHOR("Gray Girling");
++MODULE_AUTHOR("Noralf Trønnes");
++MODULE_DESCRIPTION("Mailbox userspace access");
++MODULE_LICENSE("GPL");
++MODULE_ALIAS("platform:rpi-vcio");
+-- 
+2.43.0

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/ima.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/ima.cfg
@@ -1,0 +1,29 @@
+# IMA (Integrity Measurement Architecture)
+# Measures file hashes into TPM PCR10 at execution/open time.
+# Start with measurement-only (no appraise) — safe for exploration without
+# needing signed xattrs. Appraise mode requires ima-evm-utils key provisioning.
+CONFIG_IMA=y
+# Store measurements across kexec (requires TPM for replay protection).
+CONFIG_IMA_KEXEC=y
+CONFIG_IMA_KEXEC_EXTRA_MEMORY_KB=0
+# PCR10 is the conventional IMA measurement log PCR.
+CONFIG_IMA_MEASURE_PCR_IDX=10
+# Allow LSM labels in IMA policy rules.
+CONFIG_IMA_LSM_RULES=y
+# ima-ng: sha256 hash + file path — preferred over legacy ima template.
+CONFIG_IMA_NG_TEMPLATE=y
+# CONFIG_IMA_SIG_TEMPLATE is not set
+CONFIG_IMA_DEFAULT_TEMPLATE="ima-ng"
+CONFIG_IMA_DEFAULT_HASH_SHA256=y
+CONFIG_IMA_DEFAULT_HASH="sha256"
+# Allow reading (but not writing) the IMA policy at runtime via securityfs.
+# CONFIG_IMA_WRITE_POLICY is not set
+CONFIG_IMA_READ_POLICY=y
+# Appraise mode off by default — enable when keys are provisioned.
+# CONFIG_IMA_APPRAISE is not set
+# Queue asymmetric keys added before the key subsystem is ready.
+CONFIG_IMA_MEASURE_ASYMMETRIC_KEYS=y
+CONFIG_IMA_QUEUE_EARLY_BOOT_KEYS=y
+# SHA1 must be built-in (not module) when IMA is enabled — IMA uses it
+# internally for the measurement log even when the template hash is SHA256.
+CONFIG_CRYPTO_SHA1=y

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/rtc-rpi.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/rtc-rpi.cfg
@@ -1,3 +1,6 @@
 # Raspberry Pi firmware-backed RTC (needed for Pi5 battery-backed RTC).
 CONFIG_RTC_DRV_RPI=y
 
+# Firmware mailbox support used by Raspberry Pi firmware-backed services.
+CONFIG_MAILBOX=y
+CONFIG_BCM2835_MBOX=y

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/selinux.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/selinux.cfg
@@ -1,0 +1,19 @@
+# SELinux kernel support
+# Compiled in but not set as default LSM — switch at runtime via:
+#   lsm=selinux (cmdline) or DEFAULT_SECURITY_SELINUX (rebuild)
+# Userspace tooling (policycoreutils, libselinux) requires meta-selinux layer.
+CONFIG_SECURITY_SELINUX=y
+# BOOTPARAM would allow lsm= to disable SELinux at boot; keep it off for
+# exploration so the compiled-in state is deterministic.
+# CONFIG_SECURITY_SELINUX_BOOTPARAM is not set
+# DEVELOP mode allows permissive per-domain — useful during policy development.
+CONFIG_SECURITY_SELINUX_DEVELOP=y
+CONFIG_SECURITY_SELINUX_AVC_STATS=y
+CONFIG_SECURITY_SELINUX_SIDTAB_HASH_BITS=9
+CONFIG_SECURITY_SELINUX_SID2STR_CACHE_SIZE=256
+# Explicitly include selinux in the LSM initialisation list.
+# Enabling CONFIG_SECURITY_SELINUX alone does not add it — CONFIG_LSM is a
+# string that controls which LSMs are initialised at boot.
+# AppArmor remains default; selinux is present but dormant until activated
+# via 'lsm=' cmdline or DEFAULT_SECURITY_SELINUX rebuild.
+CONFIG_LSM="lockdown,yama,apparmor,selinux"

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/vcio-rpi.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/vcio-rpi.cfg
@@ -1,0 +1,4 @@
+# Raspberry Pi VCIO mailbox character device for vcgencmd/rpi-eeprom-update.
+# Keep this fragment opt-in for mainline until validated on target.
+CONFIG_BRCM_CHAR_DRIVERS=y
+CONFIG_BCM_VCIO=y

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
@@ -39,4 +39,5 @@ SRC_URI:append = "${@' file://0002-arm64-dts-broadcom-bcm2712-add-rpi-rtc-node.p
 SRC_URI:append = "${@' file://0003-arm64-dts-broadcom-rp1-common-add-RP1-SPI0-controller.patch' if d.getVar('IOTGW_ENABLE_TPM_SLB9672') == '1' else ''}"
 SRC_URI:append = "${@' file://0004-arm64-dts-broadcom-bcm2712-rpi-5-b-add-TPM-on-RP1-SPI0-CS1.patch' if d.getVar('IOTGW_ENABLE_TPM_SLB9672') == '1' else ''}"
 SRC_URI:append = " file://0005-arm64-dts-broadcom-bcm2712-add-avs-thermal-zone.patch"
+SRC_URI:append = "${@' file://0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
 SRC_URI:append = " file://fragments/thermal-rpi5.cfg"

--- a/meta-iot-gateway/recipes-kernel/spidev-test/spidev-test.bbappend
+++ b/meta-iot-gateway/recipes-kernel/spidev-test/spidev-test.bbappend
@@ -1,0 +1,3 @@
+# Keep package feed version monotonic across temporary local recipe/PV shifts.
+# We previously emitted epoch 1 for spidev-test in this project, so pin it.
+PE = "1"


### PR DESCRIPTION
## Summary
- add SELinux/IMA kernel feature gates and supporting docs/workflow updates
- add Raspberry Pi EEPROM tooling integration (`rpi-eeprom` pin + `iotgw-rpi-eeprom` wrapper/service)
- carry and gate VCIO support on mainline (`/dev/vcio`, `vcgencmd`, `rpi-eeprom-update` path)
- add build-time gates (`IOTGW_ENABLE_RPI_EEPROM`, `IOTGW_ENABLE_VCIO`) and packagegroup wiring
- include spidev-test epoch pin to avoid package-history rollback QA during kernel line switches

## Validation
- built and installed RAUC bundle on target
- verified `/dev/vcio` exists and `vcgencmd version` works on mainline 6.18
- verified `rpi-eeprom-update` / `iotgw-rpi-eeprom status` report bootloader up-to-date
- verified RAUC slot activation and no failed systemd units


