### PR TITLE
ota: gate TPM updater path and fix polling preflight

### DIFF
--- a/docs/OTA_UPDATE.md
+++ b/docs/OTA_UPDATE.md
@@ -265,9 +265,35 @@ send-headers=boot-id;machine-id;transaction-id
 
 Device certs are provisioned by `ota-certs-provision`:
 - Production: `/boot/iotgw/ota/` or `/data/ota/certs/`
-- Dev fallback: auto-generated using dev CA
+- Existing certs in `/etc/ota` are kept when still valid
 
 Server cert must include a SAN matching the OTA server IP/hostname.
+
+### TPM-backed client key (OTA updater manifest polling)
+
+`ota-update-check` can use a TPM-backed OpenSSL key URI instead of a filesystem
+private key. Configure `/etc/ota/updater.conf`:
+
+```json
+{
+  "device_cert": "/etc/ota/device.crt",
+  "device_key_uri": "handle:0x81000001",
+  "openssl_conf": "/etc/ota/openssl-tpm2.cnf",
+  "ca_cert": "/etc/ota/ca.crt"
+}
+```
+
+Notes:
+- `device_key_uri` takes precedence over `device_key`.
+- TPM mode is build-gated by `IOTGW_ENABLE_OTA_TPM_MTLS = "1"` (default `0`,
+  preserving non-TPM file-key flow).
+- On current gateway curl builds (`--key-type` supports `ENG`, not `PROV`), TPM
+  handles are used via OpenSSL engine mode (`tpm2tss`) when
+  `device_key_uri` is `handle:0x...`.
+- `openssl_conf` remains optional for provider-based tooling and future curl
+  builds with provider key support.
+- With TPM mode enabled, `ota-updater.service` gets supplementary `iotgwtpm`
+  group access for `/dev/tpmrm0`.
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -283,6 +283,25 @@ When `IOTGW_ENABLE_TPM_SLB9672=1`, the following TPM security components are inc
 - **`tpm2-tools`** — Low-level TPM2 CLI (dev image only)
 - Default TCTI policy is pinned to `device:/dev/tpmrm0` to avoid simulator/fallback ambiguity.
 
+### Optional TPM Crypto Providers
+
+Enable extra userspace integrations for PKCS#11/OpenSSL consumers:
+
+- `tpm2-pkcs11`
+- `tpm2-openssl`
+- `tpm2-tss-engine`
+
+Build-time gate:
+
+```bash
+IOTGW_ENABLE_TPM_CRYPTO_PROVIDERS=1 make dev
+```
+
+Notes:
+- Gate is additive and only effective when `IOTGW_ENABLE_TPM_SLB9672=1`.
+- On OpenSSL 3 builds, provider-based integration is preferred; `openssl engine`
+  output may stay minimal even when TPM crypto provider packages are installed.
+
 ### Kernel Support
 - Fragment: `meta-iot-gateway/recipes-kernel/linux/files/fragments/tpm-slb9672.cfg`
 - TIS-SPI stack over RP1 DesignWare SPI controller

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -61,3 +61,20 @@ local_conf_header:
     #
     # Broader alternative (keeps image history but skips package history):
     # BUILDHISTORY_FEATURES:remove = "package"
+
+  tpm_crypto_providers: |
+    # Optional TPM crypto provider userspace integrations:
+    # tpm2-pkcs11, tpm2-openssl, tpm2-tss-engine
+    # Effective when TPM SPI profile is enabled on your build.
+    # IOTGW_ENABLE_TPM_SLB9672 = "1"
+    # IOTGW_ENABLE_TPM_CRYPTO_PROVIDERS = "1"
+
+  ota_tpm_mtls: |
+    # Optional OTA updater TPM-backed mTLS key flow (disabled by default).
+    # When enabled:
+    # - ota-updater uses TPM key handle URI instead of /etc/ota/device.key
+    # - ota-certs allows keyless cert provisioning (device.crt + ca.crt)
+    # IOTGW_ENABLE_OTA_TPM_MTLS = "1"
+    # IOTGW_OTA_TPM_KEY_URI = "handle:0x81000001"
+    # IOTGW_OTA_TPM_KEY_ENGINE = "tpm2tss"
+    # IOTGW_OTA_OPENSSL_CONF = "/etc/ota/openssl-tpm2.cnf"

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -104,6 +104,8 @@ ROOT_HOME ?= "/root"
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_ENABLE_OTBR IOTGW_ENABLE_EDGE_HEALTHD"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_SLB9672 IOTGW_TPM_DTO_OVERLAY IOTGW_ENABLE_KERNEL_NO_EFI"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_TPM_CRYPTO_PROVIDERS"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OTA_TPM_MTLS IOTGW_OTA_TPM_KEY_URI IOTGW_OTA_TPM_KEY_ENGINE IOTGW_OTA_OPENSSL_CONF"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_RPI_EEPROM IOTGW_ENABLE_VCIO"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_SELINUX IOTGW_ENABLE_IMA"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYPTED_STORE_DEV IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE"
@@ -152,6 +154,21 @@ IOTGW_KERNEL_FEATURES ?= "igw_networking_iot igw_security_prod"
 IOTGW_ENABLE_TPM_SLB9672 ?= "0"
 IOTGW_TPM_DTO_OVERLAY ?= "tpm-slb9670"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672', '1', ' igw_tpm_slb9672', '', d)}"
+
+# Optional TPM crypto provider stack (userspace integrations):
+#  - tpm2-pkcs11
+#  - tpm2-openssl
+#  - tpm2-tss-engine
+# Keep disabled by default until app/client integration is wired.
+IOTGW_ENABLE_TPM_CRYPTO_PROVIDERS ?= "0"
+
+# Optional OTA mTLS TPM key mode (ota-updater + ota-certs behavior):
+# - 0: default file-key flow (/etc/ota/device.key required)
+# - 1: TPM key-handle flow (keyless cert provisioning allowed; updater uses TPM key URI)
+IOTGW_ENABLE_OTA_TPM_MTLS ?= "0"
+IOTGW_OTA_TPM_KEY_URI ?= "handle:0x81000001"
+IOTGW_OTA_TPM_KEY_ENGINE ?= "tpm2tss"
+IOTGW_OTA_OPENSSL_CONF ?= "/etc/ota/openssl-tpm2.cnf"
 
 # Optional kernel EFI surface reduction profile for non-UEFI RPi5 boot flow.
 # Enable to append igw_no_efi fragment set.

--- a/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-dev.bb
+++ b/meta-iot-gateway/recipes-core/packagegroups/packagegroup-iot-gw-dev.bb
@@ -18,6 +18,7 @@ RDEPENDS:${PN} = " \
     ota-certs-devca \
     ota-updater \
     ${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672','1',' tpm2-tools tpm2-tss','',d)} \
+    ${@bb.utils.contains('IOTGW_ENABLE_TPM_SLB9672','1',bb.utils.contains('IOTGW_ENABLE_TPM_CRYPTO_PROVIDERS','1',' tpm2-pkcs11 tpm2-openssl tpm2-tss-engine','',d),'',d)} \
 "
 
 # Optional: container runtime tools (opt-in)

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
@@ -16,6 +16,7 @@ readonly BOOT_SRC="/boot/iotgw/ota"
 readonly BOOT_META="${BOOT_SRC}/meta.json"
 readonly DATA_SRC="/data/ota/certs"
 readonly STATE_FILE="/var/lib/ota-certs-provision.state"
+readonly ALLOW_KEYLESS_DEVICE_CERTS="${OTA_CERTS_ALLOW_KEYLESS_DEVICE_CERTS:-0}"
 
 get_device_id() {
     local mid=""
@@ -65,9 +66,12 @@ boot_meta_get_provision_id() {
 # Check if valid certs exist in an arbitrary directory
 certs_valid_in_dir() {
     local dir="$1"
-    [[ -f "$dir/device.crt" ]] && \
-    [[ -f "$dir/device.key" ]] && \
-    [[ -f "$dir/ca.crt" ]] && \
+    [[ -f "$dir/device.crt" ]] || return 1
+    [[ -f "$dir/ca.crt" ]] || return 1
+    if [[ "$ALLOW_KEYLESS_DEVICE_CERTS" != "1" ]]; then
+        [[ -f "$dir/device.key" ]] || return 1
+    fi
+
     openssl x509 -in "$dir/device.crt" -noout -checkend 86400 2>/dev/null && \
     openssl verify -CAfile "$dir/ca.crt" "$dir/device.crt" >/dev/null 2>&1
 }
@@ -118,7 +122,9 @@ backup_certs_to_data() {
     mkdir -p "$DATA_SRC"
     install -m 0644 "$CERT_DIR/ca.crt" "$DATA_SRC/ca.crt"
     install -m 0644 "$CERT_DIR/device.crt" "$DATA_SRC/device.crt"
-    install -m 0640 "$CERT_DIR/device.key" "$DATA_SRC/device.key"
+    if [[ -f "$CERT_DIR/device.key" ]]; then
+        install -m 0640 "$CERT_DIR/device.key" "$DATA_SRC/device.key"
+    fi
 }
 
 write_state() {
@@ -146,19 +152,27 @@ copy_certs() {
     local src="$1"
     local desc="$2"
 
-    if [[ -f "$src/device.crt" && -f "$src/device.key" && -f "$src/ca.crt" ]]; then
+    if [[ -f "$src/device.crt" && -f "$src/ca.crt" ]] && [[ -f "$src/device.key" || "$ALLOW_KEYLESS_DEVICE_CERTS" == "1" ]]; then
         log_info "Provisioning certificates from $desc"
 
         install -m 0644 "$src/ca.crt" "$CERT_DIR/ca.crt"
         install -m 0644 "$src/device.crt" "$CERT_DIR/device.crt"
-        install -m 0640 "$src/device.key" "$CERT_DIR/device.key"
+        if [[ -f "$src/device.key" ]]; then
+            install -m 0640 "$src/device.key" "$CERT_DIR/device.key"
+        elif [[ "$ALLOW_KEYLESS_DEVICE_CERTS" == "1" ]]; then
+            log_info "Source has no device.key; keyless mode is enabled"
+        fi
 
         # Set ownership for ota user
-        chown root:ota "$CERT_DIR/device.key" 2>/dev/null || true
+        if [[ -f "$CERT_DIR/device.key" ]]; then
+            chown root:ota "$CERT_DIR/device.key" 2>/dev/null || true
+        fi
         chown root:ota "$CERT_DIR/device.crt" 2>/dev/null || true
         chown root:ota "$CERT_DIR/ca.crt" 2>/dev/null || true
         chmod 0750 "$CERT_DIR"
-        chmod 0640 "$CERT_DIR/device.key"
+        if [[ -f "$CERT_DIR/device.key" ]]; then
+            chmod 0640 "$CERT_DIR/device.key"
+        fi
         chmod 0644 "$CERT_DIR/device.crt" "$CERT_DIR/ca.crt"
         if ! cert_chain_valid; then
             log_error "Provisioned certificates from $desc do not chain to $CERT_DIR/ca.crt"
@@ -171,6 +185,9 @@ copy_certs() {
 
 main() {
     log_info "OTA certificate provisioning starting"
+    if [[ "$ALLOW_KEYLESS_DEVICE_CERTS" == "1" ]]; then
+        log_info "Keyless device-certificate mode enabled (TPM key expected at runtime)"
+    fi
 
     # Create cert directory
     install -d -m 0750 "$CERT_DIR"

--- a/meta-iot-gateway/recipes-ota/ota-certs/ota-certs_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-certs/ota-certs_1.0.0.bb
@@ -27,6 +27,7 @@ S = "${WORKDIR}"
 PACKAGES =+ "${PN}-devca"
 
 RAUC_OTA_CA_DIR ?= ""
+IOTGW_ENABLE_OTA_TPM_MTLS ?= "0"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "ota-certs-provision.service"
@@ -41,6 +42,10 @@ do_install() {
     # Install systemd service
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${WORKDIR}/ota-certs-provision.service ${D}${systemd_system_unitdir}/
+    if ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', 'true', 'false', d)}; then
+        sed -i '/^\[Service\]/a Environment=OTA_CERTS_ALLOW_KEYLESS_DEVICE_CERTS=1' \
+            ${D}${systemd_system_unitdir}/ota-certs-provision.service
+    fi
 
     # Create certificate directory structure
     install -d ${D}${sysconfdir}/ota

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/openssl-tpm2.cnf
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/openssl-tpm2.cnf
@@ -1,0 +1,20 @@
+# OpenSSL 3 provider configuration for TPM-backed key operations.
+#
+# Usage with ota-update-check:
+# - Set "device_key_uri": "handle:0x81000001" in /etc/ota/updater.conf
+# - Set "openssl_conf": "/etc/ota/openssl-tpm2.cnf"
+
+openssl_conf = openssl_init
+
+[openssl_init]
+providers = provider_sect
+
+[provider_sect]
+default = default_sect
+tpm2 = tpm2_sect
+
+[default_sect]
+activate = 1
+
+[tpm2_sect]
+activate = 1

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
@@ -15,7 +15,7 @@ set -euo pipefail
 readonly CONFIG_FILE="${OTA_CONFIG:-/etc/ota/updater.conf}"
 readonly STATE_DIR="/data/ota"
 readonly STATE_FILE="${STATE_DIR}/last-check"
-readonly LOCK_FILE="/run/ota-updater.lock"
+readonly LOCK_FILE="${STATE_DIR}/updater.lock"
 readonly RAUC_DBUS_SERVICE="de.pengutronix.rauc"
 readonly RAUC_DBUS_PATH="/"
 readonly RAUC_DBUS_IFACE="de.pengutronix.rauc.Installer"
@@ -90,7 +90,10 @@ load_config() {
         MANIFEST_PATH=$(jq -r '.manifest_path // "/manifest.json"' "$CONFIG_FILE")
         DEVICE_CERT=$(jq -r '.device_cert // "/etc/ota/device.crt"' "$CONFIG_FILE")
         DEVICE_KEY=$(jq -r '.device_key // "/etc/ota/device.key"' "$CONFIG_FILE")
+        DEVICE_KEY_URI=$(jq -r '.device_key_uri // empty' "$CONFIG_FILE")
+        DEVICE_KEY_ENGINE=$(jq -r '.device_key_engine // "tpm2tss"' "$CONFIG_FILE")
         CA_CERT=$(jq -r '.ca_cert // "/etc/ota/ca.crt"' "$CONFIG_FILE")
+        OPENSSL_CONF_PATH=$(jq -r '.openssl_conf // empty' "$CONFIG_FILE")
         CONNECT_TIMEOUT=$(jq -r '.connect_timeout // 30' "$CONFIG_FILE")
         MAX_TIME=$(jq -r '.max_time // 300' "$CONFIG_FILE")
         FETCH_RETRIES=$(jq -r '.fetch_retries // 5' "$CONFIG_FILE")
@@ -107,6 +110,9 @@ load_config() {
     FETCH_RETRIES=${FETCH_RETRIES:-5}
     RETRY_BASE_SEC=${RETRY_BASE_SEC:-2}
     RETRY_MAX_SEC=${RETRY_MAX_SEC:-60}
+    DEVICE_KEY_URI=${DEVICE_KEY_URI:-}
+    DEVICE_KEY_ENGINE=${DEVICE_KEY_ENGINE:-tpm2tss}
+    OPENSSL_CONF_PATH=${OPENSSL_CONF_PATH:-}
 
     # Validate required settings
     if [[ -z "${SERVER_URL:-}" ]]; then
@@ -152,6 +158,10 @@ get_installed_version() {
 # Fetch manifest from update server using mTLS
 fetch_manifest_once() {
     local manifest_url="${SERVER_URL}${MANIFEST_PATH}"
+    local key_for_curl=""
+    local key_mode="none"
+    local key_arg=""
+    local -a curl_env=()
     local curl_opts=(
         --silent
         --show-error
@@ -160,10 +170,54 @@ fetch_manifest_once() {
         --max-time "${MAX_TIME:-300}"
     )
 
-    # Add mTLS options if certs are configured
-    if [[ -f "${DEVICE_CERT:-}" && -f "${DEVICE_KEY:-}" ]]; then
-        curl_opts+=(--cert "$DEVICE_CERT" --key "$DEVICE_KEY")
-        log_info "Using device certificate: $DEVICE_CERT"
+    # Add mTLS options if cert/key are configured.
+    # key selection precedence:
+    #   1. device_key_uri (explicit OpenSSL key URI, e.g. handle:0x81000001)
+    #   2. device_key if it points to a file
+    #   3. device_key if it looks like a URI scheme
+    if [[ -f "${DEVICE_CERT:-}" ]]; then
+        if [[ -n "${DEVICE_KEY_URI:-}" ]]; then
+            key_arg="${DEVICE_KEY_URI}"
+        elif [[ -n "${DEVICE_KEY:-}" && -f "${DEVICE_KEY}" ]]; then
+            key_arg="${DEVICE_KEY}"
+        elif [[ -n "${DEVICE_KEY:-}" && "${DEVICE_KEY}" == *:* ]]; then
+            key_arg="${DEVICE_KEY}"
+        fi
+
+        if [[ -n "${key_arg}" ]]; then
+            if [[ "${key_arg}" =~ ^handle:(0x[0-9A-Fa-f]+)$ ]]; then
+                key_for_curl="${BASH_REMATCH[1]}"
+                curl_opts+=(--engine "${DEVICE_KEY_ENGINE}" --key-type ENG --key "${key_for_curl}")
+                key_mode="engine"
+            elif [[ "${key_arg}" =~ ^0x[0-9A-Fa-f]+$ ]]; then
+                key_for_curl="${key_arg}"
+                curl_opts+=(--engine "${DEVICE_KEY_ENGINE}" --key-type ENG --key "${key_for_curl}")
+                key_mode="engine"
+            else
+                key_for_curl="${key_arg}"
+                curl_opts+=(--key "${key_for_curl}")
+                key_mode="file-or-uri"
+            fi
+
+            curl_opts+=(--cert "$DEVICE_CERT")
+            log_info "Using device certificate: $DEVICE_CERT"
+            if [[ "${key_mode}" == "engine" ]]; then
+                log_info "Using TPM key via engine: ${DEVICE_KEY_ENGINE} key=${key_for_curl}"
+            fi
+        else
+            log_warn "Device certificate is present but no usable private key/URI configured"
+        fi
+    elif [[ -n "${DEVICE_CERT:-}" ]]; then
+        log_warn "Configured device certificate is missing: ${DEVICE_CERT}"
+    fi
+
+    if [[ -n "${OPENSSL_CONF_PATH:-}" ]]; then
+        if [[ -r "${OPENSSL_CONF_PATH}" ]]; then
+            curl_env+=(OPENSSL_CONF="${OPENSSL_CONF_PATH}")
+            log_info "Using OpenSSL config: ${OPENSSL_CONF_PATH}"
+        else
+            die "Configured openssl_conf is not readable: ${OPENSSL_CONF_PATH}"
+        fi
     fi
 
     if [[ -f "${CA_CERT:-}" ]]; then
@@ -171,7 +225,11 @@ fetch_manifest_once() {
     fi
 
     log_info "Fetching manifest from: $manifest_url"
-    curl "${curl_opts[@]}" "$manifest_url"
+    if [[ ${#curl_env[@]} -gt 0 ]]; then
+        env "${curl_env[@]}" curl "${curl_opts[@]}" "$manifest_url"
+    else
+        curl "${curl_opts[@]}" "$manifest_url"
+    fi
 }
 
 # Exponential backoff with jitter (seconds)
@@ -370,26 +428,34 @@ record_check() {
 
 derive_manifest_version() {
     local manifest_json="$1"
+    local manifest_entry="$2"
     local v=""
 
-    v=$(echo "$manifest_json" | jq -r '.version // empty')
+    v=$(echo "$manifest_entry" | jq -r '.version // empty')
     if [[ -n "$v" ]]; then
         echo "$v"
         return 0
     fi
 
-    v=$(echo "$manifest_json" | jq -r '.released_at // empty')
+    v=$(echo "$manifest_entry" | jq -r '.released_at // empty')
     if [[ -n "$v" ]]; then
         echo "$v"
         return 0
     fi
 
-    v=$(echo "$manifest_json" | jq -r '.filename // empty')
+    v=$(echo "$manifest_entry" | jq -r '.filename // empty')
     if [[ -n "$v" ]]; then
         echo "$v"
         return 0
     fi
 
+    v=$(echo "$manifest_entry" | jq -r '.sha256 // empty')
+    if [[ -n "$v" ]]; then
+        echo "$v"
+        return 0
+    fi
+
+    # Fallback for object-only responses that provide a top-level hash/token.
     v=$(echo "$manifest_json" | jq -r '.sha256 // empty')
     if [[ -n "$v" ]]; then
         echo "$v"
@@ -397,6 +463,35 @@ derive_manifest_version() {
     fi
 
     echo "unknown"
+}
+
+select_manifest_entry() {
+    local manifest_json="$1"
+    local entry=""
+
+    # Support both:
+    # - object manifest: { "bundle_url": "...", ... }
+    # - list manifest: [ { "bundle_url": "...", ... }, ... ]
+    # For list manifests, prefer active entries when present, then the first item.
+    entry="$(echo "$manifest_json" | jq -c '
+        if type == "object" then
+            .
+        elif type == "array" then
+            (
+              [ .[] | select((.active // true) == true and (.bundle_url // .url // empty) != "") ][0]
+              // [ .[] | select((.bundle_url // .url // empty) != "") ][0]
+              // .[0]
+            )
+        else
+            empty
+        end
+    ')"
+
+    if [[ -z "$entry" || "$entry" == "null" ]]; then
+        return 1
+    fi
+
+    echo "$entry"
 }
 
 # Main
@@ -419,11 +514,12 @@ main() {
     local manifest
     manifest=$(fetch_manifest) || die "Failed to fetch manifest"
 
-    # Parse manifest
-    local available_version bundle_url compatible
-    available_version="$(derive_manifest_version "$manifest")"
-    bundle_url=$(echo "$manifest" | jq -r '.bundle_url // empty')
-    compatible=$(echo "$manifest" | jq -r '.compatible // empty')
+    # Parse manifest (supports object and array API shapes)
+    local manifest_entry available_version bundle_url compatible
+    manifest_entry="$(select_manifest_entry "$manifest")" || die "Invalid manifest: no usable entry"
+    available_version="$(derive_manifest_version "$manifest" "$manifest_entry")"
+    bundle_url=$(echo "$manifest_entry" | jq -r '.bundle_url // .url // empty')
+    compatible=$(echo "$manifest_entry" | jq -r '.compatible // empty')
 
     if [[ -z "$bundle_url" ]]; then
         die "Invalid manifest: missing bundle_url"

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-updater-tpm.service.conf
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-updater-tpm.service.conf
@@ -1,0 +1,7 @@
+# SPDX-License-Identifier: MIT
+# TPM-specific runtime additions for ota-updater.service
+
+[Service]
+# Allow ota-updater to access /dev/tpmrm0 via group policy.
+SupplementaryGroups=iotgwtpm
+PrivateDevices=false

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-updater.conf.in
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-updater.conf.in
@@ -6,6 +6,12 @@
 
     "device_cert": "/etc/ota/device.crt",
     "device_key": "/etc/ota/device.key",
+    "_device_key_uri_comment": "Optional OpenSSL key URI (e.g. handle:0x81000001 for tpm2-openssl). Overrides device_key when set.",
+    "device_key_uri": "@IOTGW_OTA_DEVICE_KEY_URI@",
+    "_device_key_engine_comment": "Engine for TPM handle mode on curl builds that support ENG (default: tpm2tss).",
+    "device_key_engine": "@IOTGW_OTA_DEVICE_KEY_ENGINE@",
+    "_openssl_conf_comment": "Optional OpenSSL config file used by curl for provider loading (e.g. /etc/ota/openssl-tpm2.cnf).",
+    "openssl_conf": "@IOTGW_OTA_OPENSSL_CONF@",
     "ca_cert": "/etc/ota/ca.crt",
 
     "connect_timeout": 30,

--- a/meta-iot-gateway/recipes-ota/ota-updater/ota-updater_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-updater/ota-updater_1.0.0.bb
@@ -19,6 +19,8 @@ SRC_URI = " \
     file://ota-updater.service \
     file://ota-updater.timer \
     file://ota-updater.conf.in \
+    file://ota-updater-tpm.service.conf \
+    file://openssl-tpm2.cnf \
     file://ota-updater.tmpfiles.conf \
 "
 
@@ -26,6 +28,14 @@ S = "${WORKDIR}"
 
 IOTGW_OTA_SERVER_URL ?= "https://updates.example.com:8443"
 IOTGW_OTA_MANIFEST_PATH ?= "/api/v1/manifest.json"
+IOTGW_ENABLE_OTA_TPM_MTLS ?= "0"
+IOTGW_OTA_TPM_KEY_URI ?= "handle:0x81000001"
+IOTGW_OTA_TPM_KEY_ENGINE ?= "tpm2tss"
+IOTGW_OTA_OPENSSL_CONF ?= "/etc/ota/openssl-tpm2.cnf"
+
+IOTGW_OTA_DEVICE_KEY_URI = "${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', d.getVar('IOTGW_OTA_TPM_KEY_URI') or '', '', d)}"
+IOTGW_OTA_DEVICE_KEY_ENGINE = "${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', d.getVar('IOTGW_OTA_TPM_KEY_ENGINE') or 'tpm2tss', 'tpm2tss', d)}"
+IOTGW_OTA_OPENSSL_CONF_VALUE = "${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', d.getVar('IOTGW_OTA_OPENSSL_CONF') or '', '', d)}"
 
 # -----------------------------------------------------------------------------
 # User/Group creation (least privilege)
@@ -59,8 +69,18 @@ do_install() {
     install -d ${D}${sysconfdir}/ota
     sed -e "s|@IOTGW_OTA_SERVER_URL@|${IOTGW_OTA_SERVER_URL}|g" \
         -e "s|@IOTGW_OTA_MANIFEST_PATH@|${IOTGW_OTA_MANIFEST_PATH}|g" \
+        -e "s|@IOTGW_OTA_DEVICE_KEY_URI@|${IOTGW_OTA_DEVICE_KEY_URI}|g" \
+        -e "s|@IOTGW_OTA_DEVICE_KEY_ENGINE@|${IOTGW_OTA_DEVICE_KEY_ENGINE}|g" \
+        -e "s|@IOTGW_OTA_OPENSSL_CONF@|${IOTGW_OTA_OPENSSL_CONF_VALUE}|g" \
         ${WORKDIR}/ota-updater.conf.in > ${D}${sysconfdir}/ota/updater.conf
     chmod 0640 ${D}${sysconfdir}/ota/updater.conf
+
+    if ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', 'true', 'false', d)}; then
+        install -m 0644 ${WORKDIR}/openssl-tpm2.cnf ${D}${sysconfdir}/ota/openssl-tpm2.cnf
+        install -d ${D}${sysconfdir}/systemd/system/ota-updater.service.d
+        install -m 0644 ${WORKDIR}/ota-updater-tpm.service.conf \
+            ${D}${sysconfdir}/systemd/system/ota-updater.service.d/10-tpm.conf
+    fi
 
     # Install tmpfiles.d for state directory
     install -d ${D}${sysconfdir}/tmpfiles.d
@@ -82,11 +102,15 @@ FILES:${PN} = " \
     ${systemd_system_unitdir}/ota-updater.service \
     ${systemd_system_unitdir}/ota-updater.timer \
     ${sysconfdir}/ota/updater.conf \
+    ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', '${sysconfdir}/ota/openssl-tpm2.cnf', '', d)} \
+    ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', '${sysconfdir}/systemd/system/ota-updater.service.d/10-tpm.conf', '', d)} \
     ${sysconfdir}/tmpfiles.d/ota-updater.conf \
 "
 
 CONFFILES:${PN} = " \
     ${sysconfdir}/ota/updater.conf \
+    ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', '${sysconfdir}/ota/openssl-tpm2.cnf', '', d)} \
+    ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', '${sysconfdir}/systemd/system/ota-updater.service.d/10-tpm.conf', '', d)} \
 "
 
 RDEPENDS:${PN} = " \
@@ -96,4 +120,5 @@ RDEPENDS:${PN} = " \
     rauc \
     systemd \
     ca-certificates \
+    ${@bb.utils.contains('IOTGW_ENABLE_OTA_TPM_MTLS', '1', 'iotgw-tpm-policy', '', d)} \
 "

--- a/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/iotgw-rauc-install.sh
@@ -221,29 +221,48 @@ _reconcile_ota_certs() {
 # full CA chain in one shot.  TLS config is read from system.conf [streaming].
 _preflight_url() {
     local label="Server  ${URL_HOST}:${URL_PORT}" curl_rc=0
+    local key_is_uri=0
+    local key_is_handle=0
+    local key_for_curl="${TLS_KEY}"
+    local -a key_opts=(--key "${TLS_KEY}")
 
     command -v curl >/dev/null 2>&1 || die "curl not found"
     _read_streaming_tls \
         || die "cannot read TLS config from /etc/rauc/system.conf [streaming]"
 
-    for f in "${TLS_CA}" "${TLS_CERT}" "${TLS_KEY}"; do
+    for f in "${TLS_CA}" "${TLS_CERT}"; do
         [ -r "${f}" ] || { _check_fail "${label}" "missing: $(basename "${f}")"; return 1; }
     done
+    if [[ "${TLS_KEY}" == *:* ]]; then
+        key_is_uri=1
+        if [[ "${TLS_KEY}" =~ ^handle:(0x[0-9A-Fa-f]+)$ ]]; then
+            key_is_handle=1
+            key_for_curl="${BASH_REMATCH[1]}"
+            key_opts=(--engine tpm2tss --key-type ENG --key "${key_for_curl}")
+        fi
+    elif [ ! -r "${TLS_KEY}" ]; then
+        _check_fail "${label}" "missing: $(basename "${TLS_KEY}")"
+        return 1
+    fi
 
     _spin_start "${label}"
     _log "preflight connect starting host=${URL_HOST} port=${URL_PORT}"
+    [ "${key_is_uri}" -eq 1 ] && _log "preflight using key URI from system.conf"
+    [ "${key_is_handle}" -eq 1 ] && _log "preflight using tpm2tss engine key=${key_for_curl}"
 
     if curl --fail --silent --show-error --location \
             --output /dev/null \
             --connect-timeout 5 --max-time 15 \
             --range 0-0 \
-            --cacert "${TLS_CA}" --cert "${TLS_CERT}" --key "${TLS_KEY}" \
+            --cacert "${TLS_CA}" --cert "${TLS_CERT}" \
+            "${key_opts[@]}" \
             "${BUNDLE_INPUT}" >/dev/null 2>&1; then
         _log "preflight connect ok"
         _check_ok "${label}"
         return 0
+    else
+        curl_rc=$?
     fi
-    curl_rc=$?
     _log "preflight connect failed curl_rc=${curl_rc}"
     _check_fail "${label}" "curl_rc=${curl_rc}"
     return 1

--- a/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.2.0.bb
+++ b/meta-iot-gateway/recipes-security/tpm-ops/tpm-ops_0.2.0.bb
@@ -1,4 +1,4 @@
 require tpm-ops.inc
 
 # Pin upstream source for reproducible non-externalsrc builds.
-SRCREV = "02885a24e047a1153a6fbfdbc08616a9fac504dc"
+SRCREV = "6ec22b470c2df68b1a4dadeb3bf92431919a8b12"

--- a/meta-iot-gateway/recipes-security/tpm2-tss-engine/tpm2-tss-engine_%.bbappend
+++ b/meta-iot-gateway/recipes-security/tpm2-tss-engine/tpm2-tss-engine_%.bbappend
@@ -1,0 +1,6 @@
+# meta-secure-core recipe installs engines-3/* into ${PN}, which captures the
+# static archive libtpm2tss.a and fails staticdev QA. For gateway runtime we
+# only need the shared engine module(s), so drop the static archive.
+do_install:append() {
+    rm -f ${D}${libdir}/engines-3/*.a || true
+}


### PR DESCRIPTION
## Summary
- gate OTA TPM mTLS path behind BitBake vars (default off)
- add updater support for TPM key URI/engine and manifest array parsing (`/api/manifests`)
- add conditional TPM service drop-in and OpenSSL TPM config packaging
- allow keyless cert provisioning mode for OTA certs when TPM OTA mode is enabled
- fix `iotgw-rauc-install` preflight curl rc handling bug
- add TPM provider package gating in dev packagegroup
- document OTA TPM behavior and security notes
- bump `tpm-ops` `SRCREV`

## Validation
- verified RAUC streaming install path on target
- verified `ota-updater` polling PoC in non-TPM mode (dry-run)
- verified TPM polling path reaches engine mode and identified current non-interactive key-auth blocker

## Notes
- docs include updated OTA/SECURITY guidance
- follow-up planned for TPM non-interactive auth (engine vs PKCS#11 path)
