### PR TITLE
ota-updater: deterministic config perms + TPM key/cert preflight

### DIFF
--- a/meta-iot-gateway/classes/iotgw-rootfs.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rootfs.bbclass
@@ -147,6 +147,7 @@ ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_mask_rauc_mark_good;"
 iotgw_rootfs_ota_updater_config_perms() {
     cfg="${IMAGE_ROOTFS}/etc/ota/updater.conf"
     grp_file="${IMAGE_ROOTFS}/etc/group"
+    ota_gid=""
 
     [ -e "${cfg}" ] || return 0
 
@@ -154,7 +155,12 @@ iotgw_rootfs_ota_updater_config_perms() {
         bbfatal "Expected ota group in rootfs when ${cfg} is present"
     fi
 
-    chown root:ota "${cfg}"
+    ota_gid="$(awk -F: '/^ota:/{print $3; exit}' "${grp_file}")"
+    if [ -z "${ota_gid}" ]; then
+        bbfatal "Failed to resolve ota group id from ${grp_file}"
+    fi
+
+    chown "root:${ota_gid}" "${cfg}"
     chmod 0640 "${cfg}"
 }
 ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_ota_updater_config_perms;"

--- a/meta-iot-gateway/classes/iotgw-rootfs.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rootfs.bbclass
@@ -141,6 +141,24 @@ iotgw_rootfs_mask_rauc_mark_good() {
 }
 ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_mask_rauc_mark_good;"
 
+###### OTA updater config ownership/mode
+# ota-updater runs as User=ota/Group=ota and needs read access to /etc/ota/updater.conf.
+# Enforce deterministic rootfs permissions here to avoid host-dependent group resolution.
+iotgw_rootfs_ota_updater_config_perms() {
+    cfg="${IMAGE_ROOTFS}/etc/ota/updater.conf"
+    grp_file="${IMAGE_ROOTFS}/etc/group"
+
+    [ -e "${cfg}" ] || return 0
+
+    if [ ! -e "${grp_file}" ] || ! grep -q '^ota:' "${grp_file}"; then
+        bbfatal "Expected ota group in rootfs when ${cfg} is present"
+    fi
+
+    chown root:ota "${cfg}"
+    chmod 0640 "${cfg}"
+}
+ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_ota_updater_config_perms;"
+
 ###### Deterministic build info (/etc/buildinfo)
 iotgw_rootfs_buildinfo() {
     install -d ${IMAGE_ROOTFS}/etc

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
@@ -84,15 +84,23 @@ pubkey_sha256_from_key() {
 pubkey_sha256_from_tpm_handle() {
     local handle="$1"
     local tmp_pub=""
+    local pub_fp=""
+
     tmp_pub="$(mktemp /tmp/ota-tpm-pub.XXXXXX.pem)"
     if ! tpm2_readpublic -c "$handle" -f pem -o "$tmp_pub" >/dev/null 2>&1; then
         rm -f "$tmp_pub"
         return 1
     fi
-    openssl pkey -pubin -in "$tmp_pub" -outform der 2>/dev/null \
+
+    if ! pub_fp="$(openssl pkey -pubin -in "$tmp_pub" -outform der 2>/dev/null \
         | sha256sum 2>/dev/null \
-        | awk '{print $1}'
+        | awk '{print $1}')"; then
+        rm -f "$tmp_pub"
+        return 1
+    fi
+
     rm -f "$tmp_pub"
+    echo "$pub_fp"
 }
 
 validate_engine_key_matches_cert() {
@@ -110,7 +118,7 @@ validate_engine_key_matches_cert() {
         return 0
     fi
 
-    cert_pub="$(pubkey_sha256_from_cert "$cert_path")"
+    cert_pub="$(pubkey_sha256_from_cert "$cert_path" || true)"
     tpm_pub="$(pubkey_sha256_from_tpm_handle "$key_handle" || true)"
     if [[ -z "$cert_pub" || -z "$tpm_pub" ]]; then
         log_warn "Skipping TPM key/cert preflight (could not extract public key fingerprints)"
@@ -329,8 +337,11 @@ fetch_manifest() {
     local rc=0
 
     while [[ "$attempt" -le "$max_attempts" ]]; do
-        manifest="$(fetch_manifest_once 2>&1)"
-        rc=$?
+        if manifest="$(fetch_manifest_once)"; then
+            rc=0
+        else
+            rc=$?
+        fi
 
         if [[ "$rc" -eq 0 ]]; then
             echo "$manifest"
@@ -338,7 +349,6 @@ fetch_manifest() {
         fi
 
         if [[ "$rc" -eq 42 ]]; then
-            [[ -n "$manifest" ]] && echo "$manifest" >&2
             die "TPM key/certificate preflight failed"
         fi
 

--- a/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
+++ b/meta-iot-gateway/recipes-ota/ota-updater/files/ota-update-check.sh
@@ -66,6 +66,73 @@ parse_rauc_progress() {
     echo "$pct|$msg|$depth"
 }
 
+pubkey_sha256_from_cert() {
+    local cert_path="$1"
+    openssl x509 -in "$cert_path" -pubkey -noout 2>/dev/null \
+        | openssl pkey -pubin -outform der 2>/dev/null \
+        | sha256sum 2>/dev/null \
+        | awk '{print $1}'
+}
+
+pubkey_sha256_from_key() {
+    local key_path="$1"
+    openssl pkey -in "$key_path" -pubout -outform der 2>/dev/null \
+        | sha256sum 2>/dev/null \
+        | awk '{print $1}'
+}
+
+pubkey_sha256_from_tpm_handle() {
+    local handle="$1"
+    local tmp_pub=""
+    tmp_pub="$(mktemp /tmp/ota-tpm-pub.XXXXXX.pem)"
+    if ! tpm2_readpublic -c "$handle" -f pem -o "$tmp_pub" >/dev/null 2>&1; then
+        rm -f "$tmp_pub"
+        return 1
+    fi
+    openssl pkey -pubin -in "$tmp_pub" -outform der 2>/dev/null \
+        | sha256sum 2>/dev/null \
+        | awk '{print $1}'
+    rm -f "$tmp_pub"
+}
+
+validate_engine_key_matches_cert() {
+    local cert_path="$1"
+    local key_handle="$2"
+    local cert_pub=""
+    local tpm_pub=""
+    local file_pub=""
+
+    if [[ -z "$cert_path" || ! -f "$cert_path" || -z "$key_handle" ]]; then
+        return 0
+    fi
+
+    if ! command -v openssl >/dev/null 2>&1 || ! command -v tpm2_readpublic >/dev/null 2>&1; then
+        return 0
+    fi
+
+    cert_pub="$(pubkey_sha256_from_cert "$cert_path")"
+    tpm_pub="$(pubkey_sha256_from_tpm_handle "$key_handle" || true)"
+    if [[ -z "$cert_pub" || -z "$tpm_pub" ]]; then
+        log_warn "Skipping TPM key/cert preflight (could not extract public key fingerprints)"
+        return 0
+    fi
+
+    if [[ "$cert_pub" == "$tpm_pub" ]]; then
+        return 0
+    fi
+
+    if [[ -n "${DEVICE_KEY:-}" && -f "${DEVICE_KEY}" ]]; then
+        file_pub="$(pubkey_sha256_from_key "${DEVICE_KEY}" || true)"
+        if [[ -n "$file_pub" && "$file_pub" == "$cert_pub" ]]; then
+            log_error "TPM handle key ($key_handle) does not match ${DEVICE_CERT}; certificate matches ${DEVICE_KEY}. Disable device_key_uri or provision a certificate for TPM key"
+            return 42
+        fi
+    fi
+
+    log_error "TPM handle key ($key_handle) does not match ${DEVICE_CERT}; reprovision certificate for the TPM key handle"
+    return 42
+}
+
 get_system_compatible() {
     local compat=""
     if rauc_dbus_available; then
@@ -187,10 +254,12 @@ fetch_manifest_once() {
         if [[ -n "${key_arg}" ]]; then
             if [[ "${key_arg}" =~ ^handle:(0x[0-9A-Fa-f]+)$ ]]; then
                 key_for_curl="${BASH_REMATCH[1]}"
+                validate_engine_key_matches_cert "${DEVICE_CERT}" "${key_for_curl}" || return $?
                 curl_opts+=(--engine "${DEVICE_KEY_ENGINE}" --key-type ENG --key "${key_for_curl}")
                 key_mode="engine"
             elif [[ "${key_arg}" =~ ^0x[0-9A-Fa-f]+$ ]]; then
                 key_for_curl="${key_arg}"
+                validate_engine_key_matches_cert "${DEVICE_CERT}" "${key_for_curl}" || return $?
                 curl_opts+=(--engine "${DEVICE_KEY_ENGINE}" --key-type ENG --key "${key_for_curl}")
                 key_mode="engine"
             else
@@ -257,11 +326,20 @@ fetch_manifest() {
     local attempt=1
     local max_attempts="$FETCH_RETRIES"
     local manifest=""
+    local rc=0
 
     while [[ "$attempt" -le "$max_attempts" ]]; do
-        if manifest=$(fetch_manifest_once); then
+        manifest="$(fetch_manifest_once 2>&1)"
+        rc=$?
+
+        if [[ "$rc" -eq 0 ]]; then
             echo "$manifest"
             return 0
+        fi
+
+        if [[ "$rc" -eq 42 ]]; then
+            [[ -n "$manifest" ]] && echo "$manifest" >&2
+            die "TPM key/certificate preflight failed"
         fi
 
         log_warn "Fetch manifest failed (attempt ${attempt}/${max_attempts})"


### PR DESCRIPTION
## Summary
- enforce deterministic `/etc/ota/updater.conf` rootfs permissions as `root:ota 0640` via `iotgw-rootfs` postprocess hook
- add updater preflight to compare TPM handle public key vs `device.crt` public key before curl mTLS
- fail fast with explicit diagnostics on deterministic key/cert mismatch (no ambiguous retry loop)

## Why
- target validation showed `ota-updater.service` failed early because `/etc/ota/updater.conf` was unreadable by `User=ota`
- TPM mode failures were opaque (`curl`/engine errors); mismatch now reports actionable root cause

## Validation
- on target, `/etc/ota/updater.conf` now renders as `-rw-r----- root ota`
- `ota-updater.service` starts and reaches updater logic without config permission errors
- with current mismatched TPM handle cert setup, service now fails with explicit message:
  - `TPM handle key (...) does not match /etc/ota/device.crt ...`
  - `TPM key/certificate preflight failed`

## Scope
- intentionally limited to ota-updater reliability/diagnostics
- RAUC 1.15 upgrade + PKCS#11/encrypted-bundle feature lane will follow in a separate PR
