### PR TITLE
docs: refactor OTA/RAUC docs and add OTA provisioning scripts

### DIFF
--- a/docs/OTA_UPDATE.md
+++ b/docs/OTA_UPDATE.md
@@ -2,7 +2,7 @@
 
 # 🔄 RAUC Over-The-Air Updates
 
-**Guide to RAUC A/B rootfs updates and slot rollback behavior**
+**Architecture and design reference for RAUC A/B rootfs updates**
 
 [![RAUC](https://img.shields.io/badge/OTA-RAUC-green.svg)](https://rauc.io/)
 [![Verity](https://img.shields.io/badge/security-dm--verity-blue.svg)](https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/verity.html)
@@ -14,20 +14,18 @@
 
 ## 📖 Overview
 
-This guide covers the OTA update workflow used in this repository on Raspberry Pi 5, including:
-- 🔀 **A/B Rootfs Updates** — Dual-partition update system
-- 🥾 **Boot Asset Updates** — Kernel, DTBs, and U-Boot via bundle hooks
-- 🔙 **Slot Rollback** — Bootchooser-based fallback behavior
-- 🔐 **Signed Bundles** — Cryptographic verification with dm-verity
+The IoT Gateway uses RAUC with an A/B partition layout for atomic,
+rollback-capable system updates. Updates are delivered as signed bundles
+containing a rootfs image and boot assets (kernel, DTBs, U-Boot).
 
-Use this document for architecture and release flow.  
-For on-target operations, preflight, and troubleshooting runbooks, use [RAUC Update Runbook](RAUC_UPDATE.md).
+For on-target operations, preflight, and troubleshooting runbooks, see
+[RAUC Update Runbook](RAUC_UPDATE.md).
 
 ### Update Flow
 
 ```mermaid
 graph LR
-    A[Boot active slot A/B] --> I[Install signed bundle to inactive slot]
+    A[Boot active slot] --> I[Install signed bundle to inactive slot]
     I --> R[Reboot to updated slot]
     R --> H{Health OK?}
     H -->|Yes| G[Mark slot good]
@@ -39,31 +37,9 @@ graph LR
 | Component | Type | Purpose |
 |-----------|------|---------|
 | **Root Filesystem** | A/B (dual ext4) | Only one active at boot |
-| **/boot Partition** | Shared FAT | Firmware, U-Boot, kernel, DTBs |
-| **Bundle Format** | dm-verity | Signed, integrity-protected |
-
----
-
-## 📦 Bundle Contents
-
-RAUC bundles can carry the artifacts needed for a rootfs + boot-asset update flow:
-
-| File | Description |
-|------|-------------|
-| `*.rootfs.ext4` | 🗂️ Root filesystem image for inactive slot |
-| `bootfiles.tar.gz` | 🥾 Boot assets (kernel, DTBs, U-Boot) |
-| `bundle-hooks.sh` | 🪝 Post-install hook script |
-
-### Boot Files Archive
-
-The `bootfiles.tar.gz` includes:
-- `boot.scr` — U-Boot boot script
-- `u-boot.bin` — U-Boot bootloader
-- `Image` — Linux kernel
-- `kernel_2712.img` — Raspberry Pi 5 kernel
-- `bcm2712-rpi-5-b.dtb` — Device Tree Blob
-- `overlays/` — Device Tree overlays
-- `splash.bmp` — Boot splash screen (optional)
+| **/boot Partition** | Shared FAT | FIT images, DTBs, U-Boot, config.txt |
+| **Bundle Format** | dm-verity | Signed, integrity-protected, optionally encrypted |
+| **Bootloader** | U-Boot | Env-based slot selection with bootcount rollback |
 
 ---
 
@@ -74,167 +50,54 @@ sequenceDiagram
     participant T as Target
     participant R as RAUC
     participant U as U-Boot
-    participant Hook as Hook Script
+    participant Hook as Bundle Hook
     participant Boot as /boot
-    participant Kernel as Kernel
-    participant RootfsB as RootFS B
 
     T->>R: iotgw-rauc-install bundle.raucb
     R->>R: Verify signature + mount verity
-    R->>RootfsB: Write rootfs.ext4 to inactive slot
-    R->>RootfsB: Mount new slot read-only
-    R->>Hook: Run slot-post-install bundle-hooks.sh
-    Hook->>Boot: Copy boot.scr, Image, DTBs, overlays if changed
-    R->>U: Set bootchooser activate Slot B
+    R->>R: Write rootfs to inactive slot
+    R->>Hook: Run slot-post-install hook
+    Hook->>Boot: Update FIT image, DTBs, overlays if changed
+    Hook->>Hook: Run overlay reconciliation
+    R->>U: Activate inactive slot (fw_setenv BOOT_ORDER)
     T->>T: Reboot
-    U->>Kernel: Load kernel/DTBs from /boot
-    Kernel->>RootfsB: Boot with rauc.slot=B
-    T->>R: Mark good auto service or rollback on failure
+    U->>U: Select slot, decrement boot counter
+    Note over T: Mark good on healthy boot, rollback otherwise
 ```
 
 ### Key Properties
 
 ✅ **Synchronized Update Path** — Bundle hook updates `/boot` in the same install transaction
-✅ **Ordered Installation** — Hook runs after rootfs write, before reboot
-✅ **Read-only Verification** — New slot mounted read-only during update
+✅ **Per-Slot FIT Naming** — Each slot writes its own kernel (`fitImage-a` / `fitImage-b`) on the shared boot partition
+✅ **Overlay Reconciliation** — Post-install hook manages `/etc` overlay entries according to policy
 
 ---
 
 ## 🔙 Rollback Behavior
 
-RAUC's bootchooser provides automatic failsafe:
+RAUC's bootchooser provides automatic failsafe via U-Boot bootcount:
 
 | Scenario | Behavior |
 |----------|----------|
-| **Boot Success** | New slot marked good, becomes default |
-| **Boot Failure** | Bootchooser fallback after configured retry budget |
-| **Health Check Fail** | Manual or auto rollback via `rauc status` |
+| **Boot Success** | `rauc-mark-good` marks slot, becomes default |
+| **Boot Failure** | Bootcount exhausted → U-Boot falls back to previous slot |
+| **Explicit Rollback** | `rauc mark-active other && reboot` |
 
-### Important Considerations
+### ⚠️ Important
 
-> ⚠️ **Shared /boot Partition**: Kernel/DTBs copied by the hook remain after rollback
-
-**Design Implications:**
-- Keep kernel ABI compatible across releases
-- Test kernel updates thoroughly before deployment
-- Advanced option: Stage bootfiles in rootfs, copy only after marking good
-
-### Rollback Commands
-
-```bash
-# Mark current slot as bad (triggers rollback on next boot)
-rauc mark-bad booted
-reboot
-
-# Or mark the other slot as active
-rauc mark-active other
-reboot
-```
-
----
-
-## 🛠️ Building Bundles
-
-### Bundle Types
-
-| Bundle Type | Target | Updates | Output File |
-|-------------|--------|---------|-------------|
-| **Rootfs Only** | Faster updates | Rootfs only | `iot-gw-bundle.raucb` |
-| **Full System** | Rootfs + boot assets | Rootfs + Kernel + DTBs | `iot-gw-bundle-full.raucb` |
-
-#### Build Commands
-
-<table>
-<tr><th>Rootfs Only</th><th>Rootfs + Kernel</th></tr>
-<tr>
-<td>
-
-```bash
-# Development
-make bundle-dev
-
-# Standard
-make bundle
-
-# Production
-make bundle-prod
-```
-
-</td>
-<td>
-
-```bash
-# Development
-make bundle-dev-full
-
-# Standard
-make bundle-full
-
-# Production
-make bundle-prod-full
-```
-
-</td>
-</tr>
-</table>
-
-> 💡 **Note**: Bundle filename is based on the recipe name, not the image variant. Makefile handles variant selection via `BUNDLE_IMAGE_NAME`.
-
----
-
-## ✅ Verification & Deployment
-
-### 1. Verify Bundle (Optional)
-
-```bash
-# Verify signature and contents
-oe-run-native rauc-native rauc info \
-  --keyring meta-iot-gateway/recipes-ota/rauc/files/dev-cert.pem \
-  build/tmp/deploy/images/raspberrypi5/iot-gw-bundle-full.raucb
-```
-
-### 2. Deploy to Device
-
-```bash
-# Copy bundle to target
-scp build/tmp/deploy/images/raspberrypi5/iot-gw-bundle-full.raucb \
-  root@device:/tmp/
-
-# Install (wrapper handles temporary /boot rw remount + restore to ro)
-ssh root@device 'iotgw-rauc-install /tmp/iot-gw-bundle-full.raucb && reboot'
-```
-
-### 3. Verify Update
-
-```bash
-# Check RAUC status
-rauc status --detailed
-
-# Review installation logs
-journalctl -u rauc -b | grep "\[bundle-hook\]"
-```
-
----
-
-## 📁 Implementation Files
-
-| Component | Path |
-|-----------|------|
-| **Bundle Recipes** | `meta-iot-gateway/recipes-ota/bundles/*.bb` |
-| **Common Config** | `meta-iot-gateway/recipes-ota/bundles/iot-gw-bundle-common.inc` |
-| **Hook Script** | `meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks.sh` |
-| **Bootfiles Archive** | `meta-iot-gateway/recipes-bsp/bootimage/rpi-bootfiles-archive.bb` |
-| **RAUC Config** | `meta-iot-gateway/recipes-ota/rauc/rauc-conf.bb` |
+> The `/boot` partition is **not A/B**. Kernel and DTB updates are applied in-place by the bundle hook. On rollback, the rootfs reverts but boot assets remain. This requires kernel ABI compatibility across releases.
 
 ---
 
 ## 🔐 Security
 
-| Feature | Implementation |
-|---------|----------------|
-| **Bundle Signing** | Cryptographic signatures verified on-device |
-| **Integrity Protection** | dm-verity format for tamper detection |
-| **Boot Integrity Chain** | U-Boot FIT verification + signed RAUC bundles |
+| Feature | Description |
+|---------|-------------|
+| **Bundle Signing** | Cryptographic signatures verified on-device before installation |
+| **Integrity Protection** | dm-verity format provides tamper detection |
+| **Boot Integrity Chain** | U-Boot FIT signature verification + signed RAUC bundles |
+| **Bundle Encryption** | Optional `crypt` format with per-device decryption key |
+| **mTLS Streaming** | Device identity verified via client certificate |
 
 ---
 
@@ -242,11 +105,9 @@ journalctl -u rauc -b | grep "\[bundle-hook\]"
 
 RAUC supports installing bundles directly over HTTPS without pre-downloading to local storage. This uses streaming mode (NBD + HTTP range requests) with mutual TLS authentication.
 
-### ✅ What This Enables
-
-- **Native streaming install**: `iotgw-rauc-install https://<server>:8443/bundles/<bundle>.raucb`
-- **Device tracking** via headers sent by RAUC (boot-id, machine-id, transaction-id)
-- **mTLS auth** using device certificates provisioned on the gateway
+- 📡 **Native streaming**: `iotgw-rauc-install https://<server>:8443/bundles/<bundle>.raucb`
+- 🏷️ **Device tracking** via RAUC headers (boot-id, machine-id, transaction-id)
+- 🔑 **mTLS auth** using device certificates provisioned on the gateway
 
 ### 🔧 Device Configuration
 
@@ -269,34 +130,35 @@ Device certs are provisioned by `ota-certs-provision`:
 
 Server cert must include a SAN matching the OTA server IP/hostname.
 
-### First boot after fresh flash
+### 🆕 First Boot After Fresh Flash
 
-After flashing a new SD card image, the OTA certificate and TPM PKCS#11
-state must be (re-)provisioned before `rauc install` or streaming updates
-will work. This is expected — the data partition is blank and the overlay
-`/etc/ota` directory contains only build-time files (CA cert,
-`openssl-tpm2.cnf`, `updater.conf`), not per-device credentials.
+After flashing a new SD card image, OTA certificate and TPM PKCS#11
+state must be (re-)provisioned before streaming updates will work. This
+is expected — the data partition is blank and `/etc/ota` contains only
+build-time files (CA cert, `openssl-tpm2.cnf`, `updater.conf`).
 
 **Provisioning steps:**
 
 1. **Sync device certs** (from host):
    ```bash
-   ./scripts/ota-certs-sync.sh          # uploads ca/device cert+key to /data/ota/certs/
+   ./scripts/ota-certs-sync.sh
    ```
-2. **Reboot** so the `/etc` overlay mounts cleanly with the new upper-dir files.
+2. **Reboot** so the `/etc` overlay mounts cleanly with new files.
 3. **Verify** cert chain on target:
    ```bash
    openssl verify -CAfile /etc/ota/ca.crt /etc/ota/device.crt
    ```
-4. **(If TPM/PKCS#11 enabled)** Re-provision the TPM2 PKCS#11 token and PIN:
+4. **(If TPM/PKCS#11 enabled)** Re-provision the TPM2 PKCS#11 token:
    ```bash
-   ./scripts/ota-pkcs11-provision-check.sh   # shows status and next steps
+   ./scripts/ota-pkcs11-provision-check.sh
    ```
 
-Until step 2 completes, `ota-certs-provision.service` will fail — this is
-harmless and self-resolves after the reboot with certs in place.
+Until step 2 completes, `ota-certs-provision.service` will log a
+degraded-mode warning — this is harmless and self-resolves after reboot.
 
-### TPM-backed client key (OTA updater manifest polling)
+---
+
+## 🔑 TPM-Backed Client Key
 
 `ota-update-check` can use a TPM-backed OpenSSL key URI instead of a filesystem
 private key. Configure `/etc/ota/updater.conf`:
@@ -314,50 +176,54 @@ Notes:
 - `device_key_uri` takes precedence over `device_key`.
 - TPM mode is build-gated by `IOTGW_ENABLE_OTA_TPM_MTLS = "1"` (default `0`,
   preserving non-TPM file-key flow).
-- On current gateway curl builds (`--key-type` supports `ENG`, not `PROV`), TPM
-  handles are used via OpenSSL engine mode (`tpm2tss`) when
-  `device_key_uri` is `handle:0x...`.
-- `openssl_conf` remains optional for provider-based tooling and future curl
-  builds with provider key support.
+- Current curl builds use OpenSSL engine mode (`tpm2tss`) for TPM handles.
+  Provider-based key support is deferred to future curl builds.
 - With TPM mode enabled, `ota-updater.service` gets supplementary `iotgwtpm`
   group access for `/dev/tpmrm0`.
 
-### Feature-Gating Matrix (Verity / TPM / PKCS#11 / Encrypted Bundles)
+---
+
+## ⚙️ Feature-Gating Profiles
 
 All advanced OTA paths are opt-in. Default remains `verity + file-key`.
 
-| Profile | `IOTGW_ENABLE_OTA_TPM_MTLS` | `IOTGW_RAUC_STREAMING_KEY_MODE` | `IOTGW_RAUC_PKCS11_BACKEND` | `IOTGW_ENABLE_RAUC_BUNDLE_ENCRYPTION` | Result |
-|--------|---|---|---|---|---|
-| **Baseline (default)** | `0` | `file` | `-` | `0` | Verity bundle, file-key mTLS, no TPM requirement |
-| **Updater TPM only** | `1` | `file` | `-` | `0` | `ota-updater` uses TPM key URI; RAUC streaming still uses file key |
-| **RAUC PKCS#11 (custom provider)** | `0` | `pkcs11` | `custom` | `0` | RAUC streaming uses `tls-key=pkcs11:...` without TPM |
-| **RAUC PKCS#11 (TPM2 backend)** | `0` | `pkcs11` | `tpm2` | `0` | RAUC streaming uses TPM2-backed PKCS#11 token/object |
-| **Encrypted bundle only** | `0` | `file` | `-` | `1` | `crypt` bundle + `[encryption]` in `system.conf`; no TPM required |
-| **Full TPM + PKCS#11 + crypt** | `1` | `pkcs11` | `tpm2` | `1` | TPM updater path + TPM2 PKCS#11 RAUC streaming + encrypted bundles |
+**Baseline (default)** — no additional variables required.
+Verity bundle, file-key mTLS, no TPM.
 
-Required companion variables when enabling feature gates:
+**Updater TPM only** — `ota-updater` uses a TPM key URI for manifest
+polling; RAUC streaming still uses the file key.
+```
+IOTGW_ENABLE_OTA_TPM_MTLS = "1"
+IOTGW_OTA_TPM_KEY_URI     = "handle:0x81000001"
+IOTGW_OTA_TPM_KEY_ENGINE  = "tpm2tss"
+```
 
-- `IOTGW_RAUC_STREAMING_KEY_MODE = "pkcs11"`:
-  - `IOTGW_RAUC_PKCS11_BACKEND` (`tpm2` or `custom`)
-  - `IOTGW_RAUC_PKCS11_TLS_KEY` (for example `pkcs11:token=iotgw;object=rauc-client-key;type=private;pin-source=file:/etc/ota/pkcs11-pin`)
-  - provision token/object for the selected backend (`tpm2` requires `IOTGW_TPM2_PKCS11_STORE` as needed)
-- `IOTGW_ENABLE_RAUC_BUNDLE_ENCRYPTION = "1"`:
-  - `IOTGW_RAUC_BUNDLE_ENCRYPT_RECIPIENTS`
-  - `IOTGW_RAUC_ENCRYPTION_KEY` (optional `IOTGW_RAUC_ENCRYPTION_CERT`)
-- `IOTGW_ENABLE_OTA_TPM_MTLS = "1"`:
-  - `IOTGW_OTA_TPM_KEY_URI`
-  - `IOTGW_OTA_TPM_KEY_ENGINE`
-  - optional `IOTGW_OTA_OPENSSL_CONF`
+**RAUC PKCS#11 streaming** — RAUC streaming authenticates via a PKCS#11
+token. Backend is `tpm2` (hardware-backed) or `custom` (software token).
+```
+IOTGW_RAUC_STREAMING_KEY_MODE = "pkcs11"
+IOTGW_RAUC_PKCS11_BACKEND    = "tpm2"
+IOTGW_RAUC_PKCS11_TLS_KEY    = "pkcs11:token=iotgw;object=rauc-client-key;type=private;pin-source=file:/etc/ota/pkcs11-pin"
+```
 
-Important compatibility notes:
+**Encrypted bundles** — RAUC `crypt` format with per-device decryption
+key. Independent of streaming key mode.
+```
+IOTGW_ENABLE_RAUC_BUNDLE_ENCRYPTION = "1"
+IOTGW_RAUC_BUNDLE_ENCRYPT_RECIPIENTS = "/path/to/device-filekey.crt"
+IOTGW_RAUC_ENCRYPTION_KEY            = "/etc/ota/device.key"
+```
 
-- PKCS#11 streaming and encrypted bundle decryption are independent.
-- To return to classic verity/non-TPM behavior, set:
-  - `IOTGW_ENABLE_OTA_TPM_MTLS = "0"`
-  - `IOTGW_RAUC_STREAMING_KEY_MODE = "file"`
-  - `IOTGW_ENABLE_RAUC_BUNDLE_ENCRYPTION = "0"`
+**Full TPM + PKCS#11 + crypt** — combines all three. Set all variables
+from the profiles above.
 
-### Security Note: PKCS#11 PIN Handling
+> 💡 **Compatibility notes:**
+> - PKCS#11 streaming and encrypted bundle decryption are independent.
+> - To return to baseline: set `IOTGW_ENABLE_OTA_TPM_MTLS = "0"`,
+>   `IOTGW_RAUC_STREAMING_KEY_MODE = "file"`, and
+>   `IOTGW_ENABLE_RAUC_BUNDLE_ENCRYPTION = "0"`.
+
+### 🔒 PKCS#11 PIN Handling
 
 - Prefer `pin-source=file:/etc/ota/pkcs11-pin` over inline `pin-value`.
 - Keep `/etc/ota/pkcs11-pin` permission-restricted (`root:ota 0640`).
@@ -366,40 +232,28 @@ Important compatibility notes:
 
 ---
 
-## ⚠️ Limitations & Considerations
+## ⚠️ Design Considerations
 
-### Current Design
+**Shared /boot partition** — kernel and DTB updates are applied in-place
+by the bundle hook. On rollback, the rootfs reverts but boot assets
+remain. Maintain kernel ABI compatibility across releases.
 
-| Aspect | Behavior |
-|--------|----------|
-| **/boot Partition** | ❌ Not A/B — updates applied in-place |
-| **Kernel Updates** | Applied immediately via hook |
-| **Rollback** | Rootfs rolls back, kernel/DTBs remain |
+**Overlay reconciliation** — OTA updates trigger the overlay reconciler
+which manages `/etc` overlay entries according to policy (`enforce`,
+`replace_if_unmodified`, `preserve`, `absent`). See
+[Overlay Reconciliation](OVERLAY_RECONCILIATION.md).
 
-### Recommendations
-
-- ✅ Maintain kernel ABI compatibility between releases
-- ✅ Test kernel updates in development environment
-- ⚠️ For fully failsafe boot: Consider GPT/MBR boot slot switching
-
-### Advanced Option (Future)
-
-Stage bootfiles in rootfs → Copy to `/boot` only after successful boot + health check → Fully transactional kernel updates
-
----
-
-## 🔧 Troubleshooting
-
-Common troubleshooting areas include:
-- wrapper/systemd-run behavior
-- fw_env and slot switching failures
-- streaming TLS/CA consistency checks
-- adaptive update alignment checks
+**Future: transactional boot updates** — stage boot assets in rootfs,
+copy to `/boot` only after successful boot and health check, enabling
+fully atomic kernel updates.
 
 ---
 
 ## 📚 References
 
+- [RAUC Update Runbook](RAUC_UPDATE.md) — on-target operations and troubleshooting
+- [U-Boot Hardening](UBOOT_HARDENING.md) — bootloader hardening and env-based slot selection
+- [Partition Layouts](PARTITIONS.md) — A/B partition sizing
+- [Overlay Reconciliation](OVERLAY_RECONCILIATION.md) — post-OTA config management
 - [RAUC Documentation](https://rauc.readthedocs.io/)
-- [U-Boot Bootchooser](https://rauc.readthedocs.io/en/latest/integration.html#u-boot)
 - [dm-verity](https://www.kernel.org/doc/html/latest/admin-guide/device-mapper/verity.html)

--- a/docs/RAUC_UPDATE.md
+++ b/docs/RAUC_UPDATE.md
@@ -1,312 +1,163 @@
-# RAUC Update Guide
+<div align="center">
 
-This runbook covers installing and validating RAUC A/B bundle updates.
+# 🛠️ RAUC Update Runbook
 
-Use this document for on-target operations, validation, and troubleshooting.  
-For OTA architecture, bundle composition, and release flow, see [OTA Updates](OTA_UPDATE.md).
+**On-target operations, validation, and troubleshooting**
 
-## Mark-Good and Cleanup Flow
+</div>
 
-This image uses upstream RAUC mark-good semantics and a separate cleanup
-oneshot for boot backup artifacts.
+For architecture and design, see [OTA Updates](OTA_UPDATE.md).
 
-```bash
-systemctl status rauc-mark-good.service
-systemctl status boot-backup-prune.service
-```
+---
 
-Current defaults:
+## 📦 Installing a Bundle
 
-- mark-good: `rauc-mark-good.service` (upstream RAUC)
-- cleanup: `boot-backup-prune.service` runs after mark-good
-- cleanup prunes old `/boot/*.bak*` artifacts and keeps recent backups
-
-## Overlay Policy for systemd Masks
-
-For unit disable/mask policy on this gateway OS, use a two-layer approach:
-
-1. Build-time rootfs masks in `iotgw-rootfs.bbclass` establish desired state in
-   each slot image (`/etc/systemd/system/*.service -> /dev/null` symlinks).
-2. RAUC overlay reconciliation enforces the same paths in `/etc` upper layer so
-   stale runtime overlay entries cannot override the new slot policy.
-
-Rationale:
-
-- `/etc` is overlay-backed at runtime.
-- A/B slot content alone is not sufficient if upper-layer entries from older
-  slots still exist.
-- Preset-based `disable` rules are not deterministic in this Yocto flow
-  (`preset-all --preset-mode=enable-only`).
-
-This policy is used for NetworkManager-only networking mode to keep
-`systemd-networkd*` and wait-online units from reappearing after OTA.
-
-Overlay reconciliation implementation notes:
-
-- Hook tool: `/usr/libexec/rauc/overlay-reconcile.py` (Python 3)
-- Hook stages:
-  - `pre`: writes transaction metadata to `/data/iotgw/overlay-reconcile/txn.json`
-  - `post`: applies managed-path policy using the newly written slot content
-- State path: `/data/iotgw/overlay-reconcile/`
-  - `state.tsv` (hash baseline for `replace_if_unmodified`)
-  - `txn.json` (last transaction status/summary)
-  - `backups/` (removed upper-layer entries)
-- Policy manifest sources in target slot:
-  - `/usr/share/iotgw/overlay-reconcile/managed-paths.conf`
-  - `/usr/share/iotgw/overlay-reconcile/managed-paths.d/*.conf`
-- Supported policies: `enforce`, `replace_if_unmodified`, `preserve`, `absent`, `enforce_meta`.
-  - `enforce_meta` is used for security-sensitive metadata drift fixes (e.g.
-    mosquitto auth files ownership/mode).
-
-For full architecture, policy tradeoffs, and data-flow diagram, see:
-- [Overlay Reconciliation](OVERLAY_RECONCILIATION.md)
-
-## Install Bundle
-
-Manual install workflow (recommended):
+### Local install
 
 ```bash
 iotgw-rauc-install <bundle>.raucb
 ```
 
-HTTPS streaming install (manual, recommended for OTA server flow):
+### HTTPS streaming install
 
 ```bash
 iotgw-rauc-install https://<ota-host>:8443/bundles/<bundle>.raucb
 ```
 
-HTTPS streaming install with explicit TLS profile selection:
+The wrapper handles `systemd-run` dispatch, OTA certificate
+reconciliation, preflight connectivity check, and temporary `/boot`
+rw remount. Use `--direct` to skip `systemd-run` dispatch (debug only).
 
-```bash
-iotgw-rauc-install --tls-profile system https://<ota-host>:8443/bundles/<bundle>.raucb
-iotgw-rauc-install --tls-profile data https://<ota-host>:8443/bundles/<bundle>.raucb
-```
-
-Optional preflight fallback (download first, then local install):
-
-```bash
-iotgw-rauc-install --fallback-download https://<ota-host>:8443/bundles/<bundle>.raucb
-```
-
-Behavior notes:
-
-- default path: wrapper dispatches through `systemd-run` to execute from system
-  manager context (recommended on hardened systems)
-- fallback path: direct execution (`--direct` or `--no-systemd-run`) for debug
-  only
-- wrapper preflight stages for HTTPS URLs: `resolve`, `user-check`, `tls-files`,
-  `connect`, `tls-verify`
-- unsafe debug flags are gated by `--debug-unsafe` and are audit-logged
-
-D-Bus access model (current):
-
-- RAUC installs the D-Bus policy shipped by the `rauc` package:
-  `/usr/share/dbus-1/system.d/de.pengutronix.rauc.conf`.
-- Service activation is system-owned via:
-  `/usr/share/dbus-1/system-services/de.pengutronix.rauc.service`.
-- Operational entry points in this project remain:
-  `iotgw-rauc-install`, `rauc status`, and `rauc-mark-good.service`.
-
-Track progress:
+### 📋 Track progress
 
 ```bash
 journalctl --no-pager -fu rauc
-```
-
-Audit wrapper events (/boot rw window + restore):
-
-```bash
 journalctl --no-pager -t iotgw-rauc-install
 ```
 
-### Streaming Preflight (mTLS)
+---
 
-Before remote installs, verify cert chain and manifest reachability:
+## ✅ Checking Slot State
 
 ```bash
+rauc status
+```
+
+After a successful install + reboot:
+- ✅ System boots from the updated slot
+- ✅ `rauc-mark-good.service` marks it as good
+- ✅ `boot-backup-prune.service` cleans up old `/boot/*.bak*` artifacts
+
+---
+
+## 🌐 Streaming Preflight (mTLS)
+
+Before remote installs, verify the cert chain and server reachability:
+
+```bash
+# Verify device cert chain
 openssl verify -CAfile /etc/ota/ca.crt /etc/ota/device.crt
+
+# Test manifest endpoint
 curl --cert /etc/ota/device.crt \
      --key /etc/ota/device.key \
      --cacert /etc/ota/ca.crt \
      -fsS https://<ota-host>:8443/api/v1/manifest.json | jq .
 ```
 
-Then install the exact `bundle_url` from the manifest.
+> 💡 If mDNS hostname (`ota-gw.local`) is not resolvable, use the server IP. Ensure the server certificate SAN matches the URL host.
 
-Notes:
+---
 
-- If mDNS hostname (`ota-gw.local`) is not resolvable on your LAN, use the
-  server IP in the install URL for manual testing.
-- Ensure the server certificate SAN matches the URL host you use (DNS name or IP).
+## ⚙️ U-Boot Environment Controls
 
-## Check Slot State
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `iotgw_appliance` | `1` | Appliance fast-path in board init |
+| `iotgw_enable_netboot` | `0` | Enable netboot network path |
+| `iotgw_diag` | `0` | Print RAUC vars + MMC info at boot |
+| `iotgw_bootstage` | `1` | Print bootstage timing on serial |
+
+On dev builds, toggle at the U-Boot prompt (type `igw` during the 2s
+autoboot window). On prod builds (`appliance_lockdown`), appliance
+variables are read-only — see [U-Boot Hardening](UBOOT_HARDENING.md).
 
 ```bash
-rauc status
+# Enable field diagnostics
+fw_setenv iotgw_diag 1
+
+# Restore defaults
+fw_setenv iotgw_appliance 1
+fw_setenv iotgw_enable_netboot 0
+fw_setenv iotgw_diag 0
+fw_setenv iotgw_bootstage 1
 ```
 
-Expected:
+---
 
-- inactive slot is written during install
-- target slot is marked active after install
-- after reboot, system boots from the updated slot
+## 📐 Adaptive Updates (block-hash-index)
 
-## Adaptive Update (block-hash-index)
+When enabled (`IOTGW_RAUC_ADAPTIVE = "1"`), RAUC uses block-hash-index
+mode requiring rootfs slot sizes to be 4 KiB aligned. Build-time guards
+validate alignment automatically.
 
-If enabled (`RAUC_SLOT_rootfs[adaptive] = "block-hash-index"`), RAUC requires
-target rootfs slot sizes to be 4 KiB aligned.
-
-Build-time guard:
-
-- implemented in reusable class:
-  `meta-iot-gateway/classes/iotgw-rauc-adaptive-guard.bbclass`
-- when `IOTGW_RAUC_ADAPTIVE = "1"`, the class task validates IoT Gateway RAUC
-  WKS root slot geometry (`rootA` and `rootB` `--fixed-size`) is a 4096-byte
-  multiple
-- build fails early if either adaptive root slot is missing or misaligned
-- image build also validates generated WIC partition geometry via
-  `do_iotgw_validate_wic_alignment` in
-  `meta-iot-gateway/classes/iotgw-rauc-image.bbclass`
-
-If not aligned, RAUC logs an adaptive mode error and falls back to normal full
-write, for example:
-
-```text
-Continuing after adaptive mode error: ... image/partition size (...) is not a multiple of 4096 bytes
-```
-
-### Verify Slot Alignment (target)
+### Verify slot alignment
 
 ```bash
 for p in /dev/mmcblk0p3 /dev/mmcblk0p4; do
   s=$(blockdev --getsize64 "$p")
   echo "$p size=$s mod4096=$((s%4096))"
 done
+# Expected: mod4096=0 for both slots
 ```
 
-Requirement:
+> ⚠️ If deployed devices have non-aligned partitions, keep adaptive mode disabled until they are reflashed.
 
-- `mod4096=0` for all adaptive rootfs slots
+---
 
-## U-Boot Fast-Boot and Diagnostics Controls
+## 🔧 Troubleshooting
 
-This project now uses explicit U-Boot environment controls to keep normal
-boots fast while preserving OTA diagnostics capability.
+### fw_setenv failures
 
-Defaults are set in the boot script:
-
-- `iotgw_appliance=1`
-- `iotgw_enable_netboot=0`
-- `iotgw_diag=0` (unset by default)
-- `iotgw_bootstage=1`
-
-Behavior:
-
-- `iotgw_appliance=1`: appliance fast-path in U-Boot board init
-- `iotgw_enable_netboot=1`: enable netboot-related network path in board init
-- `iotgw_diag=1`: print extra boot diagnostics (RAUC vars + MMC info) at boot
-- `iotgw_bootstage=1`: print U-Boot bootstage timing report on serial
-
-Bootstage build profile in this layer:
-
-- `CONFIG_BOOTSTAGE=y`
-- `CONFIG_CMD_BOOTSTAGE=y`
-- `CONFIG_BOOTSTAGE_RECORD_COUNT=100`
-- `CONFIG_BOOTSTAGE_FDT=y` (timing data available in device tree)
-- `CONFIG_BOOTSTAGE_STASH=n` (not enabled until a safe reserved memory address is defined for RPi5)
-
-Examples on target (U-Boot prompt):
+If install fails with `Failed to run fw_setenv: Child process exited with code 247`:
 
 ```bash
-# Enable one-shot/full diagnostics for field debugging
-setenv iotgw_diag 1
-saveenv
-
-# Re-enable full board-init path (disable appliance fast-path)
-setenv iotgw_appliance 0
-saveenv
-
-# Allow netboot-related initialization
-setenv iotgw_enable_netboot 1
-saveenv
-
-# Enable U-Boot bootstage timing report
-setenv iotgw_bootstage 1
-saveenv
-```
-
-Restore production defaults:
-
-```bash
-setenv iotgw_appliance 1
-setenv iotgw_enable_netboot 0
-setenv iotgw_diag 0
-setenv iotgw_bootstage 1
-saveenv
-```
-
-## Troubleshooting
-
-If install fails early with:
-
-```text
-Failed marking slot ... as bad/good: uboot backend: Failed to run fw_setenv: Child process exited with code 247
-```
-
-Check:
-
-```bash
-findmnt -no SOURCE,TARGET,FSTYPE,OPTIONS /boot
 findmnt -no SOURCE,TARGET,FSTYPE,OPTIONS /uboot-env
 head -n1 /etc/fw_env.config
-fw_printenv
-fw_setenv iotgw_test 2
+fw_printenv BOOT_ORDER
 ```
 
-Typical causes:
+Check that `/uboot-env` is mounted rw and `fw_env.config` has a single
+entry matching U-Boot's env configuration.
 
-- legacy layout: `/boot` is mounted read-only while RAUC needs to update
-  `/boot/uboot.env`
-- dedicated-env layout: `/uboot-env` is unavailable while RAUC needs to update
-  `/uboot-env/uboot.env`
+### Stale overlay masks
 
-Use the wrapper command for manual installs:
+If `rauc-mark-good.service` appears masked after update:
 
 ```bash
-iotgw-rauc-install <bundle>.raucb
+ls -la /data/overlays/etc/upper/systemd/system/rauc-mark-good.service
+journalctl -b -t rauc | grep overlay-reconcile
 ```
 
-For low-level debugging (skip systemd-run dispatch):
+The overlay reconciler removes these via the `absent` policy in
+`managed-paths.conf`.
 
-```bash
-iotgw-rauc-install --direct <bundle>.raucb
-```
+### mTLS CA mismatch
 
-If `rauc-mark-good.service` unexpectedly appears masked after update, check for
-stale overlay masks in `/data/overlays/etc/upper/systemd/system/`.
-
-### OTA mTLS CA Consistency
-
-If streaming installs fail with TLS issuer/chain errors, verify the OTA CA used
-by the server matches the device trust chain:
+If streaming installs fail with TLS chain errors:
 
 ```bash
 openssl verify -CAfile /etc/ota/ca.crt /etc/ota/device.crt
 openssl x509 -in /etc/ota/ca.crt -noout -subject -fingerprint -sha256
 ```
 
-For build-time alignment, set:
+Ensure `RAUC_OTA_CA_DIR` in `kas/local.yml` matches the OTA server's CA.
 
-```bash
-RAUC_OTA_CA_DIR = "/path/to/ota-dev-ca"
-```
+---
 
-The `ota-certs` recipe accepts either `ca.crt/ca.key` or
-`dev-ca.crt/dev-ca.key` in `RAUC_OTA_CA_DIR` and seeds `/etc/ota/ca.crt`.
+## 📚 References
 
-### What To Do If Misaligned
-
-- Fix `WKS_FILE` so `rootA` and `rootB` use aligned `--fixed-size` values.
-- Rebuild the bundle with adaptive mode enabled and confirm the gate passes.
-- If deployed devices are already on a non-aligned partition layout, keep
-  adaptive mode disabled for those devices until they are reflashed.
+- [OTA Updates](OTA_UPDATE.md) — architecture, feature-gating profiles
+- [U-Boot Hardening](UBOOT_HARDENING.md) — env lockdown, boot flow
+- [Overlay Reconciliation](OVERLAY_RECONCILIATION.md) — post-OTA config management
+- [Partition Layouts](PARTITIONS.md) — slot sizing and alignment

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -87,23 +87,6 @@ Every new or modified service should be reviewed for:
 - Syscall and namespace restrictions when compatible
 - Secret handling path (no secrets in image defaults; avoid argv leaks)
 
-## Public vs Private Documentation Policy
-
-Use `docs/` for:
-- Architecture and control objectives
-- Threat categories, boundaries, and mitigations
-- Non-sensitive operational guidance
-
-Use private/internal notes (not committed) for:
-- Incident details, exploit hypotheses, and live debugging artifacts
-- Temporary risk acceptance notes
-- Sensitive assumptions not ready for publication
-
-Promotion rule:
-- Start in private/internal notes when uncertain.
-- Promote to `docs/` after sanitization and validation.
-- Keep sensitive values, hostnames, private endpoints, and exploit specifics out of `docs/`.
-
 ## Current Focus Areas
 
 1. Credential lifecycle hardening across all services.

--- a/docs/UBOOT_HARDENING.md
+++ b/docs/UBOOT_HARDENING.md
@@ -69,7 +69,9 @@ Fragments give policy flexibility without touching the base.
 | `iot-gw-image-prod` | `surface_reduce fit_enforce appliance_lockdown` | `-2` (no interactive window) |
 
 The `IOTGW_UBOOT_BOOTDELAY` variable handles the meta-raspberrypi
-BOOTDELAY override (see [Constraints](#constraints) below).
+BOOTDELAY override — meta-raspberrypi forces `-2` via
+`do_configure:append`; our layer counteracts with a higher-priority
+append that restores `2` for dev and keeps `-2` for prod.
 
 ---
 
@@ -181,41 +183,6 @@ diagnostic pointing to the key ceremony procedure.
 
 ---
 
-## Constraints
-
-### meta-raspberrypi BOOTDELAY override
-
-meta-raspberrypi's `u-boot_%.bbappend` forces `CONFIG_BOOTDELAY=-2` via
-`do_configure:append:raspberrypi5()` to work around a U-Boot hang when
-no debug UART is connected
-([opensuse#1251192](https://bugzilla.opensuse.org/show_bug.cgi?id=1251192)).
-
-Our layer counteracts this with `IOTGW_UBOOT_BOOTDELAY`, set via a
-higher-priority `do_configure:append:raspberrypi5()` that runs after
-meta-raspberrypi's. Dev builds restore `BOOTDELAY=2`; prod builds
-(with `appliance_lockdown`) keep `-2`.
-
-### meta-rauc-community squashfs patch
-
-The `rpi_arm64_defconfig.patch` from meta-rauc-community applies before
-our defconfig patch, adding squashfs support. Our `0003` patch was
-generated against the post-squashfs state. On U-Boot version bumps,
-regenerate via the devtool workflow documented in the
-[defconfig regeneration](#defconfig-regeneration) section.
-
-### Single env file
-
-U-Boot is configured with `CONFIG_ENV_IS_IN_FAT=y` pointing to a single
-file (`uboot.env` on partition `0:2`). Redundant environment
-(`CONFIG_SYS_REDUNDAND_ENVIRONMENT`) is explicitly disabled. The
-`fw_env.config` on the target must have a single entry matching this.
-
-The overlay reconciler enforces this via `managed-paths.conf` to ensure
-OTA updates from older images (which may have had a two-line config)
-correctly replace the stale overlay entry.
-
----
-
 ## Explicit deferrals
 
 These items were evaluated and deliberately excluded:
@@ -227,22 +194,6 @@ These items were evaluated and deliberately excluded:
 | Measured boot (PCR extend in U-Boot) | TPM SPI access requires PCIe/RP1 driver chain not upstream in U-Boot |
 | UEFI Secure Boot via EDK2 | Inappropriate for appliance-class gateway; adds complexity without security benefit |
 | ECDSA FIT signing | RPi5 U-Boot `UCLASS_ECDSA` verify backend not validated; RSA-2048 is the supported path |
-
----
-
-## File map
-
-| File | Purpose |
-|------|---------|
-| `recipes-bsp/u-boot/u-boot_%.bbappend` | Feature gating, BOOTDELAY override, key guard inherit |
-| `recipes-bsp/u-boot/files/0003-defconfig-iotgw-base.patch` | Kconfig-validated base defconfig |
-| `recipes-bsp/u-boot/files/iotgw-uboot-hardening.cfg` | Surface reduction fragment |
-| `recipes-bsp/u-boot/files/iotgw-uboot-fit-enforce.cfg` | FIT enforcement fragment |
-| `recipes-bsp/u-boot/files/iotgw-uboot-prod.cfg` | Production lockdown fragment |
-| `classes/iotgw-uboot-prod-key-guard.bbclass` | Build-time dev-key guard |
-| `kas/uboot-prod-hardening.yml` | KAS overlay for production U-Boot profile |
-| `recipes-bsp/u-boot/files/0001-rpi-env-*.patch` | RAUC A/B boot env + boot_targets reduction |
-| `recipes-bsp/u-boot/files/0002-rpi-iotgw-*.patch` | Appliance fast-path and netboot gate |
 
 ---
 
@@ -278,24 +229,6 @@ devtool finish u-boot meta-iot-gateway/
 The `--no-overrides` flag is required because the bbappend uses
 conditional `SRC_URI:append` expressions that break devtool's default
 override-branch processing.
-
----
-
-## Validation checklist
-
-| Test | Expected |
-|------|----------|
-| `bitbake u-boot -c patch` | All patches apply cleanly |
-| `bitbake u-boot -c compile` | Build succeeds |
-| `devtool modify --no-overrides u-boot` + `devtool build u-boot` | Passes |
-| Serial log: `(IoT-Gateway)` in banner | Ident string present |
-| Serial log: `Autoboot in 2s - type 'igw' to stop` (dev) | Keyed autoboot works |
-| Serial log: `sha256,rsa2048:iotgw-fit-dev+ OK` | FIT signature verified |
-| `cat /proc/cmdline` contains `rauc.slot=` | RAUC slot selected |
-| `fw_printenv boot_targets` returns `mmc` | No USB/PXE/DHCP |
-| `rauc install` + reboot + `rauc status` shows new slot good | OTA cycle works |
-| Prod build with dev key | `bb.fatal` with diagnostic |
-| `IOTGW_UBOOT_BOOTDELAY` resolves to `2` (dev) / `-2` (prod) | BOOTDELAY correct per image |
 
 ---
 

--- a/scripts/ota-bench-target.sh
+++ b/scripts/ota-bench-target.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+set -u -o pipefail
+
+# Benchmark RAUC install duration on target and emit JSONL records.
+#
+# Example:
+#   ./ota-bench-target.sh /data/verity.raucb /data/crypt.raucb
+#   ./ota-bench-target.sh --key /etc/ota/device.key /data/crypt.raucb
+
+OUTPUT_FILE="${OUTPUT_FILE:-/data/ota/bench/rauc-install-bench.jsonl}"
+KEY_FILE=""
+FORMAT_OVERRIDE=""
+LABEL_PREFIX=""
+
+usage() {
+    cat <<'EOF'
+Usage: ota-bench-target.sh [options] <bundle1.raucb> [bundle2.raucb ...]
+
+Options:
+  --output <path>   JSONL output path (default: /data/ota/bench/rauc-install-bench.jsonl)
+  --key <path>      Optional key file for `rauc info` format detection
+  --format <name>   Override detected format (e.g. verity, crypt)
+  --label <text>    Optional label prefix stored in JSON records
+  -h, --help        Show this help
+EOF
+}
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || {
+        echo "ERROR: missing command: $1" >&2
+        exit 1
+    }
+}
+
+status_field() {
+    local key="$1"
+    rauc status 2>/dev/null | sed -n "s/^${key}[[:space:]]*//p" | head -n1
+}
+
+detect_format() {
+    local bundle="$1"
+    local info_out
+    local fmt=""
+
+    if [ -n "${FORMAT_OVERRIDE}" ]; then
+        printf '%s\n' "${FORMAT_OVERRIDE}"
+        return 0
+    fi
+
+    if [ -n "${KEY_FILE}" ]; then
+        info_out="$(rauc info --key="${KEY_FILE}" "${bundle}" 2>&1 || true)"
+    else
+        info_out="$(rauc info "${bundle}" 2>&1 || true)"
+    fi
+
+    fmt="$(printf '%s\n' "${info_out}" | awk '/Bundle Format:/{print $3; exit}')"
+    if [ -n "${fmt}" ]; then
+        printf '%s\n' "${fmt}"
+        return 0
+    fi
+
+    if printf '%s\n' "${info_out}" | grep -qi "Encrypted bundle detected"; then
+        printf 'crypt\n'
+        return 0
+    fi
+
+    printf 'unknown\n'
+}
+
+main() {
+    local bundles=()
+    local arg=""
+
+    while [ "$#" -gt 0 ]; do
+        arg="$1"
+        case "${arg}" in
+            --output)
+                shift
+                OUTPUT_FILE="${1:-}"
+                [ -n "${OUTPUT_FILE}" ] || { echo "ERROR: --output requires a value" >&2; exit 1; }
+                ;;
+            --key)
+                shift
+                KEY_FILE="${1:-}"
+                [ -n "${KEY_FILE}" ] || { echo "ERROR: --key requires a value" >&2; exit 1; }
+                ;;
+            --format)
+                shift
+                FORMAT_OVERRIDE="${1:-}"
+                [ -n "${FORMAT_OVERRIDE}" ] || { echo "ERROR: --format requires a value" >&2; exit 1; }
+                ;;
+            --label)
+                shift
+                LABEL_PREFIX="${1:-}"
+                [ -n "${LABEL_PREFIX}" ] || { echo "ERROR: --label requires a value" >&2; exit 1; }
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            --*)
+                echo "ERROR: unknown option: ${arg}" >&2
+                exit 1
+                ;;
+            *)
+                bundles+=("${arg}")
+                ;;
+        esac
+        shift
+    done
+
+    [ "${#bundles[@]}" -gt 0 ] || { usage; exit 1; }
+
+    need_cmd rauc
+    need_cmd jq
+    need_cmd sha256sum
+    need_cmd stat
+    need_cmd date
+    need_cmd hostname
+
+    mkdir -p "$(dirname "${OUTPUT_FILE}")"
+    mkdir -p "/data/ota/bench/logs"
+
+    for bundle in "${bundles[@]}"; do
+        if [ ! -f "${bundle}" ]; then
+            echo "WARN: skipping missing bundle: ${bundle}" >&2
+            continue
+        fi
+
+        local start_iso end_iso start_epoch end_epoch duration_s
+        local booted_before booted_after activated_before activated_after
+        local fmt size sha host label
+        local rc result log_file
+
+        start_iso="$(date -Iseconds)"
+        start_epoch="$(date +%s)"
+        booted_before="$(status_field "Booted from:")"
+        activated_before="$(status_field "Activated:")"
+        fmt="$(detect_format "${bundle}")"
+        size="$(stat -c '%s' "${bundle}")"
+        sha="$(sha256sum "${bundle}" | awk '{print $1}')"
+        host="$(hostname)"
+        label="$(basename "${bundle}")"
+        [ -n "${LABEL_PREFIX}" ] && label="${LABEL_PREFIX}:${label}"
+        log_file="/data/ota/bench/logs/$(date -u +%Y%m%dT%H%M%SZ)-$(basename "${bundle}").log"
+
+        echo "==> Installing ${bundle}" >&2
+        set +e
+        rauc install "${bundle}" >"${log_file}" 2>&1
+        rc=$?
+        set -e
+
+        end_iso="$(date -Iseconds)"
+        end_epoch="$(date +%s)"
+        duration_s="$((end_epoch - start_epoch))"
+        booted_after="$(status_field "Booted from:")"
+        activated_after="$(status_field "Activated:")"
+        if [ "${rc}" -eq 0 ]; then
+            result="success"
+        else
+            result="failure"
+        fi
+
+        jq -n \
+            --arg ts "${start_iso}" \
+            --arg host "${host}" \
+            --arg label "${label}" \
+            --arg bundle "${bundle}" \
+            --arg bundle_sha256 "${sha}" \
+            --arg format "${fmt}" \
+            --arg booted_before "${booted_before}" \
+            --arg booted_after "${booted_after}" \
+            --arg activated_before "${activated_before}" \
+            --arg activated_after "${activated_after}" \
+            --arg start "${start_iso}" \
+            --arg end "${end_iso}" \
+            --arg result "${result}" \
+            --arg log_file "${log_file}" \
+            --arg rauc_version "$(rauc --version | awk '{print $2}')" \
+            --argjson bundle_size_bytes "${size}" \
+            --argjson duration_s "${duration_s}" \
+            --argjson exit_code "${rc}" \
+            '{
+              ts: $ts,
+              host: $host,
+              label: $label,
+              bundle: $bundle,
+              bundle_sha256: $bundle_sha256,
+              bundle_size_bytes: $bundle_size_bytes,
+              format: $format,
+              rauc_version: $rauc_version,
+              booted_before: $booted_before,
+              activated_before: $activated_before,
+              booted_after: $booted_after,
+              activated_after: $activated_after,
+              start: $start,
+              end: $end,
+              duration_s: $duration_s,
+              exit_code: $exit_code,
+              result: $result,
+              log_file: $log_file
+            }' >> "${OUTPUT_FILE}"
+
+        echo "    result=${result} duration_s=${duration_s} log=${log_file}" >&2
+    done
+
+    echo "Wrote benchmark records to ${OUTPUT_FILE}" >&2
+}
+
+main "$@"

--- a/scripts/ota-certs-sync.sh
+++ b/scripts/ota-certs-sync.sh
@@ -1,0 +1,171 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Sync OTA certificate material to target and trigger provisioning.
+#
+# Default behavior:
+# - Reuse existing device-filekey.{key,crt} in CA dir when present.
+# - Generate missing key/csr/crt signed by local CA.
+# - Upload ca.crt + device.{crt,key} to /data/ota/certs on target.
+# - Restart ota-certs-provision and print verification details.
+
+TARGET="${TARGET:-iotgw}"
+CA_DIR="${CA_DIR:-$HOME/rauc-keys/ota-dev-ca}"
+DEVICE_BASENAME="${DEVICE_BASENAME:-device-filekey}"
+DAYS="${DAYS:-3650}"
+
+# DN defaults requested for project consistency.
+CERT_COUNTRY="${CERT_COUNTRY:-DE}"
+CERT_STATE="${CERT_STATE:-NRW}"
+CERT_CITY="${CERT_CITY:-Leverkusen}"
+CERT_ORG="${CERT_ORG:-IoT Gateway}"
+CERT_OU="${CERT_OU:-OTA}"
+CERT_CN="${CERT_CN:-iot-gateway}"
+
+FORCE_REGEN=0
+
+usage() {
+    cat <<EOF
+Usage: $0 [options]
+
+Options:
+  --target HOST            SSH target (default: ${TARGET})
+  --ca-dir DIR             CA directory (default: ${CA_DIR})
+  --device-basename NAME   Device cert/key basename (default: ${DEVICE_BASENAME})
+  --force-regen            Regenerate device key/csr/crt even if present
+  -h, --help               Show this help
+
+Environment overrides:
+  TARGET, CA_DIR, DEVICE_BASENAME, DAYS
+  CERT_COUNTRY, CERT_STATE, CERT_CITY, CERT_ORG, CERT_OU, CERT_CN
+EOF
+}
+
+log() { printf '[ota-certs-sync] %s\n' "$*"; }
+die() { log "ERROR: $*"; exit 1; }
+
+need_cmd() {
+    command -v "$1" >/dev/null 2>&1 || die "missing command: $1"
+}
+
+key_matches_cert() {
+    local key_file="$1"
+    local cert_file="$2"
+    local key_pub cert_pub
+
+    key_pub="$(openssl pkey -in "${key_file}" -pubout 2>/dev/null | openssl pkey -pubin -outform DER 2>/dev/null | sha256sum | awk '{print $1}')"
+    cert_pub="$(openssl x509 -in "${cert_file}" -pubkey -noout 2>/dev/null | openssl pkey -pubin -outform DER 2>/dev/null | sha256sum | awk '{print $1}')"
+    [ -n "${key_pub}" ] && [ -n "${cert_pub}" ] && [ "${key_pub}" = "${cert_pub}" ]
+}
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            --target)
+                shift; [ "${1:-}" ] || die "--target requires value"
+                TARGET="$1"
+                ;;
+            --ca-dir)
+                shift; [ "${1:-}" ] || die "--ca-dir requires value"
+                CA_DIR="$1"
+                ;;
+            --device-basename)
+                shift; [ "${1:-}" ] || die "--device-basename requires value"
+                DEVICE_BASENAME="$1"
+                ;;
+            --force-regen)
+                FORCE_REGEN=1
+                ;;
+            -h|--help)
+                usage
+                exit 0
+                ;;
+            *)
+                die "unknown argument: $1"
+                ;;
+        esac
+        shift
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    need_cmd openssl
+    need_cmd ssh
+    need_cmd scp
+
+    local ca_crt="${CA_DIR}/ca.crt"
+    local ca_key="${CA_DIR}/ca.key"
+    local dev_key="${CA_DIR}/${DEVICE_BASENAME}.key"
+    local dev_csr="${CA_DIR}/${DEVICE_BASENAME}.csr"
+    local dev_crt="${CA_DIR}/${DEVICE_BASENAME}.crt"
+    local subject="/C=${CERT_COUNTRY}/ST=${CERT_STATE}/L=${CERT_CITY}/O=${CERT_ORG}/OU=${CERT_OU}/CN=${CERT_CN}"
+
+    [ -f "${ca_crt}" ] || die "missing CA cert: ${ca_crt}"
+    [ -f "${ca_key}" ] || die "missing CA key: ${ca_key}"
+    mkdir -p "${CA_DIR}"
+
+    local regen_cert=0
+
+    if [ "${FORCE_REGEN}" -eq 1 ]; then
+        log "force regen enabled; removing existing ${DEVICE_BASENAME}.{key,csr,crt}"
+        rm -f "${dev_key}" "${dev_csr}" "${dev_crt}"
+    fi
+
+    if [ ! -f "${dev_key}" ]; then
+        log "generating ${dev_key}"
+        openssl genrsa -out "${dev_key}" 2048 >/dev/null 2>&1
+        regen_cert=1
+    else
+        log "reusing existing key: ${dev_key}"
+    fi
+
+    if [ -f "${dev_crt}" ] && ! key_matches_cert "${dev_key}" "${dev_crt}"; then
+        log "existing cert does not match key; regenerating ${dev_crt}"
+        rm -f "${dev_crt}" "${dev_csr}"
+        regen_cert=1
+    fi
+
+    if [ ! -f "${dev_crt}" ] || [ "${regen_cert}" -eq 1 ]; then
+        log "generating CSR: ${dev_csr}"
+        openssl req -new -key "${dev_key}" -subj "${subject}" -out "${dev_csr}" >/dev/null 2>&1
+
+        log "signing certificate: ${dev_crt}"
+        openssl x509 -req \
+            -in "${dev_csr}" \
+            -CA "${ca_crt}" \
+            -CAkey "${ca_key}" \
+            -CAcreateserial \
+            -out "${dev_crt}" \
+            -days "${DAYS}" \
+            -sha256 >/dev/null 2>&1
+    else
+        log "reusing existing cert: ${dev_crt}"
+    fi
+
+    log "verifying device cert chain"
+    openssl verify -CAfile "${ca_crt}" "${dev_crt}" >/dev/null
+
+    log "preparing target path /data/ota/certs on ${TARGET}"
+    ssh "${TARGET}" "mkdir -p /data/ota/certs"
+
+    log "uploading cert material"
+    scp "${ca_crt}" "${TARGET}:/data/ota/certs/ca.crt"
+    scp "${dev_crt}" "${TARGET}:/data/ota/certs/device.crt"
+    scp "${dev_key}" "${TARGET}:/data/ota/certs/device.key"
+
+    log "triggering ota-certs-provision and verifying target files"
+    ssh "${TARGET}" "\
+        systemctl restart ota-certs-provision && \
+        ls -l /etc/ota && \
+        openssl verify -CAfile /etc/ota/ca.crt /etc/ota/device.crt"
+
+    log "done"
+    log "target=${TARGET}"
+    log "ca=${ca_crt}"
+    log "device_cert=${dev_crt}"
+    log "device_key=${dev_key}"
+}
+
+main "$@"

--- a/scripts/ota-pkcs11-provision-check.sh
+++ b/scripts/ota-pkcs11-provision-check.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TARGET="${1:-iotgw}"
+TOKEN_LABEL="${TOKEN_LABEL:-iotgw}"
+KEY_LABEL="${KEY_LABEL:-rauc-client-key}"
+MODULE_PATH="${MODULE_PATH:-/usr/lib/pkcs11/libtpm2_pkcs11.so}"
+
+echo "[pkcs11-check] target=${TARGET}"
+echo "[pkcs11-check] token=${TOKEN_LABEL} key=${KEY_LABEL}"
+
+ssh "${TARGET}" "set -euo pipefail
+echo '[pkcs11-check] tool availability:'
+command -v pkcs11-tool >/dev/null && echo '  - pkcs11-tool: OK' || echo '  - pkcs11-tool: MISSING'
+if command -v tpm2_ptool >/dev/null; then
+  echo '  - tpm2_ptool: OK'
+elif command -v tpm2_ptool.py >/dev/null; then
+  echo '  - tpm2_ptool.py: OK'
+else
+  echo '  - tpm2_ptool: MISSING (install tpm2-pkcs11 tools package)'
+fi
+
+echo
+echo '[pkcs11-check] slots:'
+pkcs11-tool --module '${MODULE_PATH}' -L || true
+
+echo
+echo '[pkcs11-check] object lookup:'
+pkcs11-tool --module '${MODULE_PATH}' -O --login 2>/dev/null | grep -E 'Label:|ID:' || true
+
+echo
+echo '[pkcs11-check] expected URI:'
+echo '  pkcs11:token=${TOKEN_LABEL};object=${KEY_LABEL};type=private'
+
+echo
+echo '[pkcs11-check] next provisioning steps (run on target as root):'
+cat <<'EOF'
+# 1) Inspect local tool syntax first (varies by distro build):
+tpm2_ptool --help || tpm2_ptool.py --help
+
+# 2) Initialize token store and create token/object:
+#    (use the command variants shown by --help for your target build)
+#    Typical flow:
+#      - init store
+#      - add token label 'iotgw' with SO PIN + user PIN
+#      - add private key object label 'rauc-client-key'
+
+# 3) Verify token/object exists:
+pkcs11-tool --module /usr/lib/pkcs11/libtpm2_pkcs11.so -L
+pkcs11-tool --module /usr/lib/pkcs11/libtpm2_pkcs11.so -O --login
+
+# 4) Validate mTLS key loading with same URI RAUC uses:
+PKCS11_MODULE_PATH=/usr/lib/pkcs11/libtpm2_pkcs11.so \
+curl -vk --cert /etc/ota/device.crt \
+  --key 'pkcs11:token=iotgw;object=rauc-client-key;type=private' \
+  --cacert /etc/ota/ca.crt \
+  'https://<ota-host>:8443/api/v1/manifest.json?compatible=iot-gateway-raspberrypi5' \
+  -o /tmp/manifest.out
+EOF
+"


### PR DESCRIPTION
## Summary

- Refactor OTA_UPDATE.md — remove stale bundle file listings, build commands, implementation paths; restructure feature-gating as compact profiles; retain visual style
- Refactor RAUC_UPDATE.md — strip overlay internals, consolidate troubleshooting, link to hardening doc
- Clean UBOOT_HARDENING.md — remove file map, constraints, validation checklist (internal, not architecture-level)
- Clean THREAT_MODEL.md — remove internal doc policy section (agent scaffolding)
- Add `scripts/ota-certs-sync.sh`, `scripts/ota-pkcs11-provision-check.sh`, `scripts/ota-bench-target.sh`

## Test plan

- [ ] Docs render correctly on GitHub
- [ ] Scripts run without errors: `./scripts/ota-certs-sync.sh --help`