### PR TITLE
feat(kernel): backport BCM2712 watchdog stack and add early-boot panic recovery

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -16,11 +16,16 @@ The distribution uses **modular kernel configuration** based on feature fragment
 - `storage-filesystems.cfg` — OverlayFS, dm-verity, SquashFS (required for RAUC)
 - `ikconfig.cfg` — runtime kernel config introspection support
 - `audit.cfg` — audit framework plumbing
-- `panic-recovery.cfg` — kernel-baked panic posture: `CONFIG_PANIC_TIMEOUT=30`
-  + `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y`. Any oops escalates to panic, panic
-  reboots within 30s — applies from the first instruction the kernel runs,
-  before userspace, before sysctl, before watchdog drivers probe. Closes
-  the early-boot "kernel hangs requiring power cycle" failure class.
+- `panic-recovery.cfg` — `CONFIG_PANIC_TIMEOUT=30`. Always applied.
+  Closes the early-boot "kernel hangs requiring power cycle" failure
+  class — any panic auto-reboots within 30s, applies from the first
+  instruction the kernel runs.
+- `panic-on-oops.cfg` — `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y`. Gated by
+  `IOTGW_ENABLE_PANIC_ON_OOPS` (default `"1"`); set to `"0"` in
+  `kas/local.yml` for dev/bring-up builds where you want tainted-but-
+  running kernels for triage instead of immediate panic+reboot. Together
+  with `panic-recovery.cfg` this covers kernel-thread/driver oopses, not
+  just init-killing ones.
 - `rtc-rpi.cfg` — Raspberry Pi RTC support (gated by `IOTGW_ENABLE_RPI_RTC`)
 
 **Optional Feature Sets:** Controlled via `IOTGW_KERNEL_FEATURES` variable

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -16,6 +16,11 @@ The distribution uses **modular kernel configuration** based on feature fragment
 - `storage-filesystems.cfg` — OverlayFS, dm-verity, SquashFS (required for RAUC)
 - `ikconfig.cfg` — runtime kernel config introspection support
 - `audit.cfg` — audit framework plumbing
+- `panic-recovery.cfg` — kernel-baked panic posture: `CONFIG_PANIC_TIMEOUT=30`
+  + `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y`. Any oops escalates to panic, panic
+  reboots within 30s — applies from the first instruction the kernel runs,
+  before userspace, before sysctl, before watchdog drivers probe. Closes
+  the early-boot "kernel hangs requiring power cycle" failure class.
 - `rtc-rpi.cfg` — Raspberry Pi RTC support (gated by `IOTGW_ENABLE_RPI_RTC`)
 
 **Optional Feature Sets:** Controlled via `IOTGW_KERNEL_FEATURES` variable
@@ -112,6 +117,11 @@ unit on next boot.
 **Features (kernel):**
 - `CONFIG_PSTORE`, `CONFIG_PSTORE_RAM`, `CONFIG_PSTORE_CONSOLE`,
   `CONFIG_PSTORE_PMSG`
+
+Reboot-on-panic semantics live in the always-applied `panic-recovery.cfg`
+fragment, not here — pstore is the post-mortem capture stack, panic
+recovery is the system-wide reboot policy. They're orthogonal: pstore can
+be disabled without losing panic recovery, and vice versa.
 
 **BSP wiring (RPi5):** patch
 `0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoops-reserved-memory.patch`

--- a/kas/watchdog.yml
+++ b/kas/watchdog.yml
@@ -5,7 +5,16 @@ header:
 
 local_conf_header:
   systemd_hw_watchdog: |
-    # Enable systemd PID1 hardware watchdog handling (requires active /dev/watchdog backend).
-    IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG = "1"
-    IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC = "20s"
-    IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC = "30s"
+    # Watchdog profile. Kernel-side BSP enablement (IOTGW_ENABLE_HW_WATCHDOG)
+    # defaults to "1" in iotgw-common.inc; that ships /dev/watchdog0 via the
+    # BCM2712 backport. Userspace use of the watchdog (systemd PID1 feeding,
+    # per-image RuntimeWatchdogSec/ShutdownWatchdogSec) is currently held
+    # off pending fix for the systemd PID1 ping path on BCM2712 — pings
+    # opening /dev/watchdog0 announce a timeout but the hardware fires at
+    # the first interval rather than being kept alive. See follow-up issue.
+    #
+    # Defaults below are weak so kas/local.yml can hard-override after the
+    # PID1 bug is fixed (set to "1" + adjust RUNTIME/SHUTDOWN seconds).
+    IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG ?= "0"
+    IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC ?= "20s"
+    IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC ?= "30s"

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -17,6 +17,7 @@ SRC_URI:append = " \
     file://fragments/storage-filesystems.cfg \
     file://fragments/ikconfig.cfg \
     file://fragments/audit.cfg \
+    file://fragments/panic-recovery.cfg \
 "
 SRC_URI:append = "${@' file://fragments/rtc-rpi.cfg' if d.getVar('IOTGW_ENABLE_RPI_RTC') == '1' else ''}"
 SRC_URI:append = "${@' file://fragments/vcio-rpi.cfg' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -19,6 +19,9 @@ SRC_URI:append = " \
     file://fragments/audit.cfg \
     file://fragments/panic-recovery.cfg \
 "
+# panic-on-oops.cfg is gated so dev/bring-up builds can disable
+# CONFIG_BOOTPARAM_PANIC_ON_OOPS without source edits (default-on).
+SRC_URI:append = "${@' file://fragments/panic-on-oops.cfg' if d.getVar('IOTGW_ENABLE_PANIC_ON_OOPS') == '1' else ''}"
 SRC_URI:append = "${@' file://fragments/rtc-rpi.cfg' if d.getVar('IOTGW_ENABLE_RPI_RTC') == '1' else ''}"
 SRC_URI:append = "${@' file://fragments/vcio-rpi.cfg' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
 

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -117,6 +117,7 @@ BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYP
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_PSTORE_PERSIST IOTGW_ENABLE_CRASH_DEBUG_DEV"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_HW_WATCHDOG IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_PANIC_ON_OOPS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_BUILD_ID IOTGW_VERSION_MAJOR IOTGW_VERSION_MINOR IOTGW_VERSION_PATCH"
 
@@ -180,6 +181,13 @@ IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_CRASH_DEBUG_D
 # floor that covers early-boot/pre-sysctl panics. Lab sysctl overrides
 # this downward to 5s once userspace is up.
 IOTGW_CRASH_PANIC_TIMEOUT ?= "5"
+
+# Escalate kernel oops to panic so the panic timeout above actually fires
+# for kernel-thread/driver oopses (default-on for fleet posture). Override
+# to "0" in kas/local.yml during BSP bring-up / bisect work to keep
+# tainted-but-running kernels accessible for triage. Wires
+# panic-on-oops.cfg into the kernel build.
+IOTGW_ENABLE_PANIC_ON_OOPS ?= "1"
 
 # BCM2712 hardware watchdog kernel-side enablement (default on).
 # Pulls in three kernel patches that backport the BCM2712 PM/power/DT

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -116,6 +116,7 @@ BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_SELINUX IOTGW_ENABLE_IMA"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_ENCRYPTED_STORE_DEV IOTGW_OBSERVABILITY_REQUIRE_NETWORK_ONLINE"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_PSTORE_PERSIST IOTGW_ENABLE_CRASH_DEBUG_DEV"
+BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_ENABLE_HW_WATCHDOG IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " BUNDLE_IMAGE_NAME"
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_BUILD_ID IOTGW_VERSION_MAJOR IOTGW_VERSION_MINOR IOTGW_VERSION_PATCH"
 
@@ -173,13 +174,28 @@ IOTGW_ENABLE_PSTORE_PERSIST_EFFECTIVE = "${@'1' if (d.getVar('IOTGW_ENABLE_CRASH
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_PSTORE_PERSIST_EFFECTIVE', '1', ' igw_pstore_persist', '', d)}"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_CRASH_DEBUG_DEV', '1', ' igw_crash_debug_dev', '', d)}"
 
-# Crash-debug panic timeout (seconds). Only used by the lab sysctl/cmdline
-# drop-ins; production runs without an explicit panic timeout and relies on
-# the hardware watchdog for stuck-kernel recovery.
+# Crash-debug panic timeout (seconds). Drives the lab sysctl + cmdline
+# drop-ins for fast post-mortem turnaround. The kernel-baked default
+# (CONFIG_PANIC_TIMEOUT=30 in panic-recovery.cfg, always applied) is the
+# floor that covers early-boot/pre-sysctl panics. Lab sysctl overrides
+# this downward to 5s once userspace is up.
 IOTGW_CRASH_PANIC_TIMEOUT ?= "5"
 
+# BCM2712 hardware watchdog kernel-side enablement (default on).
+# Pulls in three kernel patches that backport the BCM2712 PM/power/DT
+# stack from raspberrypi/linux rpi-6.12.y so /dev/watchdog0 is exposed on
+# RPi5: bcm2835-pm MFD match (0008), bcm2712.dtsi PM node (0009), and
+# bcm2835-power probe NULL-deref guard (0010 — companion required when
+# bcm2835-pm registers the power cell on a BCM2712 with no asb window).
+# Disable for stripped builds that don't need a hardware watchdog at all.
+# Independent of the systemd PID1 ping below — kernel-side enablement is
+# harmless on its own (an unopened /dev/watchdog0 does not trigger reboot).
+IOTGW_ENABLE_HW_WATCHDOG ?= "1"
+
 # Optional: systemd hardware watchdog integration (disabled by default).
-# When enabled, PID1 opens /dev/watchdog and pings it at RuntimeWatchdogSec cadence.
+# When enabled, PID1 opens /dev/watchdog and pings it at RuntimeWatchdogSec
+# cadence. Requires IOTGW_ENABLE_HW_WATCHDOG=1 (or another driver source)
+# for /dev/watchdog to exist.
 IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG ?= "0"
 IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC ?= "20s"
 IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC ?= "30s"

--- a/meta-iot-gateway/recipes-kernel/linux/files/0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch
@@ -1,0 +1,81 @@
+From c57dbc94393601f74559e8badc5c77ace0d422bf Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Wed, 8 Mar 2023 14:27:58 +0000
+Subject: [PATCH] mfd: bcm2835-pm: Add support for BCM2712
+
+BCM2712 lacks the "asb" and "rpivid_asb" register ranges, but still
+requires the use of the bcm2835-power driver to reset the V3D block.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+
+(cherry-picked from raspberrypi/linux c57dbc94393601f74559e8badc5c77ace0d422bf,
+ author Phil Elwell <phil@raspberrypi.com>; carried until upstream lands BCM2712
+ PM support in stable.)
+
+Upstream-Status: Backport [from raspberrypi/linux rpi-6.12.y; pending stable]
+
+---
+ drivers/mfd/bcm2835-pm.c | 28 +++++++++++++++++++---------
+ 1 file changed, 19 insertions(+), 9 deletions(-)
+
+diff --git a/drivers/mfd/bcm2835-pm.c b/drivers/mfd/bcm2835-pm.c
+index 3cb2b9423121..8b31775da7b6 100644
+--- a/drivers/mfd/bcm2835-pm.c
++++ b/drivers/mfd/bcm2835-pm.c
+@@ -69,12 +69,30 @@ static int bcm2835_pm_get_pdata(struct platform_device *pdev,
+ 	return 0;
+ }
+ 
++static const struct of_device_id bcm2835_pm_of_match[] = {
++	{ .compatible = "brcm,bcm2835-pm-wdt", },
++	{ .compatible = "brcm,bcm2835-pm", },
++	{ .compatible = "brcm,bcm2711-pm", },
++	{ .compatible = "brcm,bcm2712-pm", .data = (const void *)1},
++	{},
++};
++MODULE_DEVICE_TABLE(of, bcm2835_pm_of_match);
++
+ static int bcm2835_pm_probe(struct platform_device *pdev)
+ {
++	const struct of_device_id *of_id;
+ 	struct device *dev = &pdev->dev;
+ 	struct bcm2835_pm *pm;
++	bool is_2712;
+ 	int ret;
+ 
++	of_id = of_match_node(bcm2835_pm_of_match, pdev->dev.of_node);
++	if (!of_id) {
++		dev_err(&pdev->dev, "Failed to match compatible string\n");
++		return -EINVAL;
++	}
++	is_2712 = !!of_id->data;
++
+ 	pm = devm_kzalloc(dev, sizeof(*pm), GFP_KERNEL);
+ 	if (!pm)
+ 		return -ENOMEM;
+@@ -97,21 +115,13 @@ static int bcm2835_pm_probe(struct platform_device *pdev)
+ 	 * bcm2835-pm binding as the key for whether we can reference
+ 	 * the full PM register range and support power domains.
+ 	 */
+-	if (pm->asb)
++	if (pm->asb || is_2712)
+ 		return devm_mfd_add_devices(dev, -1, bcm2835_power_devs,
+ 					    ARRAY_SIZE(bcm2835_power_devs),
+ 					    NULL, 0, NULL);
+ 	return 0;
+ }
+ 
+-static const struct of_device_id bcm2835_pm_of_match[] = {
+-	{ .compatible = "brcm,bcm2835-pm-wdt", },
+-	{ .compatible = "brcm,bcm2835-pm", },
+-	{ .compatible = "brcm,bcm2711-pm", },
+-	{},
+-};
+-MODULE_DEVICE_TABLE(of, bcm2835_pm_of_match);
+-
+ static struct platform_driver bcm2835_pm_driver = {
+ 	.probe		= bcm2835_pm_probe,
+ 	.driver = {
+-- 
+2.43.0
+

--- a/meta-iot-gateway/recipes-kernel/linux/files/0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch
@@ -1,0 +1,48 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Mon, 4 May 2026 16:00:00 +0200
+Subject: [PATCH] arm64: dts: broadcom: bcm2712: add PM/watchdog node
+
+Add the BCM2712 PM unit (which hosts the watchdog) to bcm2712.dtsi so the
+backported bcm2835-pm MFD driver can probe and register its child cells.
+The "bcm2835-wdt" cell exposes /dev/watchdog0; "bcm2835-power" provides
+power-domain reset for the V3D block.
+
+The PM block lives at 0x7d200000 (length 0x308) and exposes only the "pm"
+register range on BCM2712 — the "asb" and "rpivid_asb" ranges present on
+BCM2711 are absent here. The bcm2835-pm driver detects this via the
+"brcm,bcm2712-pm" compatible (added by the companion driver patch).
+
+system-power-controller is set so the watchdog's reboot path is the
+default reset path on this platform.
+
+Source: arch/arm64/boot/dts/broadcom/bcm2712-ds.dtsi in
+raspberrypi/linux rpi-6.12.y (node `pm: watchdog@7d200000`).
+
+Upstream-Status: Backport [from raspberrypi/linux rpi-6.12.y; pending stable]
+---
+ arch/arm64/boot/dts/broadcom/bcm2712.dtsi | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+index 0000000..0000000 100644
+--- a/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
++++ b/arch/arm64/boot/dts/broadcom/bcm2712.dtsi
+@@ -250,6 +250,15 @@
+ 			status = "disabled";
+ 		};
+
++		pm: watchdog@7d200000 {
++			compatible = "brcm,bcm2712-pm";
++			reg = <0x7d200000 0x308>;
++			reg-names = "pm";
++			#power-domain-cells = <1>;
++			#reset-cells = <1>;
++			system-power-controller;
++		};
++
+ 		pinctrl: pinctrl@7d504100 {
+ 			compatible = "brcm,bcm2712c0-pinctrl";
+ 			reg = <0x7d504100 0x30>;
+--
+2.43.0

--- a/meta-iot-gateway/recipes-kernel/linux/files/0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch
@@ -1,0 +1,89 @@
+From e4da63a11be546fa45fa74e0da4d85d7caddfef1 Mon Sep 17 00:00:00 2001
+From: Phil Elwell <phil@raspberrypi.com>
+Date: Wed, 8 Mar 2023 14:42:48 +0000
+Subject: [PATCH] pmdomain: bcm: bcm2835-power: Add support for BCM2712
+
+BCM2712 has a PM block but neither ASB nor RPIVID_ASB. Use the absence
+of the "asb" register range to indicate BCM2712 and its different PM
+register range.
+
+Signed-off-by: Phil Elwell <phil@raspberrypi.com>
+
+(cherry-picked from raspberrypi/linux e4da63a11be546fa45fa74e0da4d85d7caddfef1,
+ author Phil Elwell <phil@raspberrypi.com>; companion to the bcm2835-pm BCM2712
+ patch — without this, bcm2835-power probe NULL-derefs on `readl(power->asb +
+ ASB_AXI_BRDG_ID)` when bcm2835-pm registers the power cell on BCM2712.)
+
+Upstream-Status: Backport [from raspberrypi/linux rpi-6.12.y; pending stable]
+
+---
+ drivers/pmdomain/bcm/bcm2835-power.c | 29 ++++++++++++++++++----------
+ 1 file changed, 19 insertions(+), 10 deletions(-)
+
+diff --git a/drivers/pmdomain/bcm/bcm2835-power.c b/drivers/pmdomain/bcm/bcm2835-power.c
+index d2f0233cb620..5812f2a355d4 100644
+--- a/drivers/pmdomain/bcm/bcm2835-power.c
++++ b/drivers/pmdomain/bcm/bcm2835-power.c
+@@ -79,6 +79,7 @@
+ #define PM_IMAGE			0x108
+ #define PM_GRAFX			0x10c
+ #define PM_PROC				0x110
++#define PM_GRAFX_2712			0x304
+ #define PM_ENAB				BIT(12)
+ #define PM_ISPRSTN			BIT(8)
+ #define PM_H264RSTN			BIT(7)
+@@ -381,6 +382,9 @@ static int bcm2835_power_pd_power_on(struct generic_pm_domain *domain)
+ 		return bcm2835_power_power_on(pd, PM_GRAFX);
+ 
+ 	case BCM2835_POWER_DOMAIN_GRAFX_V3D:
++		if (!power->asb)
++			return bcm2835_asb_power_on(pd, PM_GRAFX_2712,
++						    0, 0, PM_V3DRSTN);
+ 		return bcm2835_asb_power_on(pd, PM_GRAFX,
+ 					    ASB_V3D_M_CTRL, ASB_V3D_S_CTRL,
+ 					    PM_V3DRSTN);
+@@ -447,6 +451,9 @@ static int bcm2835_power_pd_power_off(struct generic_pm_domain *domain)
+ 		return bcm2835_power_power_off(pd, PM_GRAFX);
+ 
+ 	case BCM2835_POWER_DOMAIN_GRAFX_V3D:
++		if (!power->asb)
++			return bcm2835_asb_power_off(pd, PM_GRAFX_2712,
++						    0, 0, PM_V3DRSTN);
+ 		return bcm2835_asb_power_off(pd, PM_GRAFX,
+ 					     ASB_V3D_M_CTRL, ASB_V3D_S_CTRL,
+ 					     PM_V3DRSTN);
+@@ -642,19 +649,21 @@ static int bcm2835_power_probe(struct platform_device *pdev)
+ 	power->asb = pm->asb;
+ 	power->rpivid_asb = pm->rpivid_asb;
+ 
+-	id = readl(power->asb + ASB_AXI_BRDG_ID);
+-	if (id != BCM2835_BRDG_ID /* "BRDG" */) {
+-		dev_err(dev, "ASB register ID returned 0x%08x\n", id);
+-		return -ENODEV;
+-	}
+-
+-	if (power->rpivid_asb) {
+-		id = readl(power->rpivid_asb + ASB_AXI_BRDG_ID);
++	if (power->asb) {
++		id = readl(power->asb + ASB_AXI_BRDG_ID);
+ 		if (id != BCM2835_BRDG_ID /* "BRDG" */) {
+-			dev_err(dev, "RPiVid ASB register ID returned 0x%08x\n",
+-				     id);
++			dev_err(dev, "ASB register ID returned 0x%08x\n", id);
+ 			return -ENODEV;
+ 		}
++
++		if (power->rpivid_asb) {
++			id = readl(power->rpivid_asb + ASB_AXI_BRDG_ID);
++			if (id != BCM2835_BRDG_ID /* "BRDG" */) {
++				dev_err(dev, "RPiVid ASB register ID returned 0x%08x\n",
++					id);
++				return -ENODEV;
++			}
++		}
+ 	}
+ 
+ 	power->pd_xlate.domains = devm_kcalloc(dev,
+-- 
+2.43.0
+

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-on-oops.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-on-oops.cfg
@@ -1,0 +1,13 @@
+# Escalate any kernel oops to panic so CONFIG_PANIC_TIMEOUT actually fires
+# for kernel-thread/driver oopses that wouldn't otherwise kill init.
+#
+# Default-on for production fleet posture (closes the "tainted-but-running
+# kernel that eventually wedges with no auto-recovery" failure class).
+# Gated by IOTGW_ENABLE_PANIC_ON_OOPS so dev/bring-up builds can disable
+# it from kas/local.yml without source edits — keeps oopses survivable
+# during BSP backport bisects.
+#
+# A target-side runtime override via `oops=` cmdline still works regardless
+# of this fragment, e.g. for kgdb-style debugging on a deployed unit.
+
+CONFIG_BOOTPARAM_PANIC_ON_OOPS=y

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-recovery.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-recovery.cfg
@@ -1,23 +1,16 @@
-# Kernel panic-recovery posture for the IoT gateway fleet.
+# Kernel panic-recovery: reboot rather than hang on panic().
 #
-# Two layers, both kernel-baked so they apply from the moment panic()/oops
-# can fire — before userspace, before sysctl drop-ins load, before any
-# watchdog driver probes. Together they close the "kernel hangs forever
-# requiring power cycle" failure class for any kernel bug, including
-# early-boot driver-probe crashes that other recovery paths can't catch.
+# Kernel-baked so it applies from the moment panic() can fire — before
+# userspace, before sysctl drop-ins load, before any watchdog driver
+# probes. Closes the early-boot "kernel hangs forever requiring power
+# cycle" failure class.
 #
-# 1. PANIC_TIMEOUT=30: panic() reboots within 30s.
-# 2. BOOTPARAM_PANIC_ON_OOPS=y: any oops escalates to panic(), so timeout
-#    actually fires for kernel-thread/driver oopses that wouldn't otherwise
-#    kill init. (Tonight's BCM2712 bcm2835-power probe oops only escalated
-#    because the offending task was PID 1 — generic-thread oopses on a
-#    running system would have left a tainted-but-running kernel that
-#    eventually wedges with no auto-recovery.)
+# Always applied (not toggleable). The complementary piece — escalating
+# oops to panic so this timeout actually fires for kernel-thread/driver
+# oopses — lives in panic-on-oops.cfg, gated on IOTGW_ENABLE_PANIC_ON_OOPS
+# (default 1) so dev/bring-up builds can disable it without source edits.
 #
 # Lab/dev profiles (igw_crash_debug_dev) override the timeout downward to
-# 5s via sysctl once userspace is up. Anyone deliberately needing to keep
-# a tainted kernel running for kgdb-style debugging can boot with `oops=`
-# cmdline override or build with this fragment removed.
+# 5s via sysctl once userspace is up.
 
 CONFIG_PANIC_TIMEOUT=30
-CONFIG_BOOTPARAM_PANIC_ON_OOPS=y

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-recovery.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-recovery.cfg
@@ -1,0 +1,23 @@
+# Kernel panic-recovery posture for the IoT gateway fleet.
+#
+# Two layers, both kernel-baked so they apply from the moment panic()/oops
+# can fire — before userspace, before sysctl drop-ins load, before any
+# watchdog driver probes. Together they close the "kernel hangs forever
+# requiring power cycle" failure class for any kernel bug, including
+# early-boot driver-probe crashes that other recovery paths can't catch.
+#
+# 1. PANIC_TIMEOUT=30: panic() reboots within 30s.
+# 2. BOOTPARAM_PANIC_ON_OOPS=y: any oops escalates to panic(), so timeout
+#    actually fires for kernel-thread/driver oopses that wouldn't otherwise
+#    kill init. (Tonight's BCM2712 bcm2835-power probe oops only escalated
+#    because the offending task was PID 1 — generic-thread oopses on a
+#    running system would have left a tainted-but-running kernel that
+#    eventually wedges with no auto-recovery.)
+#
+# Lab/dev profiles (igw_crash_debug_dev) override the timeout downward to
+# 5s via sysctl once userspace is up. Anyone deliberately needing to keep
+# a tainted kernel running for kgdb-style debugging can boot with `oops=`
+# cmdline override or build with this fragment removed.
+
+CONFIG_PANIC_TIMEOUT=30
+CONFIG_BOOTPARAM_PANIC_ON_OOPS=y

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
@@ -41,4 +41,7 @@ SRC_URI:append = "${@' file://0004-arm64-dts-broadcom-bcm2712-rpi-5-b-add-TPM-on
 SRC_URI:append = " file://0005-arm64-dts-broadcom-bcm2712-add-avs-thermal-zone.patch"
 SRC_URI:append = "${@' file://0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
 SRC_URI:append = "${@' file://0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoops-reserved-memory.patch' if d.getVar('IOTGW_ENABLE_PSTORE_PERSIST_EFFECTIVE') == '1' else ''}"
+SRC_URI:append = "${@' file://0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
+SRC_URI:append = "${@' file://0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
+SRC_URI:append = "${@' file://0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
 SRC_URI:append = " file://fragments/thermal-rpi5.cfg"


### PR DESCRIPTION
## Summary

Three patches cherry-picked from `raspberrypi/linux rpi-6.12.y` bring up the BCM2712 PM/watchdog stack on our mainline Linux 6.18 kernel, plus a new always-applied kernel fragment that closes the early-boot panic-then-hang failure class.

## Patches

| Patch | Source | Purpose |
|---|---|---|
| `0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch` | `c57dbc943936` | Add `brcm,bcm2712-pm` to `bcm2835-pm` of_match table; register the `bcm2835-power` cell on BCM2712 even without `asb` |
| `0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch` | `bcm2712-ds.dtsi` | Add `pm: watchdog@7d200000` node to mainline `bcm2712.dtsi`; `system-power-controller` for reboot via watchdog |
| `0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch` | `e4da63a11be5` | Companion to 0008. Adds `if (power->asb)` guard around `ASB_AXI_BRDG_ID` reads; without this, `bcm2835-power` probe NULL-derefs on BCM2712. Found during target validation. |

All three gated on `IOTGW_ENABLE_HW_WATCHDOG` (default `"1"`).

## panic-recovery.cfg

New always-applied kernel fragment:
- `CONFIG_PANIC_TIMEOUT=30` — kernel-baked default panic timeout
- `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y` — escalate oops to panic

Together they close the early-boot "kernel hangs requiring power cycle" failure class. Reviewer-suggested split from pstore-persist.cfg: panic recovery is reboot policy, pstore is post-mortem capture — orthogonal.

## kas/watchdog.yml hardening

Discovered during bring-up: kas merge order made a hard `=` in an included file silently override a hard `=` in the parent's `local_conf_header`, defeating attempts to disable a toggle for diagnostic builds. Switched to weak `?=` defaults so `kas/local.yml` overrides win regardless of include order.

Also: `IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG` defaults to `"0"` until the systemd PID1 ping bug is fixed (see follow-up issue).

## Validation on RPi5 hardware

- `bcm2835-pm` + `bcm2835-power` + `bcm2835-wdt` all probe cleanly (`dmesg`)
- `/dev/watchdog0` created with identity `Broadcom BCM2835 Watchdog timer`
- `wdctl` reports `KEEPALIVEPING` flag set, timeout configurable
- **Userspace ping test** (`WDIOC_SETTIMEOUT 10s` + `WDIOC_KEEPALIVE` every 3s for 60s): all 20 pings keep the box alive, magic close disarms cleanly
- `sysrq-c` panic still works end-to-end (records persisted on `/data/crash/pstore` via PR #53's pstore stack)
- RAUC slot-switch and power-off behavior unchanged

## What's deliberately not in this PR

`IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG = 1` does **not** keep the box alive on this kernel: PID1 opens `/dev/watchdog0`, announces a 20s timeout, but the hardware fires at ~21s as if no pings happened. Userspace ping test on the same hardware works fine, so the driver and silicon are healthy — the bug is somewhere in systemd's automatic ping dispatch on this kernel. Tracked as a separate follow-up issue.

Users who want active watchdog feeding *now* can use a custom daemon with the working `WDIOC_KEEPALIVE` ioctl pattern.

## Test plan

- [x] `bcm2835-pm`, `bcm2835-power`, `bcm2835-wdt` probe (dmesg)
- [x] `/dev/watchdog0` exists and `wdctl` reports BCM2835 identity
- [x] Userspace `WDIOC_SETTIMEOUT` + `WDIOC_KEEPALIVE` keeps the timer alive
- [x] Magic close disarms the watchdog
- [x] sysrq-c → ramoops → records on `/data/crash/pstore` (existing crash-debug flow unaffected)
- [x] No regressions in RAUC slot-switch flow