### PR TITLE
release: v0.4.0 — version bump, changelog, release tooling, CI lint

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -1,0 +1,58 @@
+name: release-hygiene
+
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main, "release-*" ]
+  workflow_dispatch:
+
+jobs:
+  hygiene:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Ensure release docs/scripts exist
+        run: |
+          test -f docs/RELEASE.md
+          test -f scripts/release-build.sh
+          test -f scripts/release-manifest.sh
+
+      - name: Shell syntax checks
+        run: |
+          bash -n scripts/release-build.sh
+          bash -n scripts/release-manifest.sh
+
+      - name: shellcheck (all tracked scripts)
+        run: |
+          mapfile -t scripts < <(git ls-files 'scripts/*.sh')
+          if [[ ${#scripts[@]} -eq 0 ]]; then
+            echo "no tracked scripts/*.sh found"
+            exit 0
+          fi
+          shellcheck -S warning "${scripts[@]}"
+
+      - name: Install yamllint
+        run: pip install --quiet yamllint==1.35.1
+
+      - name: yamllint (kas configs and workflows)
+        run: |
+          mapfile -t yamls < <(git ls-files 'kas/*.yml' '.github/workflows/*.yml')
+          if [[ ${#yamls[@]} -eq 0 ]]; then
+            echo "no tracked kas or workflow yaml found"
+            exit 0
+          fi
+          yamllint "${yamls[@]}"
+
+      - name: Changelog link sanity
+        run: |
+          grep -nE '^\[Unreleased\]:' CHANGELOG.md
+          grep -nE '^## \[[0-9]+\.[0-9]+\.[0-9]+\] - [0-9]{4}-[0-9]{2}-[0-9]{2}$' CHANGELOG.md
+
+      - name: Version variable sanity
+        run: |
+          grep -nE 'IOTGW_VERSION_MAJOR \?= "[0-9]+"' meta-iot-gateway/conf/distro/include/iotgw-common.inc
+          grep -nE 'IOTGW_VERSION_MINOR \?= "[0-9]+"' meta-iot-gateway/conf/distro/include/iotgw-common.inc
+          grep -nE 'IOTGW_VERSION_PATCH \?= "[0-9]+"' meta-iot-gateway/conf/distro/include/iotgw-common.inc

--- a/.gitignore
+++ b/.gitignore
@@ -43,6 +43,7 @@ claude.md
 CLAUDE.md
 .agents/
 .claude/
+.codex
 docs/kernel-config-reference/
 dev/
 docs/signature.rst

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,20 @@
+---
+# Pragmatic YAML hygiene for kas configs and GitHub Actions workflows.
+# Focus: real syntax / structural issues. Style noise (line length, doc start)
+# is suppressed because kas long-lines and YAML files without --- are common.
+extends: default
+
+rules:
+  line-length: disable
+  document-start: disable
+  brackets: disable
+  braces: disable
+  truthy:
+    allowed-values: ["true", "false", "yes", "no", "on", "off"]
+    check-keys: false
+  comments:
+    min-spaces-from-content: 1
+  comments-indentation: disable
+  indentation:
+    spaces: 2
+    indent-sequences: consistent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,57 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-09
+
+### Added
+- U-Boot hardening framework with feature-gated posture tokens:
+  `surface_reduce`, `fit_enforce`, `appliance_lockdown`.
+- Production U-Boot lockdown profile with env write allowlist and
+  force-bypass blocking (`CONFIG_ENV_ACCESS_IGNORE_FORCE=y`).
+- Production build guard for U-Boot FIT signing key policy
+  (`iotgw-uboot-prod-key-guard.bbclass`).
+- Optional crash-debug kernel profile (`IOTGW_ENABLE_CRASH_DEBUG_DEV`) layered
+  on pstore persistence for deterministic reboot-on-oops/panic lab workflows.
+- Optional dedicated kernel BTF/CO-RE metadata lane
+  (`IOTGW_ENABLE_BTF_CORE_DEV` -> `igw_btf_core_dev`) with
+  `pahole-native` dependency gating.
+- U-Boot defconfig patch raising `CONFIG_SYS_BOOTM_LEN=0x8000000` for larger
+  FIT kernel decompression envelopes.
+- LSM/IMA feature gates and RPi EEPROM/VCIO integration switches.
+- OTA/RAUC PKCS#11 and encrypted-bundle feature-gated plumbing.
+- Release tooling: `docs/RELEASE.md`, `scripts/release-build.sh`,
+  `scripts/release-manifest.sh`, and a `release-hygiene` GitHub Actions
+  workflow running `shellcheck` on tracked scripts and `yamllint`
+  (config: `.yamllint`) on tracked kas configs and workflows, plus
+  changelog/version-variable sanity gates.
+
+### Changed
+- RAUC install/reconcile flow hardened; clean `fstab` preservation improved.
+- OTA updater/cert runtime behavior gated with shared OTA user model.
+- U-Boot `iotgw_set_bootargs` now honors `EXTRA_KERNEL_ARGS`; provisioning
+  automation applies boot policy (`IOTGW_UBOOT_BOOTDELAY`,
+  `IOTGW_UBOOT_EXTRA_KERNEL_ARGS`) with lockdown-aware behavior.
+- Recovery kernel feature set alignment tightened by removing unconditional
+  observability-dev coupling.
+- Telegraf startup now gates on non-empty credential files.
+- RAUC environment handling tightened with enforced `/etc/fw_env.config`
+  via overlay reconciliation.
+
+### Fixed
+- OTA updater key/cert preflight sequencing and key-option initialization fixes.
+- OTA polling TPM updater gating and preflight behavior fixes.
+- OTA cert provisioning behavior decoupled from PKCS#11 readiness checks.
+- `tpm2` packaging/runtime fixes for offline `pytss` build and PKCS#11 tools.
+- Corrected patch metadata author attribution in `otbr-socket-dir.patch`.
+
+### Documentation
+- Added/expanded U-Boot hardening architecture reference.
+- OTA/RAUC docs refactored and provisioning script guidance updated.
+- Kernel driver backport field guide added.
+- U-Boot hardening and kernel configuration references updated for current
+  bootargs policy automation, `SYS_BOOTM_LEN` rationale, and
+  `igw_btf_core_dev` semantics.
+
 ## [0.3.1] - 2026-04-08
 
 ### Changed
@@ -120,7 +171,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added adaptive OTA benchmark and troubleshooting guidance for field validation.
 - Added HTTPS streaming OTA notes and refreshed operational docs for build/partition/security flows.
 
-[Unreleased]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/umair-as/rpi5-iot-gateway/compare/v0.1.0...v0.2.0

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 **A Yocto-based Linux distribution for IoT gateway applications**
 
+[![release-hygiene](https://github.com/umair-as/rpi5-iot-gateway/actions/workflows/release-hygiene.yml/badge.svg?branch=main)](https://github.com/umair-as/rpi5-iot-gateway/actions/workflows/release-hygiene.yml)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Yocto](https://img.shields.io/badge/Yocto-Scarthgap-orange.svg)](https://www.yoctoproject.org/)
 [![Platform](https://img.shields.io/badge/platform-Raspberry%20Pi%205-c51a4a.svg)](https://www.raspberrypi.com/products/raspberry-pi-5/)

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -98,6 +98,9 @@ Kernel debugging and tracing (development only).
 
 **⚠️ WARNING:** Development only! Do not use in production.
 
+This lane intentionally excludes heavyweight DWARF/BTF metadata knobs so
+general observability and CO-RE metadata can be toggled independently.
+
 **Usage:**
 ```bash
 # Confirm eBPF kernel plumbing is available (installed by default in dev images)
@@ -110,6 +113,37 @@ bpftool map show
 # Function tracing
 echo function > /sys/kernel/debug/tracing/current_tracer
 cat /sys/kernel/debug/tracing/trace
+```
+
+---
+
+### `igw_btf_core_dev`
+
+Dedicated BTF/CO-RE lab metadata lane (development only).
+
+**Features:** DWARF4 debug info + BTF + BTF modules metadata, with
+`pahole-native` build dependency enabled only when this lane is active.
+
+**Enable via gate:**
+
+```bash
+IOTGW_ENABLE_BTF_CORE_DEV=1
+```
+
+This appends `igw_btf_core_dev` to `IOTGW_KERNEL_FEATURES` and enables:
+- `CONFIG_DEBUG_INFO=y`
+- `CONFIG_DEBUG_INFO_DWARF4=y`
+- `CONFIG_DEBUG_INFO_BTF=y`
+- `CONFIG_DEBUG_INFO_BTF_MODULES=y`
+
+**Use for:** libbpf CO-RE workflows where `/sys/kernel/btf/vmlinux` and module
+BTF availability are required.
+
+**Verification:**
+
+```bash
+test -r /sys/kernel/btf/vmlinux && echo "vmlinux BTF present"
+bpftool btf show | head
 ```
 
 ---

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -40,9 +40,9 @@ Release version override example:
 
 ```bash
 IOTGW_VERSION_MAJOR=0 \
-IOTGW_VERSION_MINOR=3 \
+IOTGW_VERSION_MINOR=4 \
 IOTGW_VERSION_PATCH=0 \
-IOTGW_BUILD_ID=20260408 \
+IOTGW_BUILD_ID=20260509 \
 make bundle-prod-full
 ```
 

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,123 @@
+# Release Process (Lightweight, Reproducible)
+
+This project uses a lightweight release flow suited for personal infrastructure:
+
+- Cheap CI checks on GitHub Actions (no full Yocto build on hosted runners)
+- Deterministic local build from a tagged commit
+- Published release evidence (manifest + checksums)
+
+## 1. Release Branch and Scope
+
+1. Create a release branch from `main`:
+   `git checkout -b release-vX.Y.Z`
+2. Freeze scope to release-only changes:
+   - version bump
+   - changelog
+   - docs/runbook updates
+   - critical release fixes only
+
+## 2. Version Bump
+
+Update:
+
+- `meta-iot-gateway/conf/distro/include/iotgw-common.inc`
+  - `IOTGW_VERSION_MAJOR`
+  - `IOTGW_VERSION_MINOR`
+  - `IOTGW_VERSION_PATCH`
+- `CHANGELOG.md`
+  - cut `## [X.Y.Z] - YYYY-MM-DD` from `Unreleased`
+  - update bottom compare links
+
+## 3. Tag First, Then Build
+
+Build only from an annotated tag:
+
+```bash
+git checkout main
+git merge --ff-only release-vX.Y.Z
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin main vX.Y.Z
+```
+
+## 4. Deterministic Local Build (Heavy Step)
+
+Use release wrapper from clean tree:
+
+```bash
+scripts/release-build.sh \
+  --version X.Y.Z \
+  --build-id YYYYMMDDHHMM \
+  --image dev \
+  --bundle full-fit
+```
+
+For production profile:
+
+```bash
+scripts/release-build.sh \
+  --version X.Y.Z \
+  --build-id YYYYMMDDHHMM \
+  --image prod \
+  --bundle full
+```
+
+## 5. Release Evidence Bundle
+
+Generate manifest and checksums:
+
+```bash
+scripts/release-manifest.sh \
+  --tag vX.Y.Z \
+  --version X.Y.Z \
+  --build-id YYYYMMDDHHMM
+```
+
+Output directory:
+
+- `release/vX.Y.Z/manifest.txt`
+- `release/vX.Y.Z/checksums.sha256`
+
+## 6. Device Verification (Minimum)
+
+On target after install/reboot:
+
+```bash
+cat /etc/os-release
+cat /etc/buildinfo
+rauc status
+```
+
+Confirm:
+
+- `DISTRO_VERSION=igw.X.Y.Z`
+- expected release track (`dev` or `prod`)
+- expected active slot and boot status
+
+## 7. Publish Release
+
+Attach to GitHub release:
+
+- `CHANGELOG.md` notes
+- `release/vX.Y.Z/manifest.txt`
+- `release/vX.Y.Z/checksums.sha256`
+- serial/log evidence links (if available)
+
+## 8. What GitHub Actions Does
+
+The workflow intentionally runs only fast hygiene checks (no Yocto build):
+
+- release docs/scripts presence
+- `bash -n` syntax check on release scripts
+- `shellcheck -S warning` on all tracked `scripts/*.sh`
+- `yamllint` on tracked `kas/*.yml` and `.github/workflows/*.yml`
+  (rules in `.yamllint`)
+- `CHANGELOG.md` has `[Unreleased]:` link and at least one
+  `## [X.Y.Z] - YYYY-MM-DD` section
+- `IOTGW_VERSION_{MAJOR,MINOR,PATCH}` variable form is present in
+  `iotgw-common.inc`
+
+Triggers: PRs targeting `main`, pushes to `main` and `release-*`,
+manual `workflow_dispatch`.
+
+It does **not** attempt full Yocto builds, recipe parsing, or `kas dump`
+on free-tier runners.

--- a/docs/UBOOT_HARDENING.md
+++ b/docs/UBOOT_HARDENING.md
@@ -198,13 +198,16 @@ runtime boot policy override". Runtime kernel-args injection *is* a boot
 policy override; in prod it's blocked, in dev it's an intentional
 operator escape hatch.
 
-If a deployed prod fleet ever needs cmdline tuning, the path is:
+If a deployed prod fleet ever needs cmdline tuning, use a signed-image path:
 1. Build a new image with the desired arg in `cmdline.txt` via
-   `rpi-cmdline.bbappend`'s `CMDLINE:append`, or
-2. Use a future build-time policy variable (`IOTGW_UBOOT_EXTRA_KERNEL_ARGS`,
-   tracked as Issue #54 follow-up Part B) that bakes the value into
-   `iotgw_set_bootargs` itself rather than going through env writes —
-   bypasses the lockdown by being part of the signed image.
+   `rpi-cmdline.bbappend`'s `CMDLINE:append`, and/or
+2. Set build-time policy variable `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` in the
+   image build inputs.
+
+`IOTGW_UBOOT_EXTRA_KERNEL_ARGS` is consumed by provisioning policy wiring:
+`iotgw-provision.sh` applies it to U-Boot env only where runtime env writes are
+allowed (dev posture). Under `appliance_lockdown`, runtime writes are rejected
+by design, so production remains signed-image-driven.
 
 ### OTA env-refresh caveat
 
@@ -221,10 +224,25 @@ take effect. Recovery is a one-time `env default iotgw_set_bootargs;
 saveenv` from the U-Boot prompt. Fresh WIC flashes pick up the new
 default automatically.
 
-Tracked for automation under the same Issue #54 follow-up — provisioning
-will eventually `fw_setenv` the canonical `iotgw_set_bootargs` on first
-boot of an updated slot, parallel to how `IOTGW_UBOOT_BOOTDELAY` is
-applied today.
+Automation is now in place: provisioning (`iotgw-provision.sh`) detects stale
+persisted `iotgw_set_bootargs` values on non-lockdown images and clears them so
+the updated compiled default takes effect on the next boot.
+
+On `appliance_lockdown` images, this reconciliation is intentionally skipped
+because the env writeable-list blocks such writes by policy.
+
+### Larger FIT kernels: `SYS_BOOTM_LEN`
+
+To support larger compressed FIT kernel payloads, the project carries:
+
+```
+CONFIG_SYS_BOOTM_LEN=0x8000000
+```
+
+via patch
+`0004-configs-rpi_arm64_defconfig-increase-SYS_BOOTM_LEN-for-larger-fit-kernels.patch`.
+This prevents bootm decompression buffer exhaustion as kernel/FIT payload size
+grows (for example when debug/BTF metadata is enabled in dev lanes).
 
 ### Production key guard
 

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -11,7 +11,7 @@ TARGET_VENDOR ?= "-${VENDOR_SHORT_NAME}"
 # Distro/versioning policy (override OE-Core default 'nodistro.0')
 # Keep version components explicit so release policy can bump one field at a time.
 IOTGW_VERSION_MAJOR ?= "0"
-IOTGW_VERSION_MINOR ?= "3"
+IOTGW_VERSION_MINOR ?= "4"
 IOTGW_VERSION_PATCH ?= "0"
 IOTGW_VERSION ?= "${IOTGW_VERSION_MAJOR}.${IOTGW_VERSION_MINOR}.${IOTGW_VERSION_PATCH}"
 DISTRO_VERSION ?= "${VENDOR_SHORT_NAME}.${IOTGW_VERSION}"

--- a/scripts/release-build.sh
+++ b/scripts/release-build.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/release-build.sh --version X.Y.Z --build-id ID [--image dev|prod|base|desktop] [--bundle none|rootfs|full|full-fit]
+
+Examples:
+  scripts/release-build.sh --version 0.4.0 --build-id 202605091930 --image dev --bundle full-fit
+  scripts/release-build.sh --version 0.4.0 --build-id 202605091930 --image prod --bundle full
+EOF
+}
+
+require_clean_tree() {
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "error: working tree must be clean before release build" >&2
+        exit 1
+    fi
+}
+
+version=""
+build_id=""
+image="dev"
+bundle="none"
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --version) version="${2:-}"; shift 2 ;;
+        --build-id) build_id="${2:-}"; shift 2 ;;
+        --image) image="${2:-}"; shift 2 ;;
+        --bundle) bundle="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "error: unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$version" || -z "$build_id" ]]; then
+    echo "error: --version and --build-id are required" >&2
+    usage
+    exit 1
+fi
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    echo "error: --version must be semantic X.Y.Z (got: ${version})" >&2
+    exit 1
+fi
+
+case "$image" in
+    dev|prod|base|desktop) ;;
+    *) echo "error: invalid --image: $image" >&2; exit 1 ;;
+esac
+
+case "$bundle" in
+    none|rootfs|full|full-fit) ;;
+    *) echo "error: invalid --bundle: $bundle" >&2; exit 1 ;;
+esac
+
+require_clean_tree
+
+export IOTGW_VERSION_MAJOR="${version%%.*}"
+rest="${version#*.}"
+export IOTGW_VERSION_MINOR="${rest%%.*}"
+export IOTGW_VERSION_PATCH="${version##*.}"
+export IOTGW_BUILD_ID="$build_id"
+
+echo "[release-build] version=${version} build_id=${build_id} image=${image} bundle=${bundle}"
+echo "[release-build] git=$(git rev-parse --short HEAD)"
+
+make_target=""
+case "$image" in
+    dev) make_target="dev" ;;
+    prod) make_target="prod" ;;
+    base) make_target="base" ;;
+    desktop) make_target="desktop" ;;
+esac
+
+echo "[release-build] building image target: make ${make_target}"
+make "${make_target}"
+
+if [[ "$bundle" != "none" ]]; then
+    bundle_target=""
+    case "$bundle:$image" in
+        rootfs:dev) bundle_target="bundle-dev" ;;
+        rootfs:desktop) bundle_target="bundle-desktop" ;;
+        full:dev) bundle_target="bundle-dev-full" ;;
+        full:prod) bundle_target="bundle-prod-full" ;;
+        full:desktop) bundle_target="bundle-desktop-full" ;;
+        full-fit:dev) bundle_target="bundle-dev-full-fit" ;;
+        full-fit:base) bundle_target="bundle-base-full-fit-fast" ;;
+        *)
+            echo "error: unsupported image/bundle combination: image=${image}, bundle=${bundle}" >&2
+            exit 1
+            ;;
+    esac
+    echo "[release-build] building bundle target: make ${bundle_target}"
+    make "${bundle_target}"
+fi
+
+echo "[release-build] completed"

--- a/scripts/release-manifest.sh
+++ b/scripts/release-manifest.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<'EOF'
+Usage:
+  scripts/release-manifest.sh --tag vX.Y.Z --version X.Y.Z --build-id ID [--outdir release/vX.Y.Z]
+EOF
+}
+
+tag=""
+version=""
+build_id=""
+outdir=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tag) tag="${2:-}"; shift 2 ;;
+        --version) version="${2:-}"; shift 2 ;;
+        --build-id) build_id="${2:-}"; shift 2 ;;
+        --outdir) outdir="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "error: unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+if [[ -z "$tag" || -z "$version" || -z "$build_id" ]]; then
+    echo "error: --tag, --version, --build-id are required" >&2
+    usage
+    exit 1
+fi
+
+if [[ -z "$outdir" ]]; then
+    outdir="release/${tag}"
+fi
+
+mkdir -p "$outdir"
+
+manifest="${outdir}/manifest.txt"
+checksums="${outdir}/checksums.sha256"
+
+if [[ -z "$(git status --porcelain)" ]]; then
+    git_status_clean=yes
+else
+    git_status_clean=no
+fi
+
+kas_files=""
+for f in kas/*.yml; do
+    [[ -f "$f" ]] && kas_files+="$(basename "$f") "
+done
+distro_version_default="$(grep -nE 'IOTGW_VERSION_(MAJOR|MINOR|PATCH) \?=' meta-iot-gateway/conf/distro/include/iotgw-common.inc | tr '\n' ';')"
+
+{
+    echo "release_tag=${tag}"
+    echo "release_version=${version}"
+    echo "build_id=${build_id}"
+    echo "generated_at_utc=$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "git_commit=$(git rev-parse HEAD)"
+    echo "git_commit_short=$(git rev-parse --short HEAD)"
+    echo "git_branch=$(git branch --show-current)"
+    echo "git_status_clean=${git_status_clean}"
+    echo "kas_files=${kas_files}"
+    echo "distro_version_default=${distro_version_default}"
+} > "$manifest"
+
+# Checksums of common deploy artifacts when present.
+tmp_list="$(mktemp)"
+find build/tmp/deploy -type f \( \
+    -name "*.raucb" -o \
+    -name "*.wic" -o \
+    -name "*.wic.bz2" -o \
+    -name "fitImage*" -o \
+    -name "u-boot.bin" -o \
+    -name "Image" -o \
+    -name "kernel_2712.img" \
+    \) -print0 2>/dev/null | sort -z > "$tmp_list" || true
+
+if [[ -s "$tmp_list" ]]; then
+    xargs -0 sha256sum < "$tmp_list" > "$checksums"
+else
+    : > "$checksums"
+fi
+
+rm -f "$tmp_list"
+
+echo "[release-manifest] wrote ${manifest}"
+echo "[release-manifest] wrote ${checksums}"


### PR DESCRIPTION
## Summary

Cuts release **v0.4.0** on top of the work already merged via #48–#58. Substance of this PR is in two places:

- **Release tooling**: `docs/RELEASE.md`, `scripts/release-build.sh` (semver-guarded wrapper), `scripts/release-manifest.sh` (manifest + checksums).
- **CI lint gates** (`release-hygiene` workflow): `shellcheck -S warning` across all tracked `scripts/*.sh` and `yamllint` (config: `.yamllint`) across tracked `kas/*.yml` and workflows. Plus changelog format and `IOTGW_VERSION_*` variable-form gates. Triggers on PRs to `main` and pushes to `main` / `release-*`.

Version bump `0.3 → 0.4.0`, CHANGELOG cut, README badge, and doc refreshes (`KERNEL.md` for `igw_btf_core_dev`, `UBOOT_HARDENING.md` for `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` and `SYS_BOOTM_LEN`).

No Yocto build / recipe parse in CI — full builds remain a local step per `docs/RELEASE.md`.

## Test plan

- [x] `release-hygiene` green on branch (run `25610826493`, 9s)
- [x] `release-manifest.sh` smoke-tested; semver guard rejects `--version abc`
- [ ] ff-merge to `main`, tag `v0.4.0`, run `release-build.sh` + `release-manifest.sh` from clean tree
- [ ] On-target: `/etc/os-release` shows `igw.0.4.0`; `rauc status` reports expected slot