### PR TITLE
fix(release): auto-detect deploy root in release-manifest.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- `scripts/release-manifest.sh` now auto-detects the Yocto deploy directory
+  (`build/tmp/deploy` or `build/tmp-glibc/deploy`) instead of hardcoding
+  `build/tmp/deploy`. The v0.4.0 script silently produced an empty
+  `checksums.sha256` on `iotgw` (which renames `TMPDIR` to `tmp-glibc`).
+  Override with `IOTGW_DEPLOY_ROOT` for non-standard layouts. Manifest now
+  records `deploy_root` for traceability.
+
 ## [0.4.0] - 2026-05-09
 
 ### Added

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -74,8 +74,15 @@ scripts/release-manifest.sh \
 
 Output directory:
 
-- `release/vX.Y.Z/manifest.txt`
+- `release/vX.Y.Z/manifest.txt` (includes `deploy_root` field)
 - `release/vX.Y.Z/checksums.sha256`
+
+The deploy directory is auto-detected (`build/tmp/deploy` or
+`build/tmp-glibc/deploy`). Override for non-standard layouts:
+
+```bash
+IOTGW_DEPLOY_ROOT=/path/to/deploy scripts/release-manifest.sh ...
+```
 
 ## 6. Device Verification (Minimum)
 

--- a/scripts/release-manifest.sh
+++ b/scripts/release-manifest.sh
@@ -51,6 +51,19 @@ for f in kas/*.yml; do
 done
 distro_version_default="$(grep -nE 'IOTGW_VERSION_(MAJOR|MINOR|PATCH) \?=' meta-iot-gateway/conf/distro/include/iotgw-common.inc | tr '\n' ';')"
 
+# Auto-detect deploy root. Yocto's default is build/tmp/deploy, but distros
+# that rename TMPDIR (e.g. iotgw uses tmp-glibc) put artifacts elsewhere.
+# Allow override via IOTGW_DEPLOY_ROOT for non-standard layouts.
+deploy_root="${IOTGW_DEPLOY_ROOT:-}"
+if [[ -z "$deploy_root" ]]; then
+    for cand in build/tmp/deploy build/tmp-glibc/deploy; do
+        if [[ -d "$cand" ]]; then
+            deploy_root="$cand"
+            break
+        fi
+    done
+fi
+
 {
     echo "release_tag=${tag}"
     echo "release_version=${version}"
@@ -62,19 +75,28 @@ distro_version_default="$(grep -nE 'IOTGW_VERSION_(MAJOR|MINOR|PATCH) \?=' meta-
     echo "git_status_clean=${git_status_clean}"
     echo "kas_files=${kas_files}"
     echo "distro_version_default=${distro_version_default}"
+    echo "deploy_root=${deploy_root}"
 } > "$manifest"
 
 # Checksums of common deploy artifacts when present.
 tmp_list="$(mktemp)"
-find build/tmp/deploy -type f \( \
-    -name "*.raucb" -o \
-    -name "*.wic" -o \
-    -name "*.wic.bz2" -o \
-    -name "fitImage*" -o \
-    -name "u-boot.bin" -o \
-    -name "Image" -o \
-    -name "kernel_2712.img" \
-    \) -print0 2>/dev/null | sort -z > "$tmp_list" || true
+if [[ -n "$deploy_root" && -d "$deploy_root" ]]; then
+    find "$deploy_root" -type f \( \
+        -name "*.raucb" -o \
+        -name "*.wic" -o \
+        -name "*.wic.bz2" -o \
+        -name "fitImage*" -o \
+        -name "u-boot.bin" -o \
+        -name "Image" -o \
+        -name "kernel_2712.img" \
+        \) -print0 2>/dev/null | sort -z > "$tmp_list" || true
+else
+    if [[ -n "${IOTGW_DEPLOY_ROOT:-}" ]]; then
+        echo "[release-manifest] warning: IOTGW_DEPLOY_ROOT='${IOTGW_DEPLOY_ROOT}' is not a directory; checksums will be empty" >&2
+    else
+        echo "[release-manifest] warning: no deploy directory found (tried build/tmp/deploy, build/tmp-glibc/deploy); set IOTGW_DEPLOY_ROOT to override" >&2
+    fi
+fi
 
 if [[ -s "$tmp_list" ]]; then
     xargs -0 sha256sum < "$tmp_list" > "$checksums"


### PR DESCRIPTION
## Summary

`scripts/release-manifest.sh` (shipped in v0.4.0) hardcoded `build/tmp/deploy` and silently emitted an **empty** `checksums.sha256` against this project's real TMPDIR (`build/tmp-glibc/deploy` — the `iotgw` distro renames `TMPDIR`). Surfaced when generating the v0.4.0 release evidence.

## Fix

- Auto-detect `build/tmp/deploy` then `build/tmp-glibc/deploy`.
- `IOTGW_DEPLOY_ROOT` env var overrides for non-standard layouts.
- Manifest now records `deploy_root=<path>` for traceability.
- Warn (not fail) when no deploy directory is found.

## Test plan

- [x] `shellcheck -S warning` clean
- [x] Smoke test on this project: 8 artifacts hashed (was 0); manifest reports `deploy_root=build/tmp-glibc/deploy`
- [x] Override test: `IOTGW_DEPLOY_ROOT=/nonexistent` → empty checksums + accurate warning
- [x] No-deploy test: warning emitted, manifest still written
- [ ] `release-hygiene` CI green on PR