### PR TITLE
feat(otbr): event-driven otbr-agent via udev + BindsTo

### DIFF
--- a/meta-iot-gateway/recipes-connectivity/otbr/README.md
+++ b/meta-iot-gateway/recipes-connectivity/otbr/README.md
@@ -12,7 +12,7 @@ build path. It is not the default runtime model used by the gateway images.
 ## Included Recipes
 
 - `otbr-rpi5.bb`: host OTBR package
-- `otbr-webui_0.1.0.bb`: web UI package used by host OTBR path
+- `otbr-webui_0.1.1.bb`: web UI package used by host OTBR path
 - `otbr-rpi5-container.bb`: OCI image recipe for containerized OTBR
 - `otbr-rpi5-container/entrypoint.sh`: container entrypoint
 

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5.bb
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5.bb
@@ -88,8 +88,10 @@ EXTRA_OECMAKE = " \
 # Enable telemetry and link metrics for richer D-Bus/dashboard data.
 EXTRA_OECMAKE:append = " -DOTBR_TELEMETRY_DATA_API=ON -DOTBR_LINK_METRICS_TELEMETRY=ON -DOTBR_FEATURE_FLAGS=ON"
 
-# Enable and configure systemd services
-SYSTEMD_AUTO_ENABLE = "enable"
+# otbr-agent is udev-activated (see otbr-rcp.rules: SYSTEMD_WANTS).
+# Do not enable via WantedBy=multi-user.target — that would pull the unit
+# into the boot transaction and block on the missing dev-otbr\x2drcp.device.
+SYSTEMD_AUTO_ENABLE = "disable"
 SYSTEMD_SERVICE:${PN} = "otbr-agent.service"
 
 # Install fixed systemd service files

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent.service
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent.service
@@ -1,8 +1,11 @@
 [Unit]
 Description=OpenThread Border Router Agent
 ConditionPathExists=/usr/sbin/otbr-agent
-Requires=dbus.socket avahi-daemon.service dev-otbr\x2drcp.device
-After=dbus.socket avahi-daemon.service dev-otbr\x2drcp.device
+ConditionPathExists=/dev/otbr-rcp
+Requires=dbus.socket avahi-daemon.service
+After=dbus.socket avahi-daemon.service
+BindsTo=dev-otbr\x2drcp.device
+After=dev-otbr\x2drcp.device
 
 [Service]
 User=otbr
@@ -22,6 +25,11 @@ KillMode=mixed
 Restart=on-failure
 RestartSec=5
 RestartPreventExitStatus=SIGKILL
+# otbr-agent exits 5 when the RCP serial port disappears mid-operation
+# (RCP unplug). BindsTo=dev-otbr-rcp.device already stops the unit cleanly
+# in that case; treat exit 5 as success so `systemctl status` stays green
+# instead of showing a stale "failed" after every unplug.
+SuccessExitStatus=5
 
 # Capabilities and hardening
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW CAP_NET_BIND_SERVICE
@@ -47,6 +55,8 @@ StateDirectory=thread
 ReadWritePaths=/var/lib/thread
 ReadWritePaths=/run
 
-[Install]
-WantedBy=multi-user.target
-Alias=otbr-agent.service
+# No [Install] section: activation is exclusively via the udev rule
+# (ENV{SYSTEMD_WANTS}+="otbr-agent.service") when /dev/otbr-rcp appears.
+# A WantedBy=multi-user.target would pull this unit into the boot transaction
+# and block on `After=dev-otbr\x2drcp.device` until DefaultTimeoutStartSec,
+# even though ConditionPathExists would ultimately skip it.

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-rcp.rules
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-rcp.rules
@@ -1,1 +1,1 @@
-SUBSYSTEM=="tty", KERNEL=="ttyACM*", GROUP="dialout", MODE="0660", SYMLINK+="otbr-rcp"
+SUBSYSTEM=="tty", KERNEL=="ttyACM*", GROUP="dialout", MODE="0660", SYMLINK+="otbr-rcp", TAG+="systemd", ENV{SYSTEMD_WANTS}+="otbr-agent.service"

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-webui/otbr-webui.service
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-webui/otbr-webui.service
@@ -1,7 +1,5 @@
 [Unit]
 Description=OpenThread Border Router Web UI
-After=otbr-agent.service
-Wants=otbr-agent.service
 
 [Service]
 User=otbr

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-webui_0.1.1.bb
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-webui_0.1.1.bb
@@ -9,8 +9,9 @@ SRC_URI = " \
     file://otbr-webui.service \
     file://otbr-webui.default \
 "
-SRCREV = "63af7a54e31b0c4b0dd416c7ec3e3e2165a7371b"
+SRCREV = "b9d735370bd56b269e5c0439b8ca3f68d8425ee0"
 S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
 
 DEPENDS = "nodejs-bin-native"
 

--- a/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/managed-paths.conf
@@ -54,3 +54,9 @@ enforce /etc/systemd/system.conf.d/10-iotgw-tpm-defaults.conf optional
 enforce_meta /etc/ota/pkcs11-pin uid=root gid=ota mode=0640 optional
 absent /etc/systemd/system/rauc-mark-good.service
 absent /etc/systemd/system/boot-backup-prune.service
+# otbr-agent is now udev-activated (see otbr-rcp.rules: SYSTEMD_WANTS).
+# Scrub legacy [Install] symlinks from pre-bindsto images; otherwise systemd
+# still queues otbr-agent at boot and stalls multi-user.target on the missing
+# dev-otbr\x2drcp.device (~90s DefaultTimeoutStartSec).
+absent /etc/systemd/system/multi-user.target.wants/otbr-agent.service
+absent /etc/systemd/system/otbr-agent.service


### PR DESCRIPTION
## Summary

Make `otbr-agent` purely event-driven by the RCP serial device instead of being pulled into the boot transaction. Drops cold-boot userspace from **~1 min 32 s → ~10.7 s** when no RCP is plugged in. Also bumps `otbr-webui` to `0.1.1`.

## What changed

- **udev rule** (`otbr-rcp.rules`): `TAG+="systemd"` + `ENV{SYSTEMD_WANTS}+="otbr-agent.service"`. ttyACM device now materialises `dev-otbr\x2drcp.device` as an active systemd unit and queues the agent.
- **otbr-agent.service**: `BindsTo=dev-otbr\x2drcp.device` + `After=` + `ConditionPathExists=/dev/otbr-rcp`. **`[Install]` section removed** — activation is exclusively via udev `SYSTEMD_WANTS`. `SuccessExitStatus=5` so unplug doesn't leave the unit in `failed` state.
- **otbr-rpi5.bb**: `SYSTEMD_AUTO_ENABLE = "disable"` so the image doesn't ship the `multi-user.target.wants/otbr-agent.service` symlink.
- **otbr-webui.service**: decoupled from `otbr-agent` (`Wants=`/`After=` removed). Web UI boots independently — reachable even without an RCP.
- **managed-paths.conf**: `absent` entries for the legacy `multi-user.target.wants/otbr-agent.service` and `Alias=otbr-agent.service` symlinks so OTA upgraders get the prior enablement scrubbed.
- **otbr-webui_0.1.1.bb**: SRCREV bump to `b9d7353` (tip of `main` on github.com/umair-as/otbr-webui). Picks up MIT license, JSON:API + CSP hardening, RLOC16/Routers/Diagnostics fixes, v0.1.1 security hotfix (Origin check, mutation lock, body limits). Also adds explicit `B = "${WORKDIR}/build"` so the GitHub fetch path doesn't collapse `S == B` when externalsrc is inactive.

## Why

Previously, `otbr-agent` was enabled via `WantedBy=multi-user.target` with an implicit `After=` on the (untagged) RCP device unit. Cold boot without the RCP plugged in waited `DefaultTimeoutStartSec` (~90 s) for the device before `ConditionPathExists` could skip the unit. The wait was charged silently to `multi-user.target`:

- No `systemd-analyze blame` entry — self-time was ~200 ms
- Pre-branch `critical-chain` falsely pointed at `otbr-webui` (which had `Wants=otbr-agent.service`)
- Smoking gun was in the journal: `Expecting device /dev/otbr-rcp...` → `Timed out waiting for device` → `Dependency failed for OpenThread Border Router Agent` → `Reached target Multi-User System` (all stamped at the same second)

The fix: take `otbr-agent` out of the boot transaction entirely. udev brings it up on plug, `BindsTo` brings it down on unplug.

## Test plan

Verified on raspberrypi5 over RAUC OTA install + reboot:

- [x] Cold boot without RCP: `multi-user.target @10.731s`, `otbr-agent` loaded `static` and inactive, no `Expecting device` / `Timed out waiting` / `Dependency failed for OpenThread` in journal.
- [x] Cold boot — `otbr-webui` reaches `active (running)` at ~6 s independent of agent state.
- [x] Hot-plug ESP32-H2 RCP: udev creates `/dev/otbr-rcp` symlink → `dev-otbr-rcp.device` active → `otbr-agent` activates within 1 s → Thread stack initialises, NAT64 + Backbone TMF + mDNS meshcop service published.
- [x] Hot-unplug: `BindsTo` stops `otbr-agent` cleanly (mDNS unpublish, avahi group release) before the serial I/O error terminates the process. With `SuccessExitStatus=5`, unit returns to inactive (not failed).
- [x] OTA upgrade path: `managed-paths.conf` overlay-reconcile scrubs legacy `/etc/systemd/system/multi-user.target.wants/otbr-agent.service` symlink from prior installs.

Before / after `systemd-analyze`:

| | Pre-branch | Post-branch (final) |
|---|---|---|
| Userspace | 1 min 31.303 s | **10.754 s** |
| Critical-chain leaf | `otbr-webui @1m31s` (phantom wait) | `influxdb @7.3s +3.5s` (real cost) |