### PR TITLE
fix(kernel): patch CVE-2026-31431 (algif_aead) + edge-healthd v0.6.0

### DIFF
--- a/docs/KERNEL_CVE_PATCH.md
+++ b/docs/KERNEL_CVE_PATCH.md
@@ -1,0 +1,265 @@
+# Kernel CVE Patch — Field Guide
+
+How to turn a Linux kernel CVE into a backport patch carried in this
+Yocto layer, when the upstream fix isn't yet in your pinned `SRCREV`.
+
+**Worked example:** CVE-2026-31431 (`crypto: algif_aead` write-to-page-cache,
+CISA KEV). Stable backport `fafe0fa2` for `linux-6.18.y`, applied against
+our pinned `v6.18.13`.
+
+---
+
+## When to use this approach
+
+| Situation | Use |
+|-----------|-----|
+| CVE is fixed in a stable release past your `SRCREV` but you can't bump the kernel right now | **This guide** |
+| You can bump `SRCREV_machine` forward to a release that includes the fix | Bump and drop any open backport patches for that CVE |
+| The CVE is not yet patched upstream (no commit to backport) | Hold; track the kernel mailing list — out of scope here |
+| Userspace CVE (openssl, glibc, etc.) | Bump the recipe `PV`/`SRCREV` or carry a `.bbappend` patch — same mechanics, different recipe |
+
+For the automated triage that *finds* applicable CVEs, see
+`INHERIT += "cve-check"` and the [Security guide](SECURITY.md). This
+field guide is what you do **after** triage flags an unfixed CVE.
+
+### Patch vs `SRCREV` bump — picking between them
+
+When the fix has landed in a stable release **and** your branch tip is
+ahead of that release, you have two valid options. They aren't
+equivalent — pick deliberately:
+
+| Factor | Carry a backport patch | Bump `SRCREV_machine` to a release containing the fix |
+|---|---|---|
+| Blast radius | One commit, one file, byte-clean revert | Hundreds of commits across the kernel — every stable backport since your pin |
+| Verification effort | Targeted: `do_patch` clean + smoke test the affected subsystem | Broader smoke pass: boot, all live subsystems, regression watch over time |
+| Time to remediation | Hours | Days (validation, regression triage) |
+| Maintenance | Technical debt — must be dropped on next bump | None once landed |
+| Other CVEs / regressions in the window | Not addressed | Picked up "for free" |
+| Reproducibility of the in-flight release | Preserved (same kernel as last validated state) | Changed (now a different validated state) |
+
+**Use the patch path when:**
+- There's a hard deadline (CISA KEV `cisaActionDue`, customer SLA).
+- You just shipped a release on the current `SRCREV` and don't want to
+  invalidate its validation envelope.
+- The vulnerable subsystem is narrow and easy to smoke-test in isolation.
+
+**Use the `SRCREV` bump path when:**
+- You're between releases (no in-flight validation to preserve).
+- The gap between your pin and stable tip is large enough that you're
+  almost certainly missing other security fixes.
+- You have time for a broader smoke pass.
+
+**Use both, in sequence**, when both apply:
+1. Ship the carry-patch immediately for fast remediation.
+2. Open a follow-up issue to bump `SRCREV_machine` to (or past) the
+   stable release that contains the upstream fix, dropping the carry
+   patch in the same commit.
+
+The CVE-2026-31431 work in this repo took option (1) under CISA-KEV
+pressure with the v0.4.0 release fresh, and queued a follow-up for the
+6.18.13 → current-tip bump. Both moves are valid; the failure mode is
+treating the carry-patch as permanent.
+
+---
+
+## 1. Pin down what you're patching
+
+Before touching anything, two facts:
+
+```bash
+# (a) Kernel branch and pinned commit in the layer
+grep -rE "BRANCH|SRCREV_machine|LINUX_VERSION" meta-iot-gateway/recipes-kernel/linux/
+
+# (b) What's actually running on the device
+ssh iotgw "uname -r"
+```
+
+For our example: `linux-6.18.y`, `SRCREV_machine = 25e0b1c2…` (= `v6.18.13`).
+
+## 2. Read the CVE record as JSON, not prose
+
+```bash
+curl -fsSL "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2026-31431" > /tmp/cve.json
+
+# Affected version range for your kernel line
+jq -r '.vulnerabilities[0].cve.configurations[].nodes[].cpeMatch[]
+       | "\(.criteria) | start=\(.versionStartIncluding // "-") end_excl=\(.versionEndExcluding // "-")"' \
+  /tmp/cve.json | grep linux_kernel
+```
+
+This tells you whether you're in range and which release closes it. For
+CVE-2026-31431, the 6.x rows show `6.13 ≤ x < 6.18.22` — so 6.18.13 is
+vulnerable, fix lands in 6.18.22.
+
+Pull the reference URLs:
+
+```bash
+jq -r '.vulnerabilities[0].cve.references[].url' /tmp/cve.json | grep git.kernel.org
+```
+
+The `git.kernel.org/stable/c/<sha>` URLs are the fix commits: one mainline
+plus N stable backports.
+
+## 3. Identify which backport is for your branch
+
+The stable backports for one CVE all carry the same `Subject:` and an
+`[ Upstream commit <sha> ]` trailer — you can't tell them apart from the
+patch headers alone.
+
+Ask cgit for the log of the affected file scoped to your branch and grep
+for the SHAs from step 2:
+
+```bash
+curl -fsSL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/log/crypto/algif_aead.c?h=linux-6.18.y" \
+  | grep -oE 'id=[0-9a-f]{40}' | head -10
+```
+
+The SHA that appears in both lists (NVD references **and** your branch's
+file log) is your backport. For this CVE: `fafe0fa2`.
+
+> If you don't know the affected file: grab any of the backports'
+> patches (`curl ".../patch/?id=<any-sha>" | grep '^---'`) — the diff
+> headers tell you which files changed.
+
+## 4. Fetch the patch in `git format-patch` form
+
+cgit's `/patch/` endpoint returns a ready-to-`git am` mail:
+
+```bash
+curl -fsSL "https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/patch/?id=fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8" \
+  > /tmp/fix.patch
+```
+
+This format is exactly what Yocto's `do_patch` (git am / Quilt) expects.
+**Do not post-process the diff** — leave it byte-identical to upstream.
+Hand-editing the hunks is a sign you grabbed the wrong backport.
+
+## 5. Annotate for Yocto QA
+
+`oe-core` requires two lines for `cve-check.bbclass` and the patch-status
+QA to recognise the patch:
+
+```
+Upstream-Status: Backport [https://git.kernel.org/.../?id=<sha>]
+CVE: CVE-XXXX-XXXXX
+```
+
+Place them **above** the `---` diff separator (so `git am` doesn't choke).
+Easiest is an awk one-liner:
+
+```bash
+awk 'BEGIN{a=0} /^---$/ && !a {
+       print "Upstream-Status: Backport [https://git.kernel.org/.../?id=<sha>]"
+       print "CVE: CVE-XXXX-XXXXX"
+       print ""
+       print; a=1; next
+     } {print}' /tmp/fix.patch \
+  > meta-iot-gateway/recipes-kernel/linux/files/0011-CVE-2026-31431-...patch
+```
+
+Valid `Upstream-Status:` values: `Backport`, `Pending`, `Inappropriate`,
+`Submitted`, `Denied`, `Inactive-Upstream`. For a stable backport, always
+**`Backport`** with the URL of the cherry-pick commit.
+
+## 6. Wire it into the recipe
+
+For this layer, all three kernel variants (mainline, mainline-fit,
+mainline-recovery) share `linux-iotgw-mainline-common.inc`. Add the
+patch there once:
+
+```bitbake
+# Security: CVE-2026-31431 (algif_aead in-place write-to-page-cache; CISA KEV).
+# Stable 6.18.y backport (fafe0fa2) lands in 6.18.22; we pin 6.18.13 so apply
+# the patch directly. Drop this line on the next SRCREV bump past v6.18.22.
+SRC_URI:append = " file://0011-CVE-2026-31431-crypto-algif_aead-revert-to-out-of-place.patch"
+```
+
+Unconditional — security patches don't go behind feature flags. Even if
+the vulnerable kconfig is off in today's image (e.g. our
+`# CONFIG_CRYPTO_USER_API_AEAD is not set`), patching the source means a
+developer who flips the kconfig on later picks up the fixed code.
+
+The inline `# Drop on next SRCREV bump past vX.Y.Z` note prevents the
+patch from ossifying after the next kernel update.
+
+## 7. Verify the patch applies
+
+```bash
+bitbake -c cleansstate virtual/kernel
+bitbake -c patch virtual/kernel    # stops after do_patch; faster than full build
+
+grep -E "Applying patch|FAILED|Hunk" \
+  build/tmp-glibc/work/*-poky-linux/linux-iotgw-mainline*/*/temp/log.do_patch
+```
+
+A clean `Applying patch 0011-...` with **no** `FAILED` / `Hunk` lines
+proves the diff matched your tree exactly.
+
+Belt-and-suspenders after a full build — grep the patched source for a
+string unique to the fix:
+
+```bash
+grep -l "operating out-of-place" \
+  build/tmp-glibc/work/*-poky-linux/linux-iotgw-mainline*/*/git/crypto/algif_aead.c
+```
+
+For CVE-2026-31431 specifically, the AEAD path isn't compiled into our
+production kernel (`# CONFIG_CRYPTO_USER_API_AEAD is not set`), so no
+runtime test exercises it on the default config. See the [Security
+guide](SECURITY.md) for the live crypto surface (`dm-crypt`,
+TPM/openssl, RAUC bundle decrypt) — none of those touch `algif_aead`.
+
+## 8. Track the sunset
+
+Every backport patch is technical debt. Track it in three places:
+
+1. **Inline recipe comment** — *"drop on next SRCREV bump past vX.Y.Z"*.
+2. **Patch filename** — prefix with `CVE-<id>` so a `git grep CVE-`
+   surfaces all of them.
+3. **CHANGELOG** — note the CVE under "Security" for the next release.
+
+When you bump `SRCREV_machine`, sanity-check:
+
+```bash
+# Does the new SRCREV already contain the upstream fix?
+git -C $DL_DIR/git2/git.kernel.org.pub.scm.linux.kernel.git.stable.linux.git \
+    log <old_SRCREV>..<new_SRCREV> -- <affected-file>
+```
+
+If you see the cherry-pick in the log, delete the patch file and the
+`SRC_URI:append` line in the same commit as the bump.
+
+---
+
+## Anti-patterns
+
+- **Don't hand-edit the diff** to force hunks to apply. If a hunk fails,
+  you grabbed the wrong backport — redo step 3.
+- **Don't gate security patches behind feature flags.** Even if the
+  vulnerable kconfig is off today, ship the patched source.
+- **Don't skip `Upstream-Status:`.** It looks pedantic but `cve-check`
+  and PatchTest CI rely on it; a patch without it is invisible to the
+  CVE manifest.
+- **Don't combine multiple CVEs into one patch.** The "drop when SRCREV
+  passes vX.Y.Z" tracking only works if each patch closes exactly one CVE.
+- **Don't forget the recovery and FIT kernel variants.** Put the
+  `SRC_URI:append` in `linux-iotgw-mainline-common.inc`, not in one
+  variant `.bb`.
+
+## Cheat-sheet
+
+| Task | Command |
+|---|---|
+| What CVEs affect me? | `INHERIT += "cve-check"`; `bitbake -c cve_check <image>`; inspect `tmp-glibc/log/cve/<image>.cve` |
+| Is the fix in my `SRCREV`? | `git log <SRCREV>.. -- <affected-file>` — if you see the commit, you're patched |
+| Which stable branch a SHA is on | `git.kernel.org/.../log/<file>?h=<branch>` and grep for the SHA |
+| Raw patch in `git am` form | append `/patch/?id=<sha>` to the kernel.org repo URL |
+| Mailing-list context | `oss-security` archive URLs in the NVD references — usually best for PoC links and disclosure timeline |
+
+---
+
+## See also
+
+- [Security guide](SECURITY.md) — distribution-wide security posture, KSPP alignment, audit framework
+- [Kernel driver backport — field guide](KERNEL_DRIVER_BACKPORT.md) — sibling guide for backporting *drivers* (not CVE fixes) into the mainline kernel recipe
+- [Operations guide](OPERATIONS.md) — runbook for rolling a security fix to fleet (build → bundle → RAUC OTA → verify)

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -65,6 +65,17 @@ The kernel follows Kernel Self Protection Project (KSPP) recommendations.
 - **LSM** — AppArmor mandatory access control
 - **Audit** — Syscall auditing enabled
 
+### CVE Response Workflow
+
+When a kernel CVE affects a release between our pinned `SRCREV_machine`
+and the next planned kernel bump, we carry the upstream stable backport
+as a numbered patch in `meta-iot-gateway/recipes-kernel/linux/files/`.
+
+See [Kernel CVE Patch — Field Guide](KERNEL_CVE_PATCH.md) for the
+step-by-step workflow: identifying the right stable backport, annotating
+for Yocto QA (`Upstream-Status:`, `CVE:`), wiring into `SRC_URI`, and
+tracking the patch's sunset on the next `SRCREV` bump.
+
 ---
 
 ## Compiler Hardening

--- a/meta-iot-gateway/recipes-kernel/linux/files/0011-CVE-2026-31431-crypto-algif_aead-revert-to-out-of-place.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0011-CVE-2026-31431-crypto-algif_aead-revert-to-out-of-place.patch
@@ -1,0 +1,324 @@
+From fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8 Mon Sep 17 00:00:00 2001
+From: Herbert Xu <herbert@gondor.apana.org.au>
+Date: Thu, 26 Mar 2026 15:30:20 +0900
+Subject: crypto: algif_aead - Revert to operating out-of-place
+
+[ Upstream commit a664bf3d603dc3bdcf9ae47cc21e0daec706d7a5 ]
+
+This mostly reverts commit 72548b093ee3 except for the copying of
+the associated data.
+
+There is no benefit in operating in-place in algif_aead since the
+source and destination come from different mappings.  Get rid of
+all the complexity added for in-place operation and just copy the
+AD directly.
+
+Fixes: 72548b093ee3 ("crypto: algif_aead - copy AAD from src to dst")
+Reported-by: Taeyang Lee <0wn@theori.io>
+Signed-off-by: Herbert Xu <herbert@gondor.apana.org.au>
+Signed-off-by: Sasha Levin <sashal@kernel.org>
+Upstream-Status: Backport [https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=fafe0fa2995a0f7073c1c358d7d3145bcc9aedd8]
+CVE: CVE-2026-31431
+
+---
+ crypto/af_alg.c         |  49 +++++-------------------
+ crypto/algif_aead.c     | 100 +++++++++---------------------------------------
+ crypto/algif_skcipher.c |   6 +--
+ include/crypto/if_alg.h |   5 +--
+ 4 files changed, 34 insertions(+), 126 deletions(-)
+
+diff --git a/crypto/af_alg.c b/crypto/af_alg.c
+index 78e995dddf879..3236601aa6dc0 100644
+--- a/crypto/af_alg.c
++++ b/crypto/af_alg.c
+@@ -637,15 +637,13 @@ static int af_alg_alloc_tsgl(struct sock *sk)
+ /**
+  * af_alg_count_tsgl - Count number of TX SG entries
+  *
+- * The counting starts from the beginning of the SGL to @bytes. If
+- * an @offset is provided, the counting of the SG entries starts at the @offset.
++ * The counting starts from the beginning of the SGL to @bytes.
+  *
+  * @sk: socket of connection to user space
+  * @bytes: Count the number of SG entries holding given number of bytes.
+- * @offset: Start the counting of SG entries from the given offset.
+  * Return: Number of TX SG entries found given the constraints
+  */
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes)
+ {
+ 	const struct alg_sock *ask = alg_sk(sk);
+ 	const struct af_alg_ctx *ctx = ask->private;
+@@ -660,25 +658,11 @@ unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset)
+ 		const struct scatterlist *sg = sgl->sg;
+ 
+ 		for (i = 0; i < sgl->cur; i++) {
+-			size_t bytes_count;
+-
+-			/* Skip offset */
+-			if (offset >= sg[i].length) {
+-				offset -= sg[i].length;
+-				bytes -= sg[i].length;
+-				continue;
+-			}
+-
+-			bytes_count = sg[i].length - offset;
+-
+-			offset = 0;
+ 			sgl_count++;
+-
+-			/* If we have seen requested number of bytes, stop */
+-			if (bytes_count >= bytes)
++			if (sg[i].length >= bytes)
+ 				return sgl_count;
+ 
+-			bytes -= bytes_count;
++			bytes -= sg[i].length;
+ 		}
+ 	}
+ 
+@@ -690,19 +674,14 @@ EXPORT_SYMBOL_GPL(af_alg_count_tsgl);
+  * af_alg_pull_tsgl - Release the specified buffers from TX SGL
+  *
+  * If @dst is non-null, reassign the pages to @dst. The caller must release
+- * the pages. If @dst_offset is given only reassign the pages to @dst starting
+- * at the @dst_offset (byte). The caller must ensure that @dst is large
+- * enough (e.g. by using af_alg_count_tsgl with the same offset).
++ * the pages.
+  *
+  * @sk: socket of connection to user space
+  * @used: Number of bytes to pull from TX SGL
+  * @dst: If non-NULL, buffer is reassigned to dst SGL instead of releasing. The
+  *	 caller must release the buffers in dst.
+- * @dst_offset: Reassign the TX SGL from given offset. All buffers before
+- *	        reaching the offset is released.
+  */
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset)
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst)
+ {
+ 	struct alg_sock *ask = alg_sk(sk);
+ 	struct af_alg_ctx *ctx = ask->private;
+@@ -727,18 +706,10 @@ void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+ 			 * SG entries in dst.
+ 			 */
+ 			if (dst) {
+-				if (dst_offset >= plen) {
+-					/* discard page before offset */
+-					dst_offset -= plen;
+-				} else {
+-					/* reassign page to dst after offset */
+-					get_page(page);
+-					sg_set_page(dst + j, page,
+-						    plen - dst_offset,
+-						    sg[i].offset + dst_offset);
+-					dst_offset = 0;
+-					j++;
+-				}
++				/* reassign page to dst after offset */
++				get_page(page);
++				sg_set_page(dst + j, page, plen, sg[i].offset);
++				j++;
+ 			}
+ 
+ 			sg[i].length -= plen;
+diff --git a/crypto/algif_aead.c b/crypto/algif_aead.c
+index 79b016a899a1e..dda15bb05e892 100644
+--- a/crypto/algif_aead.c
++++ b/crypto/algif_aead.c
+@@ -26,7 +26,6 @@
+ #include <crypto/internal/aead.h>
+ #include <crypto/scatterwalk.h>
+ #include <crypto/if_alg.h>
+-#include <crypto/skcipher.h>
+ #include <linux/init.h>
+ #include <linux/list.h>
+ #include <linux/kernel.h>
+@@ -72,9 +71,8 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct af_alg_ctx *ctx = ask->private;
+ 	struct crypto_aead *tfm = pask->private;
+-	unsigned int i, as = crypto_aead_authsize(tfm);
++	unsigned int as = crypto_aead_authsize(tfm);
+ 	struct af_alg_async_req *areq;
+-	struct af_alg_tsgl *tsgl, *tmp;
+ 	struct scatterlist *rsgl_src, *tsgl_src = NULL;
+ 	int err = 0;
+ 	size_t used = 0;		/* [in]  TX bufs to be en/decrypted */
+@@ -154,23 +152,24 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		outlen -= less;
+ 	}
+ 
++	/*
++	 * Create a per request TX SGL for this request which tracks the
++	 * SG entries from the global TX SGL.
++	 */
+ 	processed = used + ctx->aead_assoclen;
+-	list_for_each_entry_safe(tsgl, tmp, &ctx->tsgl_list, list) {
+-		for (i = 0; i < tsgl->cur; i++) {
+-			struct scatterlist *process_sg = tsgl->sg + i;
+-
+-			if (!(process_sg->length) || !sg_page(process_sg))
+-				continue;
+-			tsgl_src = process_sg;
+-			break;
+-		}
+-		if (tsgl_src)
+-			break;
+-	}
+-	if (processed && !tsgl_src) {
+-		err = -EFAULT;
++	areq->tsgl_entries = af_alg_count_tsgl(sk, processed);
++	if (!areq->tsgl_entries)
++		areq->tsgl_entries = 1;
++	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
++					         areq->tsgl_entries),
++				  GFP_KERNEL);
++	if (!areq->tsgl) {
++		err = -ENOMEM;
+ 		goto free;
+ 	}
++	sg_init_table(areq->tsgl, areq->tsgl_entries);
++	af_alg_pull_tsgl(sk, processed, areq->tsgl);
++	tsgl_src = areq->tsgl;
+ 
+ 	/*
+ 	 * Copy of AAD from source to destination
+@@ -179,76 +178,15 @@ static int _aead_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * when user space uses an in-place cipher operation, the kernel
+ 	 * will copy the data as it does not see whether such in-place operation
+ 	 * is initiated.
+-	 *
+-	 * To ensure efficiency, the following implementation ensure that the
+-	 * ciphers are invoked to perform a crypto operation in-place. This
+-	 * is achieved by memory management specified as follows.
+ 	 */
+ 
+ 	/* Use the RX SGL as source (and destination) for crypto op. */
+ 	rsgl_src = areq->first_rsgl.sgl.sgt.sgl;
+ 
+-	if (ctx->enc) {
+-		/*
+-		 * Encryption operation - The in-place cipher operation is
+-		 * achieved by the following operation:
+-		 *
+-		 * TX SGL: AAD || PT
+-		 *	    |	   |
+-		 *	    | copy |
+-		 *	    v	   v
+-		 * RX SGL: AAD || PT || Tag
+-		 */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src,
+-			      processed);
+-		af_alg_pull_tsgl(sk, processed, NULL, 0);
+-	} else {
+-		/*
+-		 * Decryption operation - To achieve an in-place cipher
+-		 * operation, the following  SGL structure is used:
+-		 *
+-		 * TX SGL: AAD || CT || Tag
+-		 *	    |	   |	 ^
+-		 *	    | copy |	 | Create SGL link.
+-		 *	    v	   v	 |
+-		 * RX SGL: AAD || CT ----+
+-		 */
+-
+-		/* Copy AAD || CT to RX SGL buffer for in-place operation. */
+-		memcpy_sglist(areq->first_rsgl.sgl.sgt.sgl, tsgl_src, outlen);
+-
+-		/* Create TX SGL for tag and chain it to RX SGL. */
+-		areq->tsgl_entries = af_alg_count_tsgl(sk, processed,
+-						       processed - as);
+-		if (!areq->tsgl_entries)
+-			areq->tsgl_entries = 1;
+-		areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+-							 areq->tsgl_entries),
+-					  GFP_KERNEL);
+-		if (!areq->tsgl) {
+-			err = -ENOMEM;
+-			goto free;
+-		}
+-		sg_init_table(areq->tsgl, areq->tsgl_entries);
+-
+-		/* Release TX SGL, except for tag data and reassign tag data. */
+-		af_alg_pull_tsgl(sk, processed, areq->tsgl, processed - as);
+-
+-		/* chain the areq TX SGL holding the tag with RX SGL */
+-		if (usedpages) {
+-			/* RX SGL present */
+-			struct af_alg_sgl *sgl_prev = &areq->last_rsgl->sgl;
+-			struct scatterlist *sg = sgl_prev->sgt.sgl;
+-
+-			sg_unmark_end(sg + sgl_prev->sgt.nents - 1);
+-			sg_chain(sg, sgl_prev->sgt.nents + 1, areq->tsgl);
+-		} else
+-			/* no RX SGL present (e.g. authentication only) */
+-			rsgl_src = areq->tsgl;
+-	}
++	memcpy_sglist(rsgl_src, tsgl_src, ctx->aead_assoclen);
+ 
+ 	/* Initialize the crypto operation */
+-	aead_request_set_crypt(&areq->cra_u.aead_req, rsgl_src,
++	aead_request_set_crypt(&areq->cra_u.aead_req, tsgl_src,
+ 			       areq->first_rsgl.sgl.sgt.sgl, used, ctx->iv);
+ 	aead_request_set_ad(&areq->cra_u.aead_req, ctx->aead_assoclen);
+ 	aead_request_set_tfm(&areq->cra_u.aead_req, tfm);
+@@ -450,7 +388,7 @@ static void aead_sock_destruct(struct sock *sk)
+ 	struct crypto_aead *tfm = pask->private;
+ 	unsigned int ivlen = crypto_aead_ivsize(tfm);
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, ivlen);
+ 	sock_kfree_s(sk, ctx, ctx->len);
+ 	af_alg_release_parent(sk);
+diff --git a/crypto/algif_skcipher.c b/crypto/algif_skcipher.c
+index 125d395c5e009..82735e51be108 100644
+--- a/crypto/algif_skcipher.c
++++ b/crypto/algif_skcipher.c
+@@ -138,7 +138,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 	 * Create a per request TX SGL for this request which tracks the
+ 	 * SG entries from the global TX SGL.
+ 	 */
+-	areq->tsgl_entries = af_alg_count_tsgl(sk, len, 0);
++	areq->tsgl_entries = af_alg_count_tsgl(sk, len);
+ 	if (!areq->tsgl_entries)
+ 		areq->tsgl_entries = 1;
+ 	areq->tsgl = sock_kmalloc(sk, array_size(sizeof(*areq->tsgl),
+@@ -149,7 +149,7 @@ static int _skcipher_recvmsg(struct socket *sock, struct msghdr *msg,
+ 		goto free;
+ 	}
+ 	sg_init_table(areq->tsgl, areq->tsgl_entries);
+-	af_alg_pull_tsgl(sk, len, areq->tsgl, 0);
++	af_alg_pull_tsgl(sk, len, areq->tsgl);
+ 
+ 	/* Initialize the crypto operation */
+ 	skcipher_request_set_tfm(&areq->cra_u.skcipher_req, tfm);
+@@ -363,7 +363,7 @@ static void skcipher_sock_destruct(struct sock *sk)
+ 	struct alg_sock *pask = alg_sk(psk);
+ 	struct crypto_skcipher *tfm = pask->private;
+ 
+-	af_alg_pull_tsgl(sk, ctx->used, NULL, 0);
++	af_alg_pull_tsgl(sk, ctx->used, NULL);
+ 	sock_kzfree_s(sk, ctx->iv, crypto_skcipher_ivsize(tfm));
+ 	if (ctx->state)
+ 		sock_kzfree_s(sk, ctx->state, crypto_skcipher_statesize(tfm));
+diff --git a/include/crypto/if_alg.h b/include/crypto/if_alg.h
+index 107b797c33ecf..0cc8fa749f68d 100644
+--- a/include/crypto/if_alg.h
++++ b/include/crypto/if_alg.h
+@@ -230,9 +230,8 @@ static inline bool af_alg_readable(struct sock *sk)
+ 	return PAGE_SIZE <= af_alg_rcvbuf(sk);
+ }
+ 
+-unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes, size_t offset);
+-void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst,
+-		      size_t dst_offset);
++unsigned int af_alg_count_tsgl(struct sock *sk, size_t bytes);
++void af_alg_pull_tsgl(struct sock *sk, size_t used, struct scatterlist *dst);
+ void af_alg_wmem_wakeup(struct sock *sk);
+ int af_alg_wait_for_data(struct sock *sk, unsigned flags, unsigned min);
+ int af_alg_sendmsg(struct socket *sock, struct msghdr *msg, size_t size,
+-- 
+cgit 1.3-korg
+

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
@@ -46,4 +46,8 @@ SRC_URI:append = "${@' file://0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoop
 SRC_URI:append = "${@' file://0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
 SRC_URI:append = "${@' file://0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
 SRC_URI:append = "${@' file://0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
+# Security: CVE-2026-31431 (algif_aead in-place write-to-page-cache; CISA KEV).
+# Stable 6.18.y backport (fafe0fa2) lands in 6.18.22; we pin 6.18.13 so apply
+# the patch directly. Drop this line on the next SRCREV bump past v6.18.22.
+SRC_URI:append = " file://0011-CVE-2026-31431-crypto-algif_aead-revert-to-out-of-place.patch"
 SRC_URI:append = " file://fragments/thermal-rpi5.cfg"

--- a/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.5.0.bb
+++ b/meta-iot-gateway/recipes-support/edge-healthd/edge-healthd_0.5.0.bb
@@ -1,4 +1,4 @@
 require edge-healthd.inc
 
 # Pin upstream source for reproducible non-externalsrc builds.
-SRCREV = "c5f3e504aeabe38940c50d656c08fffc93dc1675"
+SRCREV = "78b53a464e3c4d5b98f0fabdf91abc5728cd4ae7"


### PR DESCRIPTION
## Summary

Three changes, validated together via a single RAUC bundle install on raspberrypi5:

1. **Kernel CVE patch** — backport `fafe0fa2` (linux-6.18.y) for CVE-2026-31431 (algif_aead in-place write-to-page-cache; CISA KEV, action due 2026-05-15) onto our pinned `v6.18.13`.
2. **CVE patch field guide** — `docs/KERNEL_CVE_PATCH.md`, reusable workflow for future kernel CVE backports.
3. **edge-healthd bump** — `c5f3e50` → `78b53a4` (v0.6.0). Repo went public, externalsrc no longer needed.

## What changed

### Kernel CVE (a0acf72)
- New `0011-CVE-2026-31431-crypto-algif_aead-revert-to-out-of-place.patch` (byte-identical to upstream stable backport).
- Annotated with `Upstream-Status: Backport [...]` and `CVE: CVE-2026-31431` so cve-check + patch-status QA recognise it.
- Added unconditionally to `linux-iotgw-mainline-common.inc` (covers mainline, mainline-fit, mainline-recovery). Includes inline "drop on next SRCREV bump past v6.18.22" note.
- Defence-in-depth: our kconfig has `# CONFIG_CRYPTO_USER_API_AEAD is not set`, so `algif_aead.ko` isn't built today — but patching the source means a developer who flips the kconfig later picks up the fixed code.

### Field guide (ba3e8c3)
- `docs/KERNEL_CVE_PATCH.md` — 8-step workflow with CVE-2026-31431 as worked example, anti-patterns, cheat-sheet, cross-links to SECURITY.md and KERNEL_DRIVER_BACKPORT.md.
- Short cross-link section added to `docs/SECURITY.md`.

### edge-healthd (bcda6f5)
- SRCREV `c5f3e50` → `78b53a4` (v0.6.0-4-g78b53a4). Filename `_0.5.0.bb` kept stable (runtime version comes from `GetGitVersion.cmake` via `git describe`).
- Picks up the new `CrashProbe`, RAUC-Completed signal subscription, atomic snapshot writes, v0.6.0 release.
- Repository was made public to support GitHub-fetch builds (no externalsrc/SSH required).

## How the kernel patch was created

For future reference (and as a sanity check for reviewers), the methodology is fully documented in `docs/KERNEL_CVE_PATCH.md`. Short version:

1. Pull NVD record → identify affected version range vs our SRCREV
2. List the 8 stable backport SHAs (NVD references)
3. Run `git.kernel.org/.../log/<affected-file>?h=linux-6.18.y` and grep for the SHA that appears on **our** branch (`fafe0fa2`)
4. Fetch via cgit's `/patch/?id=<sha>` (already in `git am` form, byte-identical to upstream)
5. Insert `Upstream-Status:` + `CVE:` above the `---` separator
6. Add to `SRC_URI` unconditionally
7. Verify `do_patch` log: counter `(11/11)`, no `FAILED`/`Hunk`/`reject`, no `Upstream-Status` QA warning

## Test plan

Verified on raspberrypi5 via RAUC bundle install (`5f794c9d` succeeded) + reboot to slot B:

- [x] **Patch applied cleanly**: `do_patch` log shows `(11/11) 0011-CVE-...patch` applied via `git am` first try (no reduced-context fallback, no FAILED). `do_qa_patch` doesn't warn on patch 0011 (annotation recognised).
- [x] **Post-revert source signature**: `crypto/algif_aead.c` is 466 lines (-100 from pre-fix); `ctx->merge` / `MAX_AAD_SIZE` / `aead_alloc_tsgl` symbols all removed. Matches upstream diffstat `49/100/6` across `af_alg.c`/`algif_aead.c`/`algif_skcipher.c`.
- [x] **Kernel boots**: `6.18.13-v8-16k-igw-00011-g8da48c597350` (was `-00010`). Userspace boot 9.857s (no regression from the post-otbr-fix 10.731s baseline).
- [x] **Crypto live paths intact**: AES-128-GCM via openssl libcrypto = 2.29 GB/s with HW AES (`armcap=0xbd`); TPM PCRs read; cryptsetup PBKDF2/argon2 healthy. (The "N/A" cipher rows in `cryptsetup benchmark` are pre-existing — `CONFIG_CRYPTO_USER_API_SKCIPHER` was never set on this kernel; LUKS itself uses in-kernel crypto API.)
- [x] **otbr (from prior PR) still good**: agent activates via udev SYSTEMD_WANTS when RCP plugged in, webui boots independently.
- [x] **edge-healthd v0.6.0**: daemon registers DBus manager, subscribes to RAUC Completed signal, new CrashProbe correctly flags a stale May-3 pstore panic artifact (historical, unrelated to this PR — confirms the probe works).
- [x] **No failed units** on the new boot.

## When to drop the kernel patch

Next routine kernel SRCREV bump past **v6.18.22** (where `a664bf3d` lands in stable). The `SRC_URI:append` line in `linux-iotgw-mainline-common.inc` has an inline comment to that effect.