### PR TITLE
fix(kernel): deterministic fragment selection + panic-on-oops symbol rename

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -476,6 +476,68 @@ CONFIG_LOCALVERSION="-v8-16k-igw"
 
 ---
 
+## Fragment Selection Policy (Implementation Notes)
+
+The fragment list is owned by `meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass`
+via the single variable `IOTGW_KERNEL_FRAGMENTS`. `SRC_URI` is derived from
+that list so the two cannot drift, and `do_configure:append` enforces two
+invariants with `bbfatal`:
+
+1. Every name in `IOTGW_KERNEL_FRAGMENTS` must be present in `${WORKDIR}/fragments/`
+   (fetch guard — catches missing `file://fragments/<name>` entries).
+2. Every `.cfg` file in `${WORKDIR}/fragments/` must appear in `IOTGW_KERNEL_FRAGMENTS`
+   (stale-residue guard — catches fragments left over from a previous build
+   with different `IOTGW_ENABLE_*` / `IOTGW_KERNEL_FEATURES` gates).
+
+The second guard is the one that matters most in practice: without it, a
+gated fragment (e.g. `btf-core-dev.cfg` from a prior BTF-on build) silently
+lingers in the workdir and is re-merged into `.config` even when the gate
+is off, inverting the gate and inflating the kernel module footprint. The
+guard's `bbfatal` names the offending path so regressions are obvious in
+the build log; the recovery is `bitbake -c cleansstate <kernel-recipe>`.
+
+### Adding a fragment
+
+Add a `file://fragments/<name>.cfg` to `meta-iot-gateway/recipes-kernel/linux/files/fragments/`,
+then add the bare filename to `IOTGW_KERNEL_FRAGMENTS` in the bbclass under
+the appropriate gate. **Do not** add a parallel `SRC_URI:append` — the
+bbclass derives `SRC_URI` from the tracked list. Adding both produces a
+duplicate fetch entry.
+
+A recipe-specific unconditional fragment (e.g. `thermal-rpi5.cfg` in
+`linux-iotgw-mainline-common.inc`) uses `IOTGW_KERNEL_FRAGMENTS:append`
+in the recipe `.inc`, not the bbclass.
+
+### BitBake gotcha: `+=` vs `:append` on `SRC_URI`
+
+The bbclass derives `SRC_URI` with `:append`, not `+=`. The reason matters
+for anyone extending it:
+
+- `+=` is **parse-time**: it appends to the variable's value at the moment
+  the line is parsed.
+- `:append =` is **expansion-time**: it's applied every time the variable
+  is expanded.
+
+Kernel recipe `.bb` files commonly do a hard `SRC_URI = "..."` set inside
+the recipe body (each kernel provider declares its own upstream URLs).
+A `set` after a `+=` wipes everything the `+=` contributed; a `:append`
+line survives because it runs after the set, at expansion time.
+
+```bitbake
+# In the bbclass:
+SRC_URI:append = " ${@' '.join('file://fragments/' + f for f in \
+    (d.getVar('IOTGW_KERNEL_FRAGMENTS') or '').split() if f)}"
+# Not  SRC_URI += "..."  — would be wiped by  SRC_URI = "..."  in the .bb.
+```
+
+Verify with `bitbake -e <kernel-recipe> | grep -B2 -A60 '^# \$SRC_URI'` —
+the ordered operation list shows whether a `set` follows your contribution.
+The Python expression itself is fine in either form: it reads the
+fully-expanded `IOTGW_KERNEL_FRAGMENTS` (including any `:append` from the
+`.inc`) at expansion time.
+
+---
+
 ## Additional Resources
 
 - [Yocto Kernel Development](https://docs.yoctoproject.org/kernel-dev/)

--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -20,7 +20,7 @@ The distribution uses **modular kernel configuration** based on feature fragment
   Closes the early-boot "kernel hangs requiring power cycle" failure
   class — any panic auto-reboots within 30s, applies from the first
   instruction the kernel runs.
-- `panic-on-oops.cfg` — `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y`. Gated by
+- `panic-on-oops.cfg` — `CONFIG_PANIC_ON_OOPS=y`. Gated by
   `IOTGW_ENABLE_PANIC_ON_OOPS` (default `"1"`); set to `"0"` in
   `kas/local.yml` for dev/bring-up builds where you want tainted-but-
   running kernels for triage instead of immediate panic+reboot. Together

--- a/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
+++ b/meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass
@@ -1,4 +1,15 @@
 # Shared IoT Gateway kernel fragment policy for all kernel providers.
+#
+# IOTGW_KERNEL_FRAGMENTS is the single source of truth for which fragments
+# are expected in ${WORKDIR}/fragments/.  SRC_URI is derived from it, so
+# the two lists cannot drift.  do_configure:append enforces the invariant
+# in both directions:
+#   - every fragment named here must exist (fetch failure guard)
+#   - every .cfg present in the workdir must be named here (stale-residue guard)
+#
+# Recipes that add their own unconditional fragments (e.g. thermal-rpi5.cfg)
+# must pair the SRC_URI:append with a matching IOTGW_KERNEL_FRAGMENTS:append
+# so the guard stays consistent.
 
 # Gate Raspberry Pi firmware RTC support for providers that carry the backport.
 IOTGW_ENABLE_RPI_RTC ?= "1"
@@ -10,42 +21,75 @@ IOTGW_ENABLE_RPI_EEPROM ?= "1"
 # Default follows EEPROM tooling gate; developers can override independently.
 IOTGW_ENABLE_VCIO ?= "${IOTGW_ENABLE_RPI_EEPROM}"
 
-# Base fragments always applied.
-SRC_URI:append = " \
-    file://fragments/branding.cfg \
-    file://fragments/trim.cfg \
-    file://fragments/storage-filesystems.cfg \
-    file://fragments/ikconfig.cfg \
-    file://fragments/audit.cfg \
-    file://fragments/panic-recovery.cfg \
-"
+# ---------------------------------------------------------------------------
+# Base fragments — always applied.
+# ---------------------------------------------------------------------------
+IOTGW_KERNEL_FRAGMENTS = "branding.cfg trim.cfg \
+    storage-filesystems.cfg ikconfig.cfg \
+    audit.cfg panic-recovery.cfg"
+
 # panic-on-oops.cfg is gated so dev/bring-up builds can disable
 # CONFIG_BOOTPARAM_PANIC_ON_OOPS without source edits (default-on).
-SRC_URI:append = "${@' file://fragments/panic-on-oops.cfg' if d.getVar('IOTGW_ENABLE_PANIC_ON_OOPS') == '1' else ''}"
-SRC_URI:append = "${@' file://fragments/rtc-rpi.cfg' if d.getVar('IOTGW_ENABLE_RPI_RTC') == '1' else ''}"
-SRC_URI:append = "${@' file://fragments/vcio-rpi.cfg' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'panic-on-oops.cfg' if d.getVar('IOTGW_ENABLE_PANIC_ON_OOPS') == '1' else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'rtc-rpi.cfg' if d.getVar('IOTGW_ENABLE_RPI_RTC') == '1' else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'vcio-rpi.cfg' if d.getVar('IOTGW_ENABLE_VCIO') == '1' else ''}"
 
 # Optional fragments toggled via IOTGW_KERNEL_FEATURES (space/comma-separated).
-SRC_URI:append = "${@' file://fragments/compute-media.cfg' if 'igw_compute_media' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/containers-cgroups.cfg' if 'igw_containers' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/networking-iot.cfg' if 'igw_networking_iot' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/observability-dev.cfg' if 'igw_observability_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/btf-core-dev.cfg' if 'igw_btf_core_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/pstore-persist.cfg' if 'igw_pstore_persist' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/debug-crash-dev.cfg' if 'igw_crash_debug_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/security-prod.cfg' if 'igw_security_prod' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/tpm-slb9672.cfg' if 'igw_tpm_slb9672' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/efi-surface-reduction.cfg' if 'igw_no_efi' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/selinux.cfg' if 'igw_selinux' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
-SRC_URI:append = "${@' file://fragments/ima.cfg' if 'igw_ima' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'compute-media.cfg' if 'igw_compute_media' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'containers-cgroups.cfg' if 'igw_containers' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'networking-iot.cfg' if 'igw_networking_iot' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'observability-dev.cfg' if 'igw_observability_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'btf-core-dev.cfg' if 'igw_btf_core_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'pstore-persist.cfg' if 'igw_pstore_persist' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'debug-crash-dev.cfg' if 'igw_crash_debug_dev' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'security-prod.cfg' if 'igw_security_prod' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'tpm-slb9672.cfg' if 'igw_tpm_slb9672' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'efi-surface-reduction.cfg' if 'igw_no_efi' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'selinux.cfg' if 'igw_selinux' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
+IOTGW_KERNEL_FRAGMENTS += "${@'ima.cfg' if 'igw_ima' in (d.getVar('IOTGW_KERNEL_FEATURES') or '').replace(',', ' ').split() else ''}"
 
-# Merge present fragments into the active kernel .config.
+# Derive SRC_URI from IOTGW_KERNEL_FRAGMENTS so the two lists cannot diverge.
+# Use :append (expansion-time) — kernel providers reset SRC_URI with `=`
+# inside the recipe body, which would wipe out a parse-time `+=`.
+SRC_URI:append = " ${@' '.join('file://fragments/' + f for f in (d.getVar('IOTGW_KERNEL_FRAGMENTS') or '').split() if f)}"
+
+# Merge tracked fragments into the active kernel .config.
+# Two invariants are enforced via bbfatal to catch regressions immediately:
+#   1. Every fragment in IOTGW_KERNEL_FRAGMENTS must be present in the workdir.
+#   2. No .cfg file in ${WORKDIR}/fragments/ may exist outside IOTGW_KERNEL_FRAGMENTS
+#      — this is the stale-residue guard that prevents leftover files from a
+#      previous build with different gates from silently altering the config.
 do_configure:append() {
+    # Build the allowed set and the ordered merge list from IOTGW_KERNEL_FRAGMENTS.
+    tracked="${IOTGW_KERNEL_FRAGMENTS}"
     frags=
-    if [ -d ${WORKDIR}/fragments ]; then
-        frags=$(ls ${WORKDIR}/fragments/*.cfg 2>/dev/null || true)
+    for fname in $tracked; do
+        fpath="${WORKDIR}/fragments/$fname"
+        if [ ! -f "$fpath" ]; then
+            bbfatal "iotgw-kernel-fragments: expected fragment missing: $fpath (check SRC_URI fetch)"
+        fi
+        frags="$frags $fpath"
+    done
+
+    # Stale-residue guard: reject any .cfg not in the tracked list.
+    if [ -d "${WORKDIR}/fragments" ]; then
+        for present in "${WORKDIR}/fragments/"*.cfg; do
+            [ -f "$present" ] || continue
+            bname=$(basename "$present")
+            found=0
+            for fname in $tracked; do
+                if [ "$bname" = "$fname" ]; then
+                    found=1
+                    break
+                fi
+            done
+            if [ "$found" = "0" ]; then
+                bbfatal "iotgw-kernel-fragments: stale fragment not in IOTGW_KERNEL_FRAGMENTS: $present -- cleansstate the recipe and rebuild"
+            fi
+        done
     fi
-    if [ -n "$frags" ] && [ -x ${S}/scripts/kconfig/merge_config.sh ]; then
+
+    if [ -n "$frags" ] && [ -x "${S}/scripts/kconfig/merge_config.sh" ]; then
         oe_runmake -C ${S} O=${B} olddefconfig
         ${S}/scripts/kconfig/merge_config.sh -m -O ${B} ${B}/.config $frags || die "merge_config failed"
         oe_runmake -C ${S} O=${B} olddefconfig

--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-on-oops.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-on-oops.cfg
@@ -9,5 +9,11 @@
 #
 # A target-side runtime override via `oops=` cmdline still works regardless
 # of this fragment, e.g. for kgdb-style debugging on a deployed unit.
+#
+# Note: the symbol is plain CONFIG_PANIC_ON_OOPS in modern kernels. The
+# older CONFIG_BOOTPARAM_PANIC_ON_OOPS name was dropped upstream and is
+# silently ignored by merge_config.sh + olddefconfig, which is how this
+# fragment ended up a no-op on linux-6.18 until PR #65 made fragment
+# selection deterministic enough for the regression to surface.
 
-CONFIG_BOOTPARAM_PANIC_ON_OOPS=y
+CONFIG_PANIC_ON_OOPS=y

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc
@@ -55,4 +55,6 @@ SRC_URI:append = "${@' file://0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoop
 SRC_URI:append = "${@' file://0008-mfd-bcm2835-pm-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
 SRC_URI:append = "${@' file://0009-arm64-dts-broadcom-bcm2712-add-pm-watchdog-node.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
 SRC_URI:append = "${@' file://0010-pmdomain-bcm-bcm2835-power-Add-support-for-BCM2712.patch' if d.getVar('IOTGW_ENABLE_HW_WATCHDOG') == '1' else ''}"
-SRC_URI:append = " file://fragments/thermal-rpi5.cfg"
+# thermal-rpi5.cfg is a recipe-specific fragment; SRC_URI is derived from
+# IOTGW_KERNEL_FRAGMENTS by iotgw-kernel-fragments.bbclass.
+IOTGW_KERNEL_FRAGMENTS:append = " thermal-rpi5.cfg"


### PR DESCRIPTION
> Supersedes #65 (closed automatically when the head branch `worktree-agent-...` was renamed to a more descriptive name; same three commits, no functional changes since target verification).

## Summary

Two related kernel-config issues, surfaced by the same diagnosis:

1. **Stale-fragment merges**: `iotgw-kernel-fragments.bbclass` selected fragments by globbing `${WORKDIR}/fragments/*.cfg`, ignoring `SRC_URI`. A `.cfg` left over from a previous build with different `IOTGW_ENABLE_*` / `IOTGW_KERNEL_FEATURES` gates was silently re-merged into the new `.config`.
2. **Latent symbol drift in `panic-on-oops.cfg`**: the fragment set the long-removed `CONFIG_BOOTPARAM_PANIC_ON_OOPS`. `merge_config.sh` ignores unknown symbols and `olddefconfig` finalizes without the value, so the fragment had been a no-op on linux-6.18 — masked by the stale-merge bug above (a prior workdir state could happen to look correct).

This PR makes fragment selection deterministic, adds a `bbfatal` guard against stale residue, and fixes the panic-on-oops symbol.

## Diagnosis evidence

With `IOTGW_ENABLE_BTF_CORE_DEV=0` (default), `btf-core-dev.cfg` lingered in the workdir from a prior BTF-on build and was re-merged:

| Symbol | Expected | Pre-fix `.config` |
|--------|----------|-------------------|
| `CONFIG_DEBUG_INFO_REDUCED` | `y` | unset |
| `CONFIG_DEBUG_INFO_DWARF4` | unset | `y` |
| `CONFIG_DEBUG_INFO_BTF` | unset | `y` |

| Artifact | Pre-fix | Post-fix |
|----------|---------|----------|
| `/lib/modules/$KVER/` on target | ~540 MB | **348 MB** |
| FIT RAUC bundle | 1008 MB | **535 MB** |

Symbol drift, separately:

```
fragment writes:  CONFIG_BOOTPARAM_PANIC_ON_OOPS=y
effective .config (pre-fix): # CONFIG_PANIC_ON_OOPS is not set
effective .config (post-fix): CONFIG_PANIC_ON_OOPS=y
```

## What changed

`meta-iot-gateway/classes/iotgw-kernel-fragments.bbclass`

- New `IOTGW_KERNEL_FRAGMENTS` variable: single source of truth, one base block plus one append per existing gate (mirrors the prior SRC_URI structure exactly — no gates added or removed).
- `SRC_URI` is derived from `IOTGW_KERNEL_FRAGMENTS` via an `:append` line. `:append` (expansion-time) rather than `+=` (parse-time) is required because the kernel recipe `.bb` does `SRC_URI = "..."` later in parse order, which would wipe a parse-time `+=`. (See `docs/KERNEL.md` for the captured lesson.)
- `do_configure:append` now:
  - iterates the tracked list to build the merge argv, `bbfatal` on any missing fragment (fetch guard),
  - walks `${WORKDIR}/fragments/*.cfg` and `bbfatal` on any unlisted residue (stale-residue guard, with the offending path named).

`meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-common.inc`

- Replaces the redundant `SRC_URI:append = " file://fragments/thermal-rpi5.cfg"` with `IOTGW_KERNEL_FRAGMENTS:append = " thermal-rpi5.cfg"`; the bbclass derives `SRC_URI` from the tracked list.

`meta-iot-gateway/recipes-kernel/linux/files/fragments/panic-on-oops.cfg`

- `CONFIG_BOOTPARAM_PANIC_ON_OOPS=y` → `CONFIG_PANIC_ON_OOPS=y` (current upstream symbol).
- Added a comment explaining the rename and why the fragment looked effective before deterministic merging surfaced the drift.

`docs/KERNEL.md`

- Updated the `panic-on-oops.cfg` symbol reference to match.
- New "Fragment Selection Policy (Implementation Notes)" section documenting the invariant, the two guards, how to add a fragment without producing duplicate SRC_URI entries, and the `+=` vs `:append` gotcha so the next person extending the bbclass doesn't re-discover it the hard way.

## Verification (off current `main`, `IOTGW_ENABLE_BTF_CORE_DEV` unset)

Build & effective .config:
```
$ bitbake -c cleansstate linux-iotgw-mainline-fit
$ make bundle-dev-full-fit
... 7015/7015 tasks, all succeeded.

$ grep -E 'CONFIG_DEBUG_INFO|CONFIG_PANIC_ON_OOPS' .../linux-raspberrypi5-standard-build/.config
CONFIG_DEBUG_INFO=y
# CONFIG_DEBUG_INFO_DWARF4 is not set
CONFIG_DEBUG_INFO_REDUCED=y
CONFIG_PANIC_ON_OOPS=y

$ ls -lah .../iot-gw-image-dev-bundle-full-fit.raucb
-rw-r--r-- 1 umair umair 535M ... iot-gw-image-dev-bundle-full-fit.raucb
```

Negative test (stale-residue guard):
```
$ touch .../fragments/stale-test.cfg
$ bitbake -c configure -f linux-iotgw-mainline-fit
ERROR: ... iotgw-kernel-fragments: stale fragment not in IOTGW_KERNEL_FRAGMENTS: \
       .../fragments/stale-test.cfg -- cleansstate the recipe and rebuild
```

On-target (deployed the 535 MB bundle, booted from rootfs.1):
```
$ rauc status
Booted from: rootfs.1 (B), boot status: good
$ zcat /proc/config.gz | grep -E 'DEBUG_INFO_(DWARF4|BTF|REDUCED)|PANIC_ON_OOPS'
# CONFIG_DEBUG_INFO_DWARF4 is not set
CONFIG_DEBUG_INFO_REDUCED=y
CONFIG_PANIC_ON_OOPS=y                       # ← was "not set" before this PR
$ du -sh /lib/modules/$(uname -r)
348M
$ systemctl --failed | grep -c failed
0
```

## Test plan

- [x] `make parse` clean
- [x] `make bundle-dev-full-fit` builds 535 MB bundle (vs 1008 MB pre-fix)
- [x] `.config`: `DEBUG_INFO_REDUCED=y`, no `DWARF4`, no `BTF`, `PANIC_ON_OOPS=y`
- [x] Stale-residue guard fires with named path
- [x] Bundle installed on target via `rauc install`; rebooted to slot B
- [x] On-target `/proc/config.gz` matches expected effective config
- [x] On-target `/lib/modules/$KVER/` = 348 MB (vs ~540 MB stale-merge baseline)
- [x] 0 failed systemd units after boot from new slot

## Scope

Three commits:
- `15a75b5` deterministic fragment policy in the bbclass + the paired `.inc` edit (the bundle on target was built from this SHA)
- `ad21760` docs(kernel): fragment policy and `+=` vs `:append` gotcha
- `04e0bf3` panic-on-oops symbol rename (latent bug uncovered by the deterministic policy)