### PR TITLE
feat(rauc): YubiKey post-build FIT signing with detached release flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help base dev prod desktop \
-        bundle-dev bundle-dev-full bundle-dev-full-fit bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        bundle-dev bundle-dev-full bundle-dev-full-fit sign-bootfiles-fit-yk bundle-dev-full-fit-resign bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
         layers parse clean-lock
 
 KAS ?= kas
@@ -26,6 +26,9 @@ help:
 	@echo "  -- Bundles (rootfs + kernel/DTBs) --"
 	@echo "  make bundle-dev-full      # Bundle from dev image"
 	@echo "  make bundle-dev-full-fit  # FIT bundle from dev image"
+	@echo "  -- HSM-signing flow (detached; CI-friendly) --"
+	@echo "  make sign-bootfiles-fit-yk    # Re-sign FIT in deploy tarball on YubiKey (interactive)"
+	@echo "  make bundle-dev-full-fit-resign  # Re-assemble bundle with HSM-signed FIT (unattended)"
 	@echo "  make bundle-base-full-fit-fast # FIT bundle from base image (OTBR off, faster)"
 	@echo "  make bundle-prod-full     # Bundle from prod image"
 	@echo "  make bundle-desktop-full  # Bundle from desktop image"
@@ -85,6 +88,59 @@ bundle-dev-full:
 
 bundle-dev-full-fit:
 	$(call bundle_cmd,iot-gw-image-dev,iot-gw-bundle-full-fit)
+
+# Detached HSM signing flow. The build and the HSM-signing step run in
+# separate processes — possibly on separate machines — so CI runners
+# can drive the unattended steps without ever needing a PIN/touch.
+#
+# Three stages, each runnable independently:
+#
+#   Stage 1 — file-key signed build (UNATTENDED, CI-friendly):
+#       make bundle-dev-full-fit
+#     Produces the deploy tarball and a file-key-signed .raucb. No HSM,
+#     no PIN, no touch. Suitable for GitHub Actions, GitLab runners, or
+#     any unattended pipeline.
+#
+#   Stage 2 — re-sign FIT in the deploy tarball (OPERATOR-ONLY):
+#       make sign-bootfiles-fit-yk [SIGN_FIT_ARGS='...']
+#     Takes the deploy tarball produced by Stage 1 and re-signs the
+#     embedded FIT against the PKCS#11 token. Requires PIN entry and a
+#     touch on the YubiKey. Only runs on a machine with the HSM
+#     physically attached (operator workstation or a hardened signing
+#     server). Never runs in CI.
+#
+#   Stage 3 — re-assemble bundle from signed tarball (UNATTENDED):
+#       make bundle-dev-full-fit-resign
+#     Re-runs the bundle recipe from do_configure so the assembled
+#     .raucb carries the HSM-signed FIT. No HSM interaction. Can run
+#     in CI on a runner that has the signed tarball deployed to
+#     DEPLOY_DIR_IMAGE (or be invoked locally by the operator after
+#     Stage 2).
+#
+# Typical release pipeline:
+#   - CI:        make bundle-dev-full-fit             → publish unsigned artifacts
+#   - Operator:  fetch artifacts → make sign-bootfiles-fit-yk → publish signed tarball
+#   - CI/Op:     make bundle-dev-full-fit-resign      → publish final signed .raucb
+#
+# SIGN_BOOTFILES_ARGS  → passed to sign-bootfiles-fit.sh (e.g. --force,
+#                       --archive PATH). Goes BEFORE '--'.
+# SIGN_FIT_ARGS        → forwarded to sign-fit.sh (e.g. --verify,
+#                       --verbose, --key-label NAME, --uri URI). Goes
+#                       AFTER '--'. Defaults to '--verify'.
+SIGN_BOOTFILES_ARGS ?=
+SIGN_FIT_ARGS ?= --verify
+sign-bootfiles-fit-yk:
+	bash scripts/sign-bootfiles-fit.sh $(SIGN_BOOTFILES_ARGS) -- $(SIGN_FIT_ARGS)
+
+bundle-dev-full-fit-resign:
+	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \
+			   BUNDLE_IMAGE_NAME=iot-gw-image-dev \
+			   IOTGW_ENABLE_OTBR=$(IOTGW_ENABLE_OTBR) \
+			   IOTGW_ENABLE_CONTAINERS=$(IOTGW_ENABLE_CONTAINERS) \
+			   IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS=$(IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS) \
+			   IOTGW_ENABLE_OBSERVABILITY=$(IOTGW_ENABLE_OBSERVABILITY) \
+			   IOTGW_ENABLE_BTF_CORE_DEV=$(IOTGW_ENABLE_BTF_CORE_DEV) \
+			   bitbake -C do_configure iot-gw-bundle-full-fit' $(BASE)
 
 bundle-base-full-fit-fast:
 	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -258,3 +258,286 @@ Expected failure symptoms in U-Boot log:
 - Keep production private keys offline/HSM-managed.
 - Do not commit keys into repository.
 - Keep RAUC signing keys and FIT signing keys separate.
+
+## YubiKey Post-Build Signing (Stage 2)
+
+The default flow above signs the FIT inside bitbake against a file-based
+RSA key under `UBOOT_SIGN_KEYDIR`. The HSM-backed flow moves the FIT
+signing key onto a YubiKey (PIV slot 9a, RSA-2048) and performs the
+signing as a **post-build** step. The bitbake-side signer stays
+file-based; only the deploy artifact is re-signed.
+
+### Why not sign inside bitbake
+
+Two interacting mkimage bugs make in-bitbake PKCS#11 signing
+unworkable as of u-boot-tools-native 2025.04:
+
+1. **URI synthesis from `-k` is malformed.** When `mkimage` is given
+   both `-k <keydir>` and `-N pkcs11`, it synthesises a non-RFC-7512
+   PKCS#11 URI of the form `pkcs11:<keydir>;object=<hint>;type=private`.
+   `engine_pkcs11` rejects it.
+2. **`-G` is ignored when `-k` is present.** `lib/rsa/rsa-sign.c`
+   prioritises the keydir path. Both upstream
+   `kernel-fitimage.bbclass` and this project's
+   `iotgw-fit-custom-its.bbclass` hardcode `-k`, and
+   `UBOOT_MKIMAGE_SIGN_ARGS` is appended *after* `-k`, so a
+   `kas/local.yml`-level override cannot reach the working `-G` path.
+
+There is also a silent no-op trap in the no-`-k` path:
+`mkimage -F -N pkcs11 <fit>` without `-k` **and** without `-G` exits 0,
+regenerates hashes, repacks the FDT, and leaves the original signature
+bytes untouched. The `sign-fit.sh` wrapper guards against this by
+comparing Sign values pre/post.
+
+Upstream migration note: the meta-oe `fitimage.bbclass` merged
+post-Scarthgap provides native PKCS#11 FIT signing support and is the
+intended migration target once this project moves beyond its current
+Scarthgap layer set.
+
+### How `scripts/sign-fit.sh` works
+
+The wrapper does three things, in order:
+
+1. **`fdtput` rewrite** — walks every
+   `/configurations/conf-*/signature*/key-name-hint` and sets it to the
+   libykcs11 CKA_LABEL exposed by the slot (default
+   `"Private key for PIV Authentication"` for PIV 9a). This is the
+   string that ends up in the resulting `Sign algo:` audit line; it is
+   **not** the key-lookup mechanism.
+2. **`mkimage -F -N pkcs11 -G "<uri>" <fit>`** — signs in place via
+   `engine_pkcs11` against `libykcs11`. The PKCS#11 URI passed via
+   `-G` is the actual lookup mechanism. Default URI is built from
+   `--key-label` (`pkcs11:object=<url-encoded label>;type=private`);
+   override `--uri` for token-anchored URIs in multi-YubiKey setups.
+   PIN is prompted on the terminal; touch is required per slot 9a's
+   touch policy (`CACHED` covers a multi-config signing call with one
+   tap).
+3. **Bytes-changed guard + structural verify** — captures Sign value
+   bytes before mkimage, dies if unchanged after. The optional
+   `--verify` is a *structural* check only — it asserts
+   `Sign algo: sha256,rsa2048:<KEY_LABEL>` and a non-empty Sign value.
+   It does **not** cryptographically verify against the slot pubkey.
+   For full crypto verification, run `mkimage -V` against a DTB
+   carrying the expected pubkey.
+
+Typical invocation against a COPY of the deploy artifact (never the
+deploy FIT directly — see warning below):
+
+```bash
+cp build/tmp-glibc/.../fitImage /tmp/fit-test/fitImage.yk
+bash scripts/sign-fit.sh --fit /tmp/fit-test/fitImage.yk --verify
+```
+
+### What success looks like
+
+On a YubiKey-signed fitImage, `dumpimage -l` shows, for every
+configuration:
+
+```
+Sign algo:    sha256,rsa2048:Private key for PIV Authentication
+Sign value:   <256 bytes of fresh RSA-2048 signature>
+Timestamp:    <signing time, not build time>
+```
+
+Compared against the file-signed source, the configurations'
+`Sign value` bytes are entirely different and the `Timestamp` is the
+post-build signing wall clock. Both keys produce 256-byte RSA-2048
+signatures over the same hash, so byte-length is identical — only the
+content differs.
+
+For release evidence, capture `dumpimage -l` output and SHA-256 hashes
+for the source and HSM-signed FIT artifacts in the release record.
+
+For bundle-side evidence, extract the final `.raucb` with RAUC itself
+instead of raw `unsquashfs` (encrypted verity bundles are not directly
+readable as SquashFS):
+
+```bash
+DEPLOY=build/tmp-glibc/deploy/images/raspberrypi5
+OUT=/tmp/iotgw-fit-bundle-check
+
+rm -rf "$OUT"
+rauc extract \
+  --trust-environment \
+  --keyring=/path/to/root-ca-primary.crt \
+  --key=/path/to/device-decryption.key \
+  "$DEPLOY/iot-gw-image-dev-bundle-full-fit.raucb" \
+  "$OUT"
+
+mkdir -p "$OUT/bootfiles"
+tar -xzf "$OUT/bootfiles-fit.tar.gz" -C "$OUT/bootfiles"
+sha256sum "$OUT/bootfiles-fit.tar.gz" "$DEPLOY/bootfiles-fit.tar.gz"
+dumpimage -l "$OUT/bootfiles/fitImage" | \
+  grep -E 'Sign algo:|Sign value:|Timestamp:'
+```
+
+### Detached signing — three independent stages
+
+HSM signing must never sit on the critical path of an unattended build.
+A CI runner or any pipeline that needs to complete without operator
+intervention has to be able to produce *something* releasable without
+contacting a YubiKey. The signing step is a separate ceremony — run on
+a machine with the HSM physically attached, by an operator who is
+present, or by a hardened signing daemon — and its output is fed back
+into a final assembly step.
+
+This repo expresses the model as three independent Make targets, none
+of them prerequisites of the others:
+
+```mermaid
+flowchart TD
+    subgraph CI1["Stage 1: unattended build runner"]
+        A["make bundle-dev-full-fit"]
+        B["bootfiles-fit.tar.gz<br/>inner FIT signed by file key"]
+        C["candidate .raucb<br/>not final release if HSM signing is required"]
+        A --> B
+        A --> C
+    end
+
+    subgraph Store1["Release artifact storage"]
+        D["file-key signed build artifacts"]
+    end
+
+    subgraph HSM["Stage 2: operator workstation or signing server"]
+        E["make sign-bootfiles-fit-yk"]
+        F["scripts/sign-bootfiles-fit.sh"]
+        G["scripts/sign-fit.sh"]
+        YK["YubiKey PIV slot 9a<br/>RSA-2048 private key<br/>non-extractable"]
+        H["bootfiles-fit.tar.gz<br/>inner FIT HSM-signed"]
+        E --> F --> G
+        G -->|"PKCS#11 via engine_pkcs11<br/>PIN + touch or signing-daemon policy"| YK
+        YK --> G --> H
+    end
+
+    subgraph Store2["Release artifact storage"]
+        I["HSM-signed bootfiles-fit.tar.gz"]
+    end
+
+    subgraph CI2["Stage 3: unattended bundle assembly"]
+        J["make bundle-dev-full-fit-resign"]
+        K["iot-gw-bundle-full-fit<br/>do_configure re-copies signed tarball"]
+        L["final .raucb<br/>contains HSM-signed FIT"]
+        J --> K --> L
+    end
+
+    B --> D --> E
+    H --> I --> J
+```
+
+The same trust boundary can be viewed as artifact movement:
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant CI as CI/build runner
+    participant Store as Artifact storage
+    participant Signer as Operator or signing service
+    participant YK as YubiKey/HSM
+    participant Final as Final assembly runner
+
+    CI->>CI: make bundle-dev-full-fit
+    CI->>Store: publish bootfiles-fit.tar.gz and candidate .raucb
+    Store->>Signer: fetch bootfiles-fit.tar.gz
+    Signer->>YK: PKCS#11 sign FIT hashes<br/>PIN/touch or daemon policy
+    YK-->>Signer: RSA-2048 signatures
+    Signer->>Store: publish HSM-signed bootfiles-fit.tar.gz
+    Store->>Final: fetch signed tarball
+    Final->>Final: make bundle-dev-full-fit-resign
+    Final->>Store: publish final HSM-signed .raucb
+```
+
+#### Stage 1 — `make bundle-dev-full-fit` (UNATTENDED)
+
+Same target as the file-key flow above. No HSM, no PIN, no touch.
+Suitable for GitHub Actions, GitLab runners, or any unattended
+pipeline. Produces the file-key-signed `.raucb` plus the deploy
+`bootfiles-fit.tar.gz` whose inner FIT is file-key signed.
+
+#### Stage 2 — `make sign-bootfiles-fit-yk` (OPERATOR-ONLY)
+
+Wraps `scripts/sign-bootfiles-fit.sh`. Extracts
+`deploy/.../bootfiles-fit.tar.gz`, calls `sign-fit.sh` on the inner
+FIT (prompts for PIN, requires touch under slot 9a's `CACHED`
+policy), repacks the tarball in place. Snapshot/restore semantics: if
+anything fails between extract and repack, the original tarball is
+restored from a `.bak` sibling.
+
+The wrapper is idempotent. Before extracting and re-signing, it peeks
+at the inner `fitImage`'s `Sign algo:` audit lines; if **every**
+signature node already advertises the HSM key-name-hint
+(`sha256,rsa2048:<KEY_LABEL>`), Stage 2 exits cleanly without
+contacting the YubiKey. A fresh Stage 1 build produces a
+file-key-signed FIT, so the audit line shows the file-key label and
+Stage 2 signs. A partially labelled FIT (one config matches, another
+still shows the file-key label) is NOT skipped — the wrapper logs the
+mismatch and re-signs all nodes, so a mixed-trust tarball never makes
+it to the bundle. To override the skip and re-sign anyway, pass
+`--force` to the wrapper. With the Make wrapper:
+
+```bash
+make sign-bootfiles-fit-yk SIGN_BOOTFILES_ARGS=--force
+```
+
+`SIGN_BOOTFILES_ARGS` is consumed by `sign-bootfiles-fit.sh` before
+the `--` separator; `SIGN_FIT_ARGS` is forwarded to `sign-fit.sh`
+after `--`.
+
+The check is content-based: the "already labelled" signal lives
+inside the artifact, not in a sidecar file. The same archive can be
+moved between machines (CI → operator workstation → final-assembly
+runner) and the idempotency decision is consistent everywhere. The
+check inspects audit metadata (the key-name-hint embedded in each
+`signature*` node), not the cryptographic signature. The
+authoritative signature verification still belongs to U-Boot at boot
+time, against the public key embedded in the signing DTB.
+
+Runs **only** on a machine with the HSM physically attached — an
+operator workstation or a hardened signing server. Never runs in CI.
+The signing step is bounded in time and well-defined: one PIN entry,
+one touch (CACHED covers all configurations in the FIT), seconds of
+wall clock.
+
+#### Stage 3 — `make bundle-dev-full-fit-resign` (UNATTENDED)
+
+`bitbake -C do_configure iot-gw-bundle-full-fit`. Invalidates the
+bundle recipe's `do_configure` stamp so it re-copies the now-HSM-
+signed tarball from DEPLOY_DIR_IMAGE into its WORKDIR and re-runs
+`do_bundle`. A few minutes; no kernel/rootfs rebuild. Can run in CI
+on any runner that has the signed tarball deployed (e.g. via an
+artifact pull from release storage), or locally by the operator
+right after Stage 2.
+
+#### CI / signing-server integration
+
+For pipelines that have to be fully unattended, the only options are:
+
+1. **Detached signing server** — a small daemon on a controlled host
+   with the HSM permanently attached. It receives a signing request
+   (artifact + metadata) over an authenticated channel (mTLS), runs
+   the equivalent of Stage 2, returns the signed artifact. PIN is
+   pre-loaded into the daemon's session at boot (operator
+   authenticates once); touch can be CACHED with a long window or
+   NEVER (lower-assurance only). Stage 3 then runs on the CI runner.
+2. **Manual handoff** — CI does Stage 1, publishes artifacts; a
+   release manager pulls them to a workstation with the YubiKey
+   attached, runs Stage 2, pushes the signed tarball back; a final
+   CI job (or the operator) runs Stage 3.
+
+The repository ships only the building blocks (sign-fit.sh,
+sign-bootfiles-fit.sh, the three Make targets). The signing daemon
+is intentionally not in scope here — it belongs to whichever signing
+infrastructure the consumer of this layer already runs.
+
+The example YubiKey policy used during bring-up is touch `CACHED` +
+PIN `ALWAYS`, which prevents headless unattended HSM signing unless a
+project explicitly chooses a relaxed signing-server policy.
+
+### Slot 9a provisioning reference
+
+Provision slot 9a with an RSA-2048 private key generated on-device,
+create or import the matching public certificate used for U-Boot FIT
+verification, and capture the YubiKey F9 attestation certificate in the
+release key-management record. Private-key material must never be
+exported or committed. Local engine/provider configuration and
+certificates are expected to live outside the repository, for example
+under an operator-controlled key directory.

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -259,13 +259,14 @@ Expected failure symptoms in U-Boot log:
 - Do not commit keys into repository.
 - Keep RAUC signing keys and FIT signing keys separate.
 
-## YubiKey Post-Build Signing (Stage 2)
+## Signing FIT against a PKCS#11 token (YubiKey)
 
 The default flow above signs the FIT inside bitbake against a file-based
 RSA key under `UBOOT_SIGN_KEYDIR`. The HSM-backed flow moves the FIT
-signing key onto a YubiKey (PIV slot 9a, RSA-2048) and performs the
-signing as a **post-build** step. The bitbake-side signer stays
-file-based; only the deploy artifact is re-signed.
+signing key to a PKCS#11 token (the YubiKey PIV slot 9a in this
+repository's example, RSA-2048) and performs the signing as a
+**post-build** step. The bitbake-side signer stays file-based; only the
+deploy artifact is re-signed.
 
 ### Why not sign inside bitbake
 
@@ -287,7 +288,8 @@ There is also a silent no-op trap in the no-`-k` path:
 `mkimage -F -N pkcs11 <fit>` without `-k` **and** without `-G` exits 0,
 regenerates hashes, repacks the FDT, and leaves the original signature
 bytes untouched. The `sign-fit.sh` wrapper guards against this by
-comparing Sign values pre/post.
+requiring at least one `Signature written` line in mkimage's captured
+output before declaring success.
 
 Upstream migration note: the meta-oe `fitimage.bbclass` merged
 post-Scarthgap provides native PKCS#11 FIT signing support and is the
@@ -312,16 +314,20 @@ The wrapper does three things, in order:
    PIN is prompted on the terminal; touch is required per slot 9a's
    touch policy (`CACHED` covers a multi-config signing call with one
    tap).
-3. **Bytes-changed guard + structural verify** — captures Sign value
-   bytes before mkimage, dies if unchanged after. The optional
-   `--verify` is a *structural* check only — it asserts
-   `Sign algo: sha256,rsa2048:<KEY_LABEL>` and a non-empty Sign value.
-   It does **not** cryptographically verify against the slot pubkey.
-   For full crypto verification, run `mkimage -V` against a DTB
-   carrying the expected pubkey.
+3. **Success detection + structural verify** — captures mkimage's
+   output; requires at least one `Signature written` log line.
+   Deterministic RSA-PKCS#1 v1.5 over the FIT signed range makes
+   byte-comparison guards unreliable (re-signing the same content
+   with the same key produces identical bytes), so the log line is
+   the authoritative success signal. The optional `--verify` is a
+   *structural* check on top: it asserts every signature node
+   carries `Sign algo: sha256,rsa2048:<KEY_LABEL>` and a non-empty
+   `Sign value`. It does **not** cryptographically verify the
+   signature against the slot's public key — for that, run
+   `mkimage -V` against a DTB that embeds the expected pubkey.
 
-Typical invocation against a COPY of the deploy artifact (never the
-deploy FIT directly — see warning below):
+The script mutates `--fit` in place. Run it against a copy of the
+deploy artifact:
 
 ```bash
 cp build/tmp-glibc/.../fitImage /tmp/fit-test/fitImage.yk
@@ -386,7 +392,7 @@ of them prerequisites of the others:
 
 ```mermaid
 flowchart TD
-    subgraph CI1["Stage 1: unattended build runner"]
+    subgraph BuildPhase["Build phase (unattended build runner)"]
         A["make bundle-dev-full-fit"]
         B["bootfiles-fit.tar.gz<br/>inner FIT signed by file key"]
         C["candidate .raucb<br/>not final release if HSM signing is required"]
@@ -398,11 +404,11 @@ flowchart TD
         D["file-key signed build artifacts"]
     end
 
-    subgraph HSM["Stage 2: operator workstation or signing server"]
+    subgraph SignPhase["Sign phase (operator workstation or signing server)"]
         E["make sign-bootfiles-fit-yk"]
         F["scripts/sign-bootfiles-fit.sh"]
         G["scripts/sign-fit.sh"]
-        YK["YubiKey PIV slot 9a<br/>RSA-2048 private key<br/>non-extractable"]
+        YK["PKCS#11 token<br/>RSA-2048 private key<br/>non-extractable"]
         H["bootfiles-fit.tar.gz<br/>inner FIT HSM-signed"]
         E --> F --> G
         G -->|"PKCS#11 via engine_pkcs11<br/>PIN + touch or signing-daemon policy"| YK
@@ -413,7 +419,7 @@ flowchart TD
         I["HSM-signed bootfiles-fit.tar.gz"]
     end
 
-    subgraph CI2["Stage 3: unattended bundle assembly"]
+    subgraph AssemblePhase["Assemble phase (unattended bundle assembly)"]
         J["make bundle-dev-full-fit-resign"]
         K["iot-gw-bundle-full-fit<br/>do_configure re-copies signed tarball"]
         L["final .raucb<br/>contains HSM-signed FIT"]
@@ -446,33 +452,33 @@ sequenceDiagram
     Final->>Store: publish final HSM-signed .raucb
 ```
 
-#### Stage 1 — `make bundle-dev-full-fit` (UNATTENDED)
+#### Build — `make bundle-dev-full-fit` (unattended)
 
 Same target as the file-key flow above. No HSM, no PIN, no touch.
 Suitable for GitHub Actions, GitLab runners, or any unattended
 pipeline. Produces the file-key-signed `.raucb` plus the deploy
 `bootfiles-fit.tar.gz` whose inner FIT is file-key signed.
 
-#### Stage 2 — `make sign-bootfiles-fit-yk` (OPERATOR-ONLY)
+#### Sign — `make sign-bootfiles-fit-yk` (operator-only)
 
 Wraps `scripts/sign-bootfiles-fit.sh`. Extracts
 `deploy/.../bootfiles-fit.tar.gz`, calls `sign-fit.sh` on the inner
-FIT (prompts for PIN, requires touch under slot 9a's `CACHED`
-policy), repacks the tarball in place. Snapshot/restore semantics: if
+FIT (prompts for PIN, requires touch when the slot policy demands
+one), repacks the tarball in place. Snapshot/restore semantics: if
 anything fails between extract and repack, the original tarball is
 restored from a `.bak` sibling.
 
 The wrapper is idempotent. Before extracting and re-signing, it peeks
 at the inner `fitImage`'s `Sign algo:` audit lines; if **every**
 signature node already advertises the HSM key-name-hint
-(`sha256,rsa2048:<KEY_LABEL>`), Stage 2 exits cleanly without
-contacting the YubiKey. A fresh Stage 1 build produces a
-file-key-signed FIT, so the audit line shows the file-key label and
-Stage 2 signs. A partially labelled FIT (one config matches, another
-still shows the file-key label) is NOT skipped — the wrapper logs the
-mismatch and re-signs all nodes, so a mixed-trust tarball never makes
-it to the bundle. To override the skip and re-sign anyway, pass
-`--force` to the wrapper. With the Make wrapper:
+(`sha256,rsa2048:<KEY_LABEL>`), the wrapper exits cleanly without
+contacting the token. A fresh build produces a file-key-signed FIT, so
+the audit line shows the file-key label and the wrapper signs. A
+partially labelled FIT (one config matches, another still shows the
+file-key label) is NOT skipped — the wrapper logs the mismatch and
+re-signs all nodes, so a mixed-trust tarball never makes it to the
+bundle. To override the skip and re-sign anyway, pass `--force` to the
+wrapper. With the Make wrapper:
 
 ```bash
 make sign-bootfiles-fit-yk SIGN_BOOTFILES_ARGS=--force
@@ -497,7 +503,7 @@ The signing step is bounded in time and well-defined: one PIN entry,
 one touch (CACHED covers all configurations in the FIT), seconds of
 wall clock.
 
-#### Stage 3 — `make bundle-dev-full-fit-resign` (UNATTENDED)
+#### Assemble — `make bundle-dev-full-fit-resign` (unattended)
 
 `bitbake -C do_configure iot-gw-bundle-full-fit`. Invalidates the
 bundle recipe's `do_configure` stamp so it re-copies the now-HSM-
@@ -505,7 +511,7 @@ signed tarball from DEPLOY_DIR_IMAGE into its WORKDIR and re-runs
 `do_bundle`. A few minutes; no kernel/rootfs rebuild. Can run in CI
 on any runner that has the signed tarball deployed (e.g. via an
 artifact pull from release storage), or locally by the operator
-right after Stage 2.
+right after the sign phase.
 
 #### CI / signing-server integration
 
@@ -514,22 +520,23 @@ For pipelines that have to be fully unattended, the only options are:
 1. **Detached signing server** — a small daemon on a controlled host
    with the HSM permanently attached. It receives a signing request
    (artifact + metadata) over an authenticated channel (mTLS), runs
-   the equivalent of Stage 2, returns the signed artifact. PIN is
-   pre-loaded into the daemon's session at boot (operator
-   authenticates once); touch can be CACHED with a long window or
-   NEVER (lower-assurance only). Stage 3 then runs on the CI runner.
-2. **Manual handoff** — CI does Stage 1, publishes artifacts; a
-   release manager pulls them to a workstation with the YubiKey
-   attached, runs Stage 2, pushes the signed tarball back; a final
-   CI job (or the operator) runs Stage 3.
+   the equivalent of the sign phase, returns the signed artifact.
+   The PIN is pre-loaded into the daemon's session at start-up
+   (operator authenticates once); touch can be CACHED with a long
+   window or NEVER (lower-assurance only). The CI runner then runs
+   the assemble phase.
+2. **Manual handoff** — CI runs the build phase and publishes
+   artifacts; a release manager pulls them to a workstation with the
+   token attached, runs the sign phase, publishes the signed tarball
+   back; a final CI job (or the operator) runs the assemble phase.
 
-The repository ships only the building blocks (sign-fit.sh,
-sign-bootfiles-fit.sh, the three Make targets). The signing daemon
-is intentionally not in scope here — it belongs to whichever signing
-infrastructure the consumer of this layer already runs.
+The repository ships only the building blocks (`sign-fit.sh`,
+`sign-bootfiles-fit.sh`, the three Make targets). The signing daemon
+is intentionally out of scope here — it belongs to whichever signing
+infrastructure consumes this layer.
 
-The example YubiKey policy used during bring-up is touch `CACHED` +
-PIN `ALWAYS`, which prevents headless unattended HSM signing unless a
+The example token policy in this repository is touch `CACHED` + PIN
+`ALWAYS`, which prevents headless unattended HSM signing unless a
 project explicitly chooses a relaxed signing-server policy.
 
 ### Slot 9a provisioning reference

--- a/docs/RAUC_PKI.md
+++ b/docs/RAUC_PKI.md
@@ -933,20 +933,3 @@ anchors installed into `/etc/rauc/keyring.d/`). The two settings serve
 different audiences (build host vs device) and intentionally don't
 share a variable.
 
-## References
-
-- `kas/local.yml.example` — committed convention for the build-time
-  variables consumed by `rauc-conf-iotgw`.
-- `meta-iot-gateway/recipes-ota/rauc/rauc-conf-iotgw_1.0.bb` — recipe
-  that renders `/etc/rauc/system.conf` and installs the keyring
-  directory.
-- `meta-iot-gateway/recipes-ota/rauc/files/iotgw-system.conf` —
-  `system.conf` template with the four token placeholders the recipe
-  substitutes (compatible string, TLS key, keyring locator, check-purpose,
-  allowed-signer-cns).
-- `docs/RAUC_UPDATE.md` — RAUC bundle install lifecycle on the device
-  (RAUC slot/boot semantics, install hooks, A/B rollback). Trust-anchor
-  policy described here is independent of the install mechanics
-  documented there.
-- `docs/SECURITY.md` — overall security posture; this PKI is one
-  component of it.

--- a/docs/RAUC_PKI.md
+++ b/docs/RAUC_PKI.md
@@ -33,15 +33,15 @@ is public, the hardware inventory is operator-local.
   `check-purpose=codesign` and `allowed-signer-cns=` gates add CN
   allowlisting and X.509 purpose enforcement on top of chain trust.
 
-### What it does NOT protect against (Stage 1 residual risks)
+### What it does NOT protect against
 
 - **File-based intermediate CA compromise.** The Dev/Prod intermediate
   CA private keys live on the build host's filesystem (`0600` ownership,
   but recoverable by any process running as the operator). An attacker
   who roots the build host can sign new leaves under the Dev/Prod CA
-  without ever touching the YubiKey. **This is the explicit residual
-  risk closed by a follow-on phase** that promotes Dev/Prod CA private
-  keys into YubiKey PIV slots 9d/82.
+  without ever touching the YubiKey. Moving these intermediate CA keys
+  to a hardware-backed slot would close this gap; that migration is out
+  of scope for this document.
 - **Physical YubiKey + PIN attack.** A stolen YubiKey with three PIN
   attempts is locked out (and PUK has its own three-attempt limit). The
   dual-Root design assumes physical compromise of only one of the two
@@ -118,59 +118,17 @@ self-heals from leaf compromise without active CRL infrastructure.
 
 The libykcs11 path is `/usr/local/lib/libykcs11.so` (source-built rather
 than distro-packaged because distro packages historically do not expose
-the PIV retired slots 82–95 that this design uses for Stage 4 promotion).
-`opensc-pkcs11.so` is present on most hosts but **not used** here — it
-cannot enumerate retired slots.
-
-### Operator-local inventory (never committed)
-
-Operators record the following in their own vault, never in repo:
-
-- The two YubiKey serial numbers (referred to in this doc as
-  `${YK_PRIMARY_SERIAL}` and `${YK_BACKUP_SERIAL}`)
-- The F9 attestation certs captured at provisioning time
-- The PIN/PUK values
-
-Suggested vault layout under `${RAUC_CA_DIR}` (e.g.
-`~/rauc-keys/rauc-ca/`):
-
-```
-${RAUC_CA_DIR}/
-├── root-ca/
-│   ├── openssl-root.cnf
-│   ├── openssl-root-backup.cnf
-│   ├── openssl-ca-primary.cnf       # `openssl ca` config for Root signing
-│   ├── root-ca-primary.crt          # exported Root cert (public)
-│   ├── root-ca-primary.pub          # exported Root pubkey
-│   ├── root-ca-backup.crt
-│   ├── root-ca-backup.pub
-│   ├── index.txt                    # `openssl ca` issuance database
-│   ├── serial
-│   ├── newcerts/                    # `openssl ca` cert copies
-│   └── attestations/
-│       ├── yk-${YK_PRIMARY_SERIAL}-9c-attest.crt
-│       └── yk-${YK_BACKUP_SERIAL}-9c-attest.crt
-├── dev-ca/
-│   ├── openssl-dev-ca.cnf
-│   ├── dev-ca.key.pem               # FILE-BASED — Stage 4 promotes to HSM
-│   ├── dev-ca.csr
-│   └── dev-ca.cert.pem
-├── prod-ca/
-│   ├── openssl-prod-ca.cnf
-│   ├── prod-ca.key.pem
-│   ├── prod-ca.csr
-│   └── prod-ca.cert.pem
-└── issued/dev/
-    ├── openssl-dev-leaf.cnf
-    ├── iotgw-rauc-dev-signer-2026.key.pem
-    ├── iotgw-rauc-dev-signer-2026.csr
-    └── iotgw-rauc-dev-signer-2026.cert.pem
-```
+the PIV retired slots 82–95 that this design uses). `opensc-pkcs11.so`
+is present on most hosts but **not used** here — it cannot enumerate
+retired slots.
 
 The Root certs (`root-ca-{primary,backup}.crt`) are public and *will*
 land in committed image bundles via the device keyring directory — but
-they are not committed to the repo directly. The recipe consumes them at
-build time via `IOTGW_RAUC_KEYRING_CERTS` (see below).
+the certificate files themselves are not committed to the repo. The
+recipe consumes them at build time via `IOTGW_RAUC_KEYRING_CERTS` (see
+below). Private-key material, F9 attestation certs, PIN/PUK values, and
+YubiKey serial numbers live on the operator's workstation outside the
+repository.
 
 ### Serial-anchored PKCS#11 URIs
 
@@ -186,32 +144,31 @@ pkcs11:token=YubiKey%20PIV%20%23${YK_BACKUP_SERIAL};id=%02;type=private
 `%23` is URL-encoded `#`, the prefix Yubico's libykcs11 uses in the
 token label (e.g. `YubiKey PIV #<serial>`).
 
-## Slot Reservation Map
+## PIV slots used by this design
 
-PIV slots are assigned by purpose, not by which YubiKey holds them. Both
-the primary and backup YubiKey use the same slot layout. The
-`CKA_ID (hex)` column is the integer ykcs11 maps each PIV slot to (per
-`ykcs11/objects.c`).
+This document's procedures touch the following PIV slots on each
+YubiKey. Slot purposes are assigned by role, not by which YubiKey holds
+them — primary and backup use the same layout.
 
-| Slot | CKA_ID | Role | Algorithm | PIN | Touch | Stage 1 status |
-|---|---|---|---|---|---|---|
-| 9c | 0x02 | RAUC Root CA (shared with sibling projects) | P-384 | ALWAYS | ALWAYS | **Key + cert provisioned** |
-| 9d | 0x03 | RAUC Dev CA | (P-256) | — | — | Cert-only beacon (no key in slot) |
-| 82 | 0x05 | RAUC Prod CA | (P-256) | — | — | Cert-only beacon |
-| 83 | 0x06 | RAUC Dev signing leaf | (P-256) | — | — | Cert-only beacon |
-| 9a | 0x01 | FIT image signing | — | — | — | Reserved (future) |
-| 84–87 | 0x07–0x0a | Reserved for sibling project intermediates | — | — | — | Reserved |
-| F9 | — | Yubico attestation (factory) | — | — | — | **Never touch** |
+| Slot | Role | Algorithm | PIN | Touch |
+|---|---|---|---|---|
+| 9c | RAUC Root CA (on-device key) | P-384 | ALWAYS | ALWAYS |
+| 9d | RAUC Dev CA cert (cert-only, no in-slot key) | P-256 cert | — | — |
+| 82 | RAUC Prod CA cert (cert-only) | P-256 cert | — | — |
+| 83 | RAUC Dev signing-leaf cert (cert-only) | P-256 cert | — | — |
+| F9 | Yubico factory attestation (read-only) | — | — | — |
 
-The cert-only beacons in 9d/82/83 carry the corresponding intermediate /
-leaf cert without a matching on-device private key. Their purpose is
-twofold: operator traceability (`ykman piv info` instantly reveals which
-PKI tier each slot represents) and future-phase readiness (when a key
-is generated into the slot later, the slot already advertises the
-correct subject DN under the same operator workflow).
+The cert-only entries in 9d / 82 / 83 carry the corresponding
+intermediate or leaf certificate without a matching on-device private
+key. Their purpose is operator traceability: `ykman piv info` reveals
+which PKI tier each slot represents at a glance.
 
 Slot F9 holds Yubico's factory-loaded attestation key. **Overwriting it
 voids the attestation evidence chain.** It is read-only in this design.
+
+CKA_ID values (hex) used in PKCS#11 URIs for the slots above:
+`9c → 0x02`, `9d → 0x03`, `82 → 0x05`, `83 → 0x06`. Per
+`libykcs11`'s `ykcs11/objects.c` mapping.
 
 ## Provisioning Runbook
 
@@ -516,7 +473,8 @@ that the two Roots come from physically separate hardware.
 ykman piv info
 ```
 
-Expected on primary after Stage 1 — four populated slots:
+Expected on the primary YubiKey after running the provisioning runbook
+above — four populated slots:
 
 | Slot | Algorithm | Subject |
 |---|---|---|
@@ -595,7 +553,7 @@ Expected results:
 | **Legacy-signed bundle**    | ✓ accept (chain depth 1, `iot-gateway-rpi5`) | ✓ accept (legacy anchor still present) | ✗ **reject** — `Verify error: self-signed certificate` |
 | **Chain-signed bundle**     | ✗ **reject** — `unable to get local issuer certificate` | ✓ accept (chain depth 3, anchors on Root) | ✓ accept (chain depth 3, signer `iotgw-rauc-dev-signer-2026`) |
 
-The two reject cells are the portfolio-gold negative tests:
+The two reject cells are the critical negative tests:
 
 - **Legacy bundle on cutover keyring**: proves that once a device boots
   into the Root-only state, no legacy-signed bundle can install. The
@@ -606,7 +564,7 @@ The two reject cells are the portfolio-gold negative tests:
   climbed one step at a time.
 
 For each chain-signed accept, the chain breakdown rauc emits is itself
-worth capturing for the portfolio evidence folder:
+worth capturing in the release-evidence folder:
 
 ```
 Certificate Chain:
@@ -769,10 +727,11 @@ signature.
    chain anchors on the still-trusted backup Root.
 4. **Physically destroy** the lost primary YubiKey if recovered, or
    accept the residual risk if not.
-5. **Provision a fresh new-primary** in a new YubiKey (same procedure as
-   Stage 1-A), and ship a follow-up bundle re-anchoring the keyring
-   directory on `new-primary + backup` for redundancy. Optional: issue a
-   fresh Dev CA under the new primary Root and rotate signing leaves.
+5. **Provision a fresh new-primary** in a new YubiKey (same procedure
+   as the primary-Root provisioning runbook above), and ship a
+   follow-up bundle re-anchoring the keyring directory on
+   `new-primary + backup` for redundancy. Optional: issue a fresh Dev
+   CA under the new primary Root and rotate signing leaves.
 
 ### Backup YubiKey lost
 
@@ -826,41 +785,10 @@ A planned re-key is the three-image migration in reverse order:
    contains the new Root only (cutover image).
 4. Decommission the old YubiKey.
 
-## Out of Scope (Stage 4 preview)
-
-A follow-on phase promotes the file-based Dev/Prod intermediate CA
-private keys into the primary YubiKey's slots 9d/82, closing the residual
-risk that the build host's filesystem holds intermediate signing keys.
-
-Sketch of the migration:
-
-1. Generate a fresh P-256 keypair into slot 9d on the primary YubiKey
-   (PIN ALWAYS, touch CACHED for usability — intermediate signings happen
-   in batches during routine leaf rotation, so touch caching is OK at
-   the intermediate tier).
-2. Build a new CSR for the same `iotgw-rauc-dev-ca-2026` subject DN
-   (key changes; subject DN stays so leaves issued under the old key
-   remain verifiable until they expire naturally).
-3. Re-issue the Dev CA cert under the same Root primary YubiKey signing
-   path, using the new in-slot key.
-4. Replace the cert-only beacon in slot 9d with the freshly-issued cert.
-5. Optionally retire the file-based `dev-ca.key.pem` (shred the disk
-   key) once a couple of leaf rotations under the new HSM-resident Dev
-   CA have validated end-to-end.
-
-Repeat for slot 82 (Prod CA). The leaf signing key in slot 83 follows
-the same pattern at the next annual rotation.
-
-The retired slots 82–95 layout also lets us keep previous-generation
-signing keys on-device for verifying older artifacts after a rotation
-— see `~/ykcs11-build/SLOT_MAPPING.md` for the operator-local mapping
-documentation.
-
 ## Known Pitfalls and Workarounds
 
-Five real ecosystem traps hit during the rpi5-iot-gw rollout. Each costs
-hours the first time. Documented here so the next operator can skip
-straight to the fix.
+Five ecosystem traps documented here so they don't have to be
+re-derived. Each costs hours the first time.
 
 ### 1. Leaf cert needs both `codeSigning` AND `emailProtection` EKUs
 

--- a/scripts/sign-bootfiles-fit.sh
+++ b/scripts/sign-bootfiles-fit.sh
@@ -1,0 +1,210 @@
+#!/usr/bin/env bash
+# sign-bootfiles-fit.sh — re-sign the fitImage embedded in a
+# `bootfiles-fit.tar.gz` archive against a PKCS#11-resident key.
+#
+# Wraps `sign-fit.sh` to operate on the bootfiles tarball that the
+# RAUC bundle recipe consumes. After this script runs, the bundle
+# recipe must be re-driven (e.g. via `bitbake -C do_configure
+# iot-gw-bundle-full-fit`) so the bundle re-packages with the
+# updated tarball.
+#
+# Flow:
+#   1. Snapshot the archive (`<archive>.bak`) for rollback.
+#   2. Extract into a temp dir.
+#   3. Run scripts/sign-fit.sh on the extracted fitImage.
+#   4. Re-pack the tarball in place.
+#   5. Print SHA-256 of old/new archives.
+#
+# WARNING: mutates the bootfiles tarball in place. The script
+# restores the backup if any step after extraction fails.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+SIGN_FIT="${SCRIPT_DIR}/sign-fit.sh"
+
+DEFAULT_ARCHIVE="build/tmp-glibc/deploy/images/raspberrypi5/bootfiles-fit.tar.gz"
+
+ARCHIVE=""
+PASSTHROUGH=()
+FORCE=0
+
+BACKUP=""
+TMPDIR_WORK=""
+MUTATED=0
+
+die()  { echo "sign-bootfiles-fit.sh: error: $*" >&2; exit 1; }
+warn() { echo "sign-bootfiles-fit.sh: warning: $*" >&2; }
+log()  { echo "sign-bootfiles-fit.sh: $*"; }
+
+cleanup() {
+    local rc=$?
+    if [[ -n "${BACKUP}" && -f "${BACKUP}" ]]; then
+        if [[ ${rc} -ne 0 && ${MUTATED} -eq 1 ]]; then
+            if cp -f -- "${BACKUP}" "${ARCHIVE}" 2>/dev/null; then
+                warn "restored ${ARCHIVE} from ${BACKUP} after failure (exit ${rc})"
+            else
+                warn "FAILED to restore ${ARCHIVE} from ${BACKUP} — inspect manually (exit ${rc})"
+            fi
+        fi
+        rm -f -- "${BACKUP}"
+    fi
+    if [[ -n "${TMPDIR_WORK}" && -d "${TMPDIR_WORK}" ]]; then
+        rm -rf -- "${TMPDIR_WORK}"
+    fi
+}
+trap cleanup EXIT
+
+usage() {
+    cat <<EOF
+Usage: sign-bootfiles-fit.sh [--archive PATH] [-- <sign-fit.sh args>...]
+
+  --archive PATH   Path to bootfiles-fit.tar.gz.
+                   Default: ${DEFAULT_ARCHIVE}
+  --force          Re-sign even when the inner FIT already advertises
+                   the HSM key-name-hint in its 'Sign algo:' audit
+                   line. Useful when refreshing signature timestamps
+                   or recovering from a tampered audit field.
+  -h, --help       Show this help and exit.
+
+All arguments after '--' are forwarded to sign-fit.sh. Useful
+forwards: --uri, --key-label, --engine-conf, --verify.
+
+Example:
+  sign-bootfiles-fit.sh -- --verify
+  sign-bootfiles-fit.sh --archive /path/to/bootfiles-fit.tar.gz -- \\
+      --uri 'pkcs11:token=<encoded>;id=%01;type=private' --verify
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --archive) [[ $# -ge 2 ]] || die "--archive needs a value"; ARCHIVE="$2"; shift 2 ;;
+        --force)   FORCE=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --)        shift; PASSTHROUGH=("$@"); break ;;
+        -*)        usage >&2; die "unknown option: $1 (forwards to sign-fit.sh go after '--')" ;;
+        *)         usage >&2; die "unexpected positional argument: $1" ;;
+    esac
+done
+
+[[ -n "${ARCHIVE}" ]] || ARCHIVE="${DEFAULT_ARCHIVE}"
+[[ -f "${ARCHIVE}" ]] || die "archive not found: ${ARCHIVE}"
+[[ -w "${ARCHIVE}" ]] || die "archive not writable: ${ARCHIVE}"
+[[ -x "${SIGN_FIT}" ]] || die "helper not found or not executable: ${SIGN_FIT}"
+
+# Resolve to absolute path so the repack subshell's `cd` into TMPDIR_WORK
+# cannot break the archive reference.
+ARCHIVE="$(readlink -f -- "${ARCHIVE}")" || die "could not resolve absolute path of ${ARCHIVE}"
+ARCHIVE_DIR="$(dirname -- "${ARCHIVE}")"
+[[ -w "${ARCHIVE_DIR}" ]] || die "archive directory not writable: ${ARCHIVE_DIR}"
+
+for tool in tar sha256sum dumpimage; do
+    command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
+done
+
+PRE_SHA="$(sha256sum -- "${ARCHIVE}" | awk '{print $1}')"
+log "archive: ${ARCHIVE}"
+log "pre  sha256: ${PRE_SHA}"
+
+# Content-based idempotency check: peek at the inner FIT's `Sign algo:`
+# audit line. If it already advertises the HSM key-name-hint we would
+# sign with, skip — this is the signal a downstream consumer
+# (operator, signing service, U-Boot DTB verify) reads. The check is
+# spoofable in principle (someone could rewrite the FIT's
+# key-name-hint without actually signing with the HSM); for the
+# Stage 1 → Stage 2 flow that this script supports, the trade-off
+# favours an in-artifact signal over a sidecar trust file that does
+# not travel across machines. Use --force to override.
+#
+# Effective KEY_LABEL is what sign-fit.sh will use: parse from
+# PASSTHROUGH for an explicit --key-label, otherwise fall back to
+# sign-fit.sh's documented default.
+DEFAULT_HSM_LABEL="Private key for PIV Authentication"
+EFFECTIVE_LABEL="${DEFAULT_HSM_LABEL}"
+for ((i=0; i<${#PASSTHROUGH[@]}; i++)); do
+    if [[ "${PASSTHROUGH[i]}" == "--key-label" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
+        EFFECTIVE_LABEL="${PASSTHROUGH[i+1]}"
+        break
+    fi
+done
+EXPECTED_ALGO="sha256,rsa2048:${EFFECTIVE_LABEL}"
+
+if [[ "${FORCE}" -eq 0 ]]; then
+    peek_dir="$(mktemp -d -t sign-bootfiles-peek.XXXXXX)"
+    algo_total=0
+    algo_match=0
+    if tar -xzf "${ARCHIVE}" -C "${peek_dir}" ./fitImage 2>/dev/null \
+            && [[ -f "${peek_dir}/fitImage" ]]; then
+        # Skip only if every `Sign algo:` line in the FIT matches the
+        # expected algo. A partial state (one config labelled, another
+        # still showing the file-key label) must NOT skip — that would
+        # ship a mixed-trust bundle silently.
+        mapfile -t algo_lines < <(dumpimage -l "${peek_dir}/fitImage" 2>/dev/null \
+            | grep -F 'Sign algo:' || true)
+        algo_total="${#algo_lines[@]}"
+        for line in "${algo_lines[@]}"; do
+            if [[ "${line}" == *"${EXPECTED_ALGO}"* ]]; then
+                algo_match=$((algo_match + 1))
+            fi
+        done
+    fi
+    rm -rf -- "${peek_dir}"
+    if [[ "${algo_total}" -gt 0 && "${algo_match}" -eq "${algo_total}" ]]; then
+        log "all ${algo_total} signature node(s) in inner FIT already labelled '${EXPECTED_ALGO}'; skipping (use --force to re-sign)"
+        echo
+        echo "============ sign-bootfiles-fit summary ============"
+        printf "  Archive       : %s\n" "${ARCHIVE}"
+        printf "  SHA           : %s\n" "${PRE_SHA}"
+        printf "  Inner FIT     : all %d signature node(s) labelled '%s'\n" "${algo_total}" "${EXPECTED_ALGO}"
+        printf "  Mode          : skipped (use --force to re-sign)\n"
+        printf "  Timestamp     : %s\n" "$(date -u +%FT%TZ)"
+        echo "===================================================="
+        exit 0
+    fi
+    if [[ "${algo_total}" -gt 0 && "${algo_match}" -gt 0 ]]; then
+        log "inner FIT is partially labelled (${algo_match} of ${algo_total} signature node(s) match '${EXPECTED_ALGO}'); proceeding to re-sign all"
+    fi
+fi
+
+BACKUP="${ARCHIVE}.bak"
+cp -f -- "${ARCHIVE}" "${BACKUP}" || die "failed to write backup at ${BACKUP}"
+
+TMPDIR_WORK="$(mktemp -d -t sign-bootfiles-fit.XXXXXX)"
+log "extracting into ${TMPDIR_WORK}"
+tar -xzf "${ARCHIVE}" -C "${TMPDIR_WORK}" || die "tar extract failed"
+
+EXTRACTED_FIT="${TMPDIR_WORK}/fitImage"
+[[ -f "${EXTRACTED_FIT}" ]] || die "fitImage not found in archive (looked at ${EXTRACTED_FIT})"
+
+log "invoking sign-fit.sh on extracted fitImage"
+MUTATED=1
+"${SIGN_FIT}" --fit "${EXTRACTED_FIT}" "${PASSTHROUGH[@]}"
+
+log "repacking ${ARCHIVE}"
+# Re-pack from TMPDIR_WORK with the same ./<files> layout the original
+# archive used (verified to start with './' entries by the bundle recipe).
+( cd "${TMPDIR_WORK}" && tar -czf "${ARCHIVE}.new" . ) \
+    || die "tar repack failed"
+mv -f -- "${ARCHIVE}.new" "${ARCHIVE}" \
+    || die "failed to replace ${ARCHIVE} with repacked archive"
+
+POST_SHA="$(sha256sum -- "${ARCHIVE}" | awk '{print $1}')"
+log "post sha256: ${POST_SHA}"
+
+if [[ "${PRE_SHA}" == "${POST_SHA}" ]]; then
+    die "archive SHA unchanged after repack — sign-fit.sh likely no-op'd; check args (need --verify or signing args after '--')"
+fi
+
+echo
+echo "============ sign-bootfiles-fit summary ============"
+printf "  Archive   : %s\n" "${ARCHIVE}"
+printf "  Pre  SHA  : %s\n" "${PRE_SHA}"
+printf "  Post SHA  : %s\n" "${POST_SHA}"
+printf "  Inner FIT : signed (audit line '%s')\n" "${EXPECTED_ALGO}"
+printf "  Timestamp : %s\n" "$(date -u +%FT%TZ)"
+echo
+echo "Next step: re-drive the bundle recipe so it picks up the new"
+echo "tarball. With this project's KAS+make wrapper, that is:"
+echo "  make bundle-dev-full-fit-resign"
+echo "===================================================="

--- a/scripts/sign-fit.sh
+++ b/scripts/sign-fit.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+# sign-fit.sh — re-sign a U-Boot FIT image using a key on a PKCS#11
+# token (typically a YubiKey PIV slot) via OpenSSL's engine_pkcs11.
+#
+# Intended as a post-build release step: the build system signs the
+# FIT with a file-based key; this wrapper overwrites that signature in
+# place against an HSM-resident key.
+#
+# mkimage gotcha: `mkimage -F -N pkcs11 <fit>` without `-G` is a
+# silent no-op for the signing step. It repacks the FDT, regenerates
+# hashes, exits 0, and leaves the original signature bytes untouched.
+# This script always passes `-G <uri>` and additionally guards
+# against the trap by capturing mkimage's stdout/stderr and
+# requiring at least one "Signature written" log line — that line is
+# absent in the silent no-op case.
+#
+# The FIT's `key-name-hint` is metadata only — it determines the
+# audit string in `Sign algo: <alg>:<hint>`; the actual key lookup is
+# driven by the PKCS#11 URI passed via `-G`. fdtput rewrites the hint
+# before signing so the audit line reflects the HSM-resident key.
+#
+# WARNING: mutates --fit in place. Run against a copy of the deploy
+# artifact, not the deploy artifact directly. The script writes a
+# `<fit>.bak` next to the target before any mutation and restores it
+# on failure, but a successful sign-then-fail-elsewhere flow can
+# still leave a partially-updated bundle pipeline if the script is
+# pointed at the live deploy path.
+
+set -euo pipefail
+
+DEFAULT_KEY_LABEL="Private key for PIV Authentication"
+DEFAULT_ENGINE_CONF="${HOME}/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
+
+FIT=""
+ENGINE_CONF="${DEFAULT_ENGINE_CONF}"
+KEY_LABEL="${DEFAULT_KEY_LABEL}"
+URI=""
+VERIFY=0
+REWRITE_ONLY=0
+VERBOSE=0
+
+BACKUP=""
+MUTATED=0
+
+die()  { echo "sign-fit.sh: error: $*" >&2; exit 1; }
+warn() { echo "sign-fit.sh: warning: $*" >&2; }
+log()  { echo "sign-fit.sh: $*"; }
+
+cleanup() {
+    local rc=$?
+    if [[ -n "${BACKUP}" && -f "${BACKUP}" ]]; then
+        if [[ ${rc} -ne 0 && ${MUTATED} -eq 1 ]]; then
+            if cp -f -- "${BACKUP}" "${FIT}" 2>/dev/null; then
+                warn "restored ${FIT} from ${BACKUP} after failure (exit ${rc})"
+            else
+                warn "FAILED to restore ${FIT} from ${BACKUP} — inspect manually (exit ${rc})"
+                return
+            fi
+        fi
+        rm -f -- "${BACKUP}"
+    fi
+}
+trap cleanup EXIT
+
+# URL-encode anything outside the RFC 7512 pk11-unreserved subset.
+url_encode() {
+    local s="$1" i c out=""
+    for (( i=0; i<${#s}; i++ )); do
+        c="${s:i:1}"
+        case "$c" in
+            [a-zA-Z0-9._~-]) out+="$c" ;;
+            *)               printf -v c '%%%02X' "'$c"; out+="$c" ;;
+        esac
+    done
+    printf '%s' "$out"
+}
+
+usage() {
+    cat <<EOF
+Usage: sign-fit.sh --fit PATH [OPTIONS]
+
+  --fit PATH           Path to fitImage (required).
+  --engine-conf PATH   OpenSSL engine config that loads engine_pkcs11
+                       against the PKCS#11 module.
+                       Default: ${DEFAULT_ENGINE_CONF}
+  --key-label NAME     FIT key-name-hint to write before re-signing.
+                       Metadata only — drives the resulting
+                       'Sign algo:' audit line, not the key lookup.
+                       Should match the CKA_LABEL exposed by the
+                       PKCS#11 token when --uri is omitted (the
+                       default URI is built from this label).
+                       Default: "${DEFAULT_KEY_LABEL}"
+  --uri URI            PKCS#11 URI passed to mkimage via -G. Without
+                       this (or -k), mkimage -F silently skips
+                       signing. Default is built from --key-label as
+                       pkcs11:object=<url-encoded label>;type=private.
+                       Override for token-anchored URIs, e.g.
+                       'pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;id=%01;type=private'.
+  --verify             Structural check after signing (NOT a crypto
+                       verification). Asserts every signature node
+                       has algo 'sha256,rsa2048:<KEY_LABEL>' and a
+                       non-empty Sign value (rejects "unavailable").
+                       For cryptographic verification, run
+                       'mkimage -V' against a DTB carrying the
+                       expected public key.
+  --rewrite-only       Mutating: rewrite the FIT key-name-hint and
+                       stop before mkimage. Useful for plumbing
+                       tests without touching the token. The FIT is
+                       still modified — run on a copy.
+  --verbose            Forward mkimage's full stdout (FIT listing,
+                       per-image hashes) to the terminal. Default
+                       suppresses it; on mkimage failure the
+                       captured output is printed to stderr for
+                       diagnostics regardless of this flag.
+  -h, --help           Show this help and exit.
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --fit)          [[ $# -ge 2 ]] || die "--fit needs a value"; FIT="$2"; shift 2 ;;
+        --engine-conf)  [[ $# -ge 2 ]] || die "--engine-conf needs a value"; ENGINE_CONF="$2"; shift 2 ;;
+        --key-label)    [[ $# -ge 2 ]] || die "--key-label needs a value"; KEY_LABEL="$2"; shift 2 ;;
+        --uri)          [[ $# -ge 2 ]] || die "--uri needs a value"; URI="$2"; shift 2 ;;
+        --verify)       VERIFY=1; shift ;;
+        --rewrite-only) REWRITE_ONLY=1; shift ;;
+        --verbose)      VERBOSE=1; shift ;;
+        -h|--help)      usage; exit 0 ;;
+        --)             shift; break ;;
+        -*)             usage >&2; die "unknown option: $1" ;;
+        *)              usage >&2; die "unexpected positional argument: $1" ;;
+    esac
+done
+
+[[ -n "${FIT}" ]]         || { usage >&2; die "--fit is required"; }
+[[ -n "${KEY_LABEL}" ]]   || die "--key-label must not be empty"
+[[ -n "${ENGINE_CONF}" ]] || die "--engine-conf must not be empty"
+[[ -f "${FIT}" ]]         || die "fitImage not found: ${FIT}"
+[[ -w "${FIT}" ]]         || die "fitImage not writable: ${FIT}"
+FIT_DIR="$(dirname -- "${FIT}")"
+[[ -w "${FIT_DIR}" ]]     || die "cannot write backup next to ${FIT} (directory not writable: ${FIT_DIR})"
+[[ -f "${ENGINE_CONF}" ]] || die "engine conf not found: ${ENGINE_CONF}"
+
+if [[ -z "${URI}" ]]; then
+    URI="pkcs11:object=$(url_encode "${KEY_LABEL}");type=private"
+fi
+[[ "${URI}" == pkcs11:* ]] || die "URI must start with 'pkcs11:': ${URI}"
+
+for tool in fdtget fdtput mkimage; do
+    command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
+done
+if [[ "${REWRITE_ONLY}" -eq 0 || "${VERIFY}" -eq 1 ]]; then
+    command -v dumpimage >/dev/null 2>&1 \
+        || die "dumpimage required for signing and --verify (not on PATH)"
+fi
+
+# Token presence check (best-effort; engine_pkcs11 has no serial-anchor
+# CLI flag, so multi-token setups are inherently ambiguous unless --uri
+# carries token=...).
+if [[ "${REWRITE_ONLY}" -eq 0 ]] && command -v ykman >/dev/null 2>&1; then
+    if ! ykman_out="$(ykman list 2>&1)"; then
+        warn "ykman list failed (${ykman_out%%$'\n'*}) — skipping presence check"
+    else
+        mapfile -t yk_tokens < <(printf '%s' "${ykman_out}" | grep -v '^[[:space:]]*$' || true)
+        case "${#yk_tokens[@]}" in
+            0) die "no YubiKey detected on the bus (use --rewrite-only to skip signing)" ;;
+            1) : ;;
+            *) warn "${#yk_tokens[@]} YubiKeys detected — without 'token=' in --uri, engine_pkcs11 selects whichever it sees first" ;;
+        esac
+    fi
+fi
+
+# Take backup before any mutation so the EXIT trap can restore on
+# failure. From here on, MUTATED=1 means the on-disk FIT differs from
+# the backup.
+BACKUP="${FIT}.bak"
+cp -f -- "${FIT}" "${BACKUP}" || die "failed to write backup at ${BACKUP}"
+
+# Enumerate /configurations subnodes. fdtget -l prints one subnode per
+# line; properties (e.g. 'default') are not listed.
+if ! confs_raw="$(fdtget -l "${FIT}" /configurations 2>&1)"; then
+    die "fdtget failed to list /configurations: ${confs_raw}"
+fi
+mapfile -t CONFS < <(printf '%s\n' "${confs_raw}")
+# Strip empties (mapfile can yield a trailing empty element).
+filtered=()
+for c in "${CONFS[@]}"; do [[ -n "${c}" ]] && filtered+=("${c}"); done
+CONFS=("${filtered[@]}")
+[[ "${#CONFS[@]}" -gt 0 ]] || die "no configuration nodes under /configurations in ${FIT}"
+
+TOTAL_SIGS=0
+for conf in "${CONFS[@]}"; do
+    if ! children_raw="$(fdtget -l "${FIT}" "/configurations/${conf}" 2>&1)"; then
+        die "fdtget failed to list /configurations/${conf}: ${children_raw}"
+    fi
+    mapfile -t CHILDREN < <(printf '%s\n' "${children_raw}")
+    sig_found=0
+    for child in "${CHILDREN[@]}"; do
+        [[ -n "${child}" ]] || continue
+        case "${child}" in
+            signature*)
+                MUTATED=1
+                fdtput -t s "${FIT}" "/configurations/${conf}/${child}" \
+                    key-name-hint "${KEY_LABEL}" \
+                    || die "fdtput failed on /configurations/${conf}/${child}"
+                sig_found=$((sig_found+1))
+                TOTAL_SIGS=$((TOTAL_SIGS+1))
+                ;;
+        esac
+    done
+    [[ "${sig_found}" -gt 0 ]] || die "no signature* nodes under /configurations/${conf}"
+done
+log "rewrote key-name-hint to '${KEY_LABEL}' on ${TOTAL_SIGS} signature node(s) across ${#CONFS[@]} configuration(s)"
+
+if [[ "${REWRITE_ONLY}" -eq 1 ]]; then
+    log "rewrite-only: FIT key-name-hint rewritten in place; skipping mkimage"
+else
+    log "signing FIT via engine_pkcs11 (PIN/touch may be required)"
+    log "  URI: ${URI}"
+
+    # Capture mkimage output to detect the explicit "Signature
+    # written" success line. Default is quiet — mkimage's own
+    # FIT-listing dump is suppressed; on failure it is dumped to
+    # stderr for diagnostics. --verbose forwards the listing live.
+    #
+    # PIN prompts from engine_pkcs11 are not affected: OpenSSL's UI
+    # writes them to /dev/tty, bypassing stdout/stderr redirection.
+    #
+    # Detection by log line, not byte comparison: RSA-PKCS#1 v1.5
+    # over the FIT signed range is deterministic — re-signing the
+    # same FIT with the same key produces byte-identical signatures
+    # and would false-positive a pre/post bytes-changed guard.
+    mk_log="$(mktemp)"
+    trap 'rm -f "${mk_log}"; cleanup' EXIT
+    set +e
+    if [[ "${VERBOSE}" -eq 1 ]]; then
+        OPENSSL_CONF="${ENGINE_CONF}" \
+            mkimage -F -N pkcs11 -G "${URI}" "${FIT}" 2>&1 | tee "${mk_log}"
+        mk_rc=${PIPESTATUS[0]}
+    else
+        OPENSSL_CONF="${ENGINE_CONF}" \
+            mkimage -F -N pkcs11 -G "${URI}" "${FIT}" >"${mk_log}" 2>&1
+        mk_rc=$?
+    fi
+    set -e
+    if [[ "${mk_rc}" -ne 0 ]]; then
+        echo "---- mkimage output ----" >&2
+        cat "${mk_log}" >&2
+        echo "------------------------" >&2
+        rm -f "${mk_log}"
+        die "mkimage -F failed (exit ${mk_rc})"
+    fi
+
+    sig_written_count=$(grep -c -F 'Signature written' "${mk_log}" || true)
+    if [[ "${sig_written_count}" -eq 0 ]]; then
+        echo "---- mkimage output ----" >&2
+        cat "${mk_log}" >&2
+        echo "------------------------" >&2
+        rm -f "${mk_log}"
+        die "mkimage exited 0 but emitted no 'Signature written' line — signing was a silent no-op (check engine config and that -G reached mkimage)"
+    fi
+    rm -f "${mk_log}"
+    trap cleanup EXIT
+    log "mkimage signed (${sig_written_count} 'Signature written' line(s) observed)"
+fi
+
+VERIFY_RESULT="skipped"
+if [[ "${VERIFY}" -eq 1 ]]; then
+    if ! dump_out="$(dumpimage -l "${FIT}" 2>&1)"; then
+        die "dumpimage failed during --verify: ${dump_out}"
+    fi
+    expected_algo="sha256,rsa2048:${KEY_LABEL}"
+
+    algo_count=$(printf '%s\n' "${dump_out}" | grep -c -F 'Sign algo:' || true)
+    match_count=$(printf '%s\n' "${dump_out}" | grep -c -F "${expected_algo}" || true)
+
+    if [[ "${algo_count}" -lt "${TOTAL_SIGS}" || "${match_count}" -lt "${TOTAL_SIGS}" ]]; then
+        printf '%s\n' "${dump_out}" >&2
+        die "verify failed: expected ${TOTAL_SIGS} signature(s) with algo '${expected_algo}', found ${match_count}"
+    fi
+
+    bad_sigs=0
+    while IFS= read -r line; do
+        val="${line#*Sign value:}"
+        val="$(printf '%s' "${val}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
+        if [[ -z "${val}" || "${val}" == "unavailable" ]]; then
+            bad_sigs=$((bad_sigs+1))
+        fi
+    done < <(printf '%s\n' "${dump_out}" | grep -F 'Sign value:')
+
+    if [[ "${bad_sigs}" -gt 0 ]]; then
+        printf '%s\n' "${dump_out}" >&2
+        die "verify failed: ${bad_sigs} signature node(s) have empty or 'unavailable' Sign value"
+    fi
+
+    VERIFY_RESULT="PASS (${match_count} signature(s) matched '${expected_algo}')"
+    log "verify: ${VERIFY_RESULT}"
+fi
+
+if [[ "${REWRITE_ONLY}" -eq 1 ]]; then
+    MODE="rewrite-only (FIT mutated, mkimage skipped)"
+else
+    MODE="signed via engine_pkcs11"
+fi
+
+echo
+echo "================ sign-fit summary ================"
+printf "  FIT image       : %s\n" "${FIT}"
+printf "  Key label       : %s\n" "${KEY_LABEL}"
+printf "  PKCS#11 URI     : %s\n" "${URI}"
+printf "  Engine conf     : %s\n" "${ENGINE_CONF}"
+printf "  Configurations  : %d\n" "${#CONFS[@]}"
+printf "  Signature nodes : %d\n" "${TOTAL_SIGS}"
+printf "  Mode            : %s\n" "${MODE}"
+printf "  Verify          : %s\n" "${VERIFY_RESULT}"
+printf "  Timestamp       : %s\n" "$(date -u +%FT%TZ)"
+echo "=================================================="


### PR DESCRIPTION
## Summary

Stage 2 of the YubiKey-rooted PKI portfolio: post-build FIT image
signing on the YubiKey (PIV slot 9a, RSA-2048). Builds on Stage 1's
chain-rooted RAUC bundle signing (PR #67).

The signing happens **outside** bitbake, as a detached release step,
because:

- mkimage 2025.04 (Yocto u-boot-tools-native) synthesises a malformed
  PKCS#11 URI when given both `-k <keydir>` and `-N pkcs11`, and
  ignores `-G <uri>` whenever `-k` is also present. Both
  `kernel-fitimage.bbclass` and this project's
  `iotgw-fit-custom-its.bbclass` hardcode `-k`, so `kas/local.yml`-
  level overrides cannot reach the working `-G` path.
- HSM signing inside bitbake forces an interactive PIN entry mid-
  build, which is unworkable for CI runners and for any long-running
  unattended build.

## What ships

- `scripts/sign-fit.sh` — re-sign a FIT against a PKCS#11 token via
  `engine_pkcs11`. Drives
  `mkimage -F -N pkcs11 -G "<uri>" <fit>`, rewrites the FIT's
  `key-name-hint` via `fdtput` first so the resulting `Sign algo:`
  audit line reflects the HSM-resident label.
- `scripts/sign-bootfiles-fit.sh` — wrap the above to operate on
  `bootfiles-fit.tar.gz` (extract → sign-fit.sh → repack), with
  content-based idempotency on the inner FIT's audit lines.
- Three independent Make targets express the detached signing model:

  ```
  make bundle-dev-full-fit         unattended file-key build (CI-safe)
  make sign-bootfiles-fit-yk       operator-only HSM signing (PIN/touch)
  make bundle-dev-full-fit-resign  unattended bundle re-assembly
  ```

  No prerequisites between the targets, so CI can drive stages 1+3
  without ever needing PIN entry; only the HSM-attached host runs
  stage 2.

- `docs/FIT_BOOT_SIGNING.md` — model rationale, mkimage gotchas,
  `rauc extract` evidence-capture flow, and trade-offs of the
  content-based idempotency check.

## Wrapper hardening

- Backup-and-restore via EXIT trap on either script; mutation flag
  so the trap only restores when work actually started.
- `--rewrite-only` mode for plumbing tests without YubiKey contact.
- `--verify` structural check (Sign algo label + non-empty Sign
  value, rejects `unavailable`); explicitly documented as audit-line
  check, **not** cryptographic verification.
- `--verbose` flag; default suppresses mkimage's FIT-listing dump
  and prints the captured log only on failure for diagnostics.
- Success detection via mkimage `Signature written` log line —
  deterministic RSA-PKCS#1 v1.5 rules out byte-comparison guards.
- Content-based idempotency: peeks at every `Sign algo:` line in
  the inner FIT before extracting; skips only when **all**
  signature nodes already advertise the HSM key-name-hint. A
  partially labelled FIT is re-signed in full rather than shipped
  silently. `--force` overrides.

## Test plan

- [x] `--rewrite-only` regression: rewrite-only path mutates FIT
      key-name-hint without invoking mkimage; rewrite-only +
      `--verify` passes structural check.
- [x] Live YubiKey signing: PIN prompts via `/dev/tty`, slot 9a
      produces RSA-2048 signatures, mkimage logs `Signature written`,
      structural verify passes.
- [x] Bundle pipeline: `make sign-bootfiles-fit-yk` followed by
      `make bundle-dev-full-fit-resign`; final `.raucb` extracted
      with `rauc extract` carries an inner FIT whose `Sign algo:`
      reflects the HSM label, with byte-identical signature values
      to the deploy tarball.
- [x] Idempotency — all-match skip: re-running Stage 2 against an
      already-labelled tarball skips without YubiKey contact.
- [x] Idempotency — partial-match no-skip: hand-crafted FIT with
      one HSM-labelled and one file-key-labelled signature node
      proceeds to re-sign all rather than shipping mixed-trust.
- [x] `--force` overrides idempotency skip.
- [x] Error handling: empty `--key-label`, missing `--fit`, unknown
      option, non-`pkcs11:` URI all rejected cleanly; backup
      restored on mid-flight failure.
- [x] Privacy review: no operator paths, no YubiKey serials, no
      personal narrative in committed files.

## Follow-ups (separate PRs)

- U-Boot signing-DTB rotation to trust the YubiKey-resident pubkey
  instead of the file key.
- Touch-policy decision for any unattended signing-server pattern
  (slot 9a is currently PIN ALWAYS + touch CACHED).