### PR TITLE
feat(fit): dtb dual-trust transition image for yubikey pubkey rotation

### DIFF
--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -259,6 +259,156 @@ Expected failure symptoms in U-Boot log:
 - Do not commit keys into repository.
 - Keep RAUC signing keys and FIT signing keys separate.
 
+## DTB trust rotation: file key → YubiKey
+
+The U-Boot **control FDT** (the runtime DTB the RPi firmware passes to
+U-Boot) holds the public keys U-Boot trusts when verifying FIT
+signatures at boot. Rotating from a file-key-only trust root to a
+hardware-resident YubiKey pubkey is the second leg of FIT-signing
+adoption: PR-side HSM signing produces FITs that only verify on devices
+whose control FDT carries the corresponding pubkey.
+
+This project ships a three-image rotation pattern modelled after the
+RAUC PKI rotation (see `docs/RAUC_PKI.md`):
+
+| Image | DTB trust roots | FIT signing key | Notes |
+|-------|-----------------|-----------------|-------|
+| A (legacy) | file key only | file key | Status quo before this rotation. |
+| **B (transition)** | **file key + YK pubkey** | file key (build) or YK (post-build, optional) | DTB carries both pubkeys with `/signature/required-mode = "any"`. A FIT signed by either root verifies. |
+| C (cutover) | YK pubkey only | YK (post-build, mandatory) | File key retired. `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. |
+
+Image B is the only image that should ship while operators still hold
+the legacy file-key private material. Devices that boot Image B will
+accept any future YK-signed FIT, so the rotation can proceed without
+re-flashing.
+
+### Operator pre-flight: export the YK public certificate
+
+The build host needs the public certificate from slot 9a. **No private
+key is exported, ever.** Capture once into the operator key tree:
+
+```bash
+KEY_DIR="${IOTGW_RAUC_KEY_DIR}/rauc-ca/fit"
+install -d -m 700 "$KEY_DIR"
+ykman piv certificates export 9a "$KEY_DIR/iotgw-fit-yk-2026.crt"
+chmod 644 "$KEY_DIR/iotgw-fit-yk-2026.crt"
+openssl x509 -in "$KEY_DIR/iotgw-fit-yk-2026.crt" -noout -subject -dates
+```
+
+The certificate filename is `<IOTGW_FIT_YK_KEYNAME>.crt`; renaming the
+YubiKey hint string in the project requires renaming this file in
+lockstep. The default `iotgw-fit-yk-2026` is intentionally year-tagged
+so a future rotation lands at `iotgw-fit-yk-<NEW_YEAR>` without
+clobbering existing trust anchors on already-deployed Image B devices.
+
+### Build-time configuration (Image B)
+
+In `kas/local.yml`, enable both trust roots:
+
+```yaml
+local_conf_header:
+  fit_dtb_yk_pubkey_trust: |
+    IOTGW_FIT_TRUST_FILE_KEY:fitflow = "1"
+    IOTGW_FIT_TRUST_YK_KEY:fitflow = "1"
+    IOTGW_FIT_YK_KEYDIR:fitflow = "${IOTGW_RAUC_KEY_DIR}/rauc-ca/fit"
+    IOTGW_FIT_YK_KEYNAME:fitflow = "iotgw-fit-yk-2026"
+```
+
+Force rebuild of the kernel so the deploy step re-mutates the DTBs:
+
+```bash
+kas shell kas/local.yml -c 'bitbake -c cleansstate virtual/kernel'
+make bundle-dev-full-fit
+```
+
+The kernel-fit recipe's `do_deploy:append` block:
+
+- Loops over `RPI_KERNEL_DEVICETREE` DTBs.
+- When `IOTGW_FIT_TRUST_FILE_KEY = "1"`: runs `mkimage -F -k -K -r` to
+  sign the FIT with the file key AND inject the file-key public key
+  into the DTB under `/signature/key-<UBOOT_SIGN_KEYNAME>`.
+- When `IOTGW_FIT_TRUST_YK_KEY = "1"`: runs `fdt_add_pubkey -a
+  ${FIT_HASH_ALG},${FIT_SIGN_ALG} -k <yk-keydir> -n <yk-keyname>
+  -r conf` to add a second key node under
+  `/signature/key-<IOTGW_FIT_YK_KEYNAME>` (no private key required), then
+  sets `/signature/required-mode = "any"` via `fdtput` so a FIT signed by
+  either root verifies.
+
+Setting both gates to `"0"` with `UBOOT_SIGN_ENABLE=1` is fatal — the
+recipe refuses to deploy unsigned-trust DTBs.
+
+### Verifying the DTB build output
+
+Inspect the deployed DTB:
+
+```bash
+DTB=build/tmp-glibc/deploy/images/raspberrypi5/bcm2712-rpi-5-b.dtb
+fdtdump "$DTB" | sed -n '/signature {/,/};/p'
+```
+
+Expected structure:
+
+```dts
+signature {
+    required-mode = "any";
+    key-iotgw-fit-dev {
+        required = "conf";
+        algo = "sha256,rsa2048";
+        rsa,num-bits = <0x800>;
+        rsa,modulus = [ ... ];
+        ...
+    };
+    key-iotgw-fit-yk-2026 {
+        required = "conf";
+        algo = "sha256,rsa2048";
+        rsa,num-bits = <0x800>;
+        rsa,modulus = [ ... ];
+        ...
+    };
+};
+```
+
+Both `key-*` subnodes present, `required-mode = "any"`. If
+`required-mode` is missing or set to `"all"` and both keys are
+`required = "conf"`, a FIT signed by only one key will be rejected at
+boot.
+
+### On-target verification
+
+After flashing Image B and booting:
+
+```bash
+# Confirm both trust roots are live in U-Boot's control FDT.
+nsenter -t 1 -m cat /sys/firmware/devicetree/base/signature/required-mode
+nsenter -t 1 -m ls /sys/firmware/devicetree/base/signature/
+```
+
+Expected: `any` on stdout, and two `key-*` directories.
+
+Test both signing paths sequentially:
+
+1. **File-key-signed FIT path** — flash the Image B build, boot, check
+   U-Boot log for FIT verification success against
+   `key-${UBOOT_SIGN_KEYNAME}`. Normal `iotgw-rauc-install` flow works
+   as it did pre-rotation.
+2. **YK-signed FIT path** — run `make sign-bootfiles-fit-yk` against the
+   same build to swap the inner FIT signature to slot 9a (see the next
+   section), reassemble the bundle, install on the device that booted
+   step 1, reboot. U-Boot must accept the FIT against
+   `key-iotgw-fit-yk-2026`.
+
+Both paths must boot cleanly on the same device before promoting Image
+B to fleet rollout, and before scoping Image C.
+
+### Cutover (Image C, separate PR)
+
+Image C drops `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. The
+recipe then injects only the YK pubkey; `required-mode = "any"` is
+still set (harmless with one key). The bundle FIT MUST be HSM-signed
+before release; a file-key-signed FIT would be rejected by every
+fielded Image C device. Image C is scoped to a separate PR after
+Image B is validated on hardware.
+
 ## Signing FIT against a PKCS#11 token (YubiKey)
 
 The default flow above signs the FIT inside bitbake against a file-based
@@ -302,15 +452,19 @@ The wrapper does three things, in order:
 
 1. **`fdtput` rewrite** — walks every
    `/configurations/conf-*/signature*/key-name-hint` and sets it to the
-   libykcs11 CKA_LABEL exposed by the slot (default
-   `"Private key for PIV Authentication"` for PIV 9a). This is the
-   string that ends up in the resulting `Sign algo:` audit line; it is
-   **not** the key-lookup mechanism.
+   project-controlled hint (default `iotgw-fit-yk-2026`, override with
+   `--key-name-hint`). This hint must match the
+   `/signature/key-<hint>` node injected into U-Boot's control FDT by
+   the kernel-fit recipe — devices reject FITs whose hint doesn't
+   resolve to a trusted key. It also drives the resulting `Sign algo:`
+   audit line. It is **not** the key-lookup mechanism for signing.
 2. **`mkimage -F -N pkcs11 -G "<uri>" <fit>`** — signs in place via
    `engine_pkcs11` against `libykcs11`. The PKCS#11 URI passed via
-   `-G` is the actual lookup mechanism. Default URI is built from
-   `--key-label` (`pkcs11:object=<url-encoded label>;type=private`);
-   override `--uri` for token-anchored URIs in multi-YubiKey setups.
+   `-G` is the actual lookup mechanism. Default URI is
+   `pkcs11:id=%01;type=private`, which selects PIV slot 9a by PKCS#11
+   ID (libykcs11 maps slot 9a to ID 01). Override `--uri` for
+   token-anchored URIs in multi-YubiKey setups, e.g.
+   `pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;id=%01;type=private`.
    PIN is prompted on the terminal; touch is required per slot 9a's
    touch policy (`CACHED` covers a multi-config signing call with one
    tap).
@@ -321,7 +475,7 @@ The wrapper does three things, in order:
    with the same key produces identical bytes), so the log line is
    the authoritative success signal. The optional `--verify` is a
    *structural* check on top: it asserts every signature node
-   carries `Sign algo: sha256,rsa2048:<KEY_LABEL>` and a non-empty
+   carries `Sign algo: sha256,rsa2048:<KEY_NAME_HINT>` and a non-empty
    `Sign value`. It does **not** cryptographically verify the
    signature against the slot's public key — for that, run
    `mkimage -V` against a DTB that embeds the expected pubkey.
@@ -340,7 +494,7 @@ On a YubiKey-signed fitImage, `dumpimage -l` shows, for every
 configuration:
 
 ```
-Sign algo:    sha256,rsa2048:Private key for PIV Authentication
+Sign algo:    sha256,rsa2048:iotgw-fit-yk-2026
 Sign value:   <256 bytes of fresh RSA-2048 signature>
 Timestamp:    <signing time, not build time>
 ```
@@ -471,7 +625,7 @@ restored from a `.bak` sibling.
 The wrapper is idempotent. Before extracting and re-signing, it peeks
 at the inner `fitImage`'s `Sign algo:` audit lines; if **every**
 signature node already advertises the HSM key-name-hint
-(`sha256,rsa2048:<KEY_LABEL>`), the wrapper exits cleanly without
+(`sha256,rsa2048:<KEY_NAME_HINT>`), the wrapper exits cleanly without
 contacting the token. A fresh build produces a file-key-signed FIT, so
 the audit line shows the file-key label and the wrapper signs. A
 partially labelled FIT (one config matches, another still shows the

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -420,26 +420,32 @@ deploy artifact is re-signed.
 
 ### Why not sign inside bitbake
 
-Two interacting mkimage bugs make in-bitbake PKCS#11 signing
-unworkable as of u-boot-tools-native 2025.04:
+mkimage 2025.04's `-N pkcs11` code path has three behaviours that
+together make in-bitbake PKCS#11 signing unworkable and constrain even
+post-build wrapper use:
 
-1. **URI synthesis from `-k` is malformed.** When `mkimage` is given
-   both `-k <keydir>` and `-N pkcs11`, it synthesises a non-RFC-7512
-   PKCS#11 URI of the form `pkcs11:<keydir>;object=<hint>;type=private`.
-   `engine_pkcs11` rejects it.
-2. **`-G` is ignored when `-k` is present.** `lib/rsa/rsa-sign.c`
-   prioritises the keydir path. Both upstream
-   `kernel-fitimage.bbclass` and this project's
-   `iotgw-fit-custom-its.bbclass` hardcode `-k`, and
-   `UBOOT_MKIMAGE_SIGN_ARGS` is appended *after* `-k`, so a
-   `kas/local.yml`-level override cannot reach the working `-G` path.
+1. **`-G` is ignored entirely.** `lib/rsa/rsa-sign.c`'s
+   `rsa_engine_get_priv_key()` never references `params.keyfile`
+   inside the pkcs11 branch. The URI mkimage actually uses is built
+   from `-k` (`keydir`) and the FIT's `key-name-hint` (`name`), never
+   from `-G`.
+2. **`-k <bare-keydir-path>` is malformed.** When `keydir` does not
+   contain `object=`, mkimage synthesises
+   `pkcs11:<keydir>;object=<hint>;type=private` — a non-RFC-7512 URI
+   that `engine_pkcs11` rejects. Both upstream `kernel-fitimage.bbclass`
+   and this project's `iotgw-fit-custom-its.bbclass` hardcode `-k`
+   with a filesystem path, hitting this case.
+3. **`-k <URI-containing-object=>` is the only working form.** mkimage
+   takes the `keydir` verbatim and appends `;type=private`, producing
+   a clean RFC-7512 URI. `scripts/sign-fit.sh` uses this form with the
+   default URI pointing to libykcs11's hardcoded slot 9a label
+   (`Private key for PIV Authentication`).
 
-There is also a silent no-op trap in the no-`-k` path:
-`mkimage -F -N pkcs11 <fit>` without `-k` **and** without `-G` exits 0,
-regenerates hashes, repacks the FDT, and leaves the original signature
-bytes untouched. The `sign-fit.sh` wrapper guards against this by
-requiring at least one `Signature written` line in mkimage's captured
-output before declaring success.
+There is also a silent no-op trap: `mkimage -F -N pkcs11 <fit>`
+without `-k` exits 0, regenerates hashes, repacks the FDT, and leaves
+the original signature bytes untouched. The `sign-fit.sh` wrapper
+guards against this by requiring at least one `Signature written` line
+in mkimage's captured output before declaring success.
 
 Upstream migration note: the meta-oe `fitimage.bbclass` merged
 post-Scarthgap provides native PKCS#11 FIT signing support and is the
@@ -458,16 +464,23 @@ The wrapper does three things, in order:
    the kernel-fit recipe — devices reject FITs whose hint doesn't
    resolve to a trusted key. It also drives the resulting `Sign algo:`
    audit line. It is **not** the key-lookup mechanism for signing.
-2. **`mkimage -F -N pkcs11 -G "<uri>" <fit>`** — signs in place via
-   `engine_pkcs11` against `libykcs11`. The PKCS#11 URI passed via
-   `-G` is the actual lookup mechanism. Default URI is
-   `pkcs11:id=%01;type=private`, which selects PIV slot 9a by PKCS#11
-   ID (libykcs11 maps slot 9a to ID 01). Override `--uri` for
-   token-anchored URIs in multi-YubiKey setups, e.g.
-   `pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;id=%01;type=private`.
-   PIN is prompted on the terminal; touch is required per slot 9a's
-   touch policy (`CACHED` covers a multi-config signing call with one
-   tap).
+2. **`mkimage -F -N pkcs11 -k "<uri>" <fit>`** — signs in place via
+   `engine_pkcs11` against `libykcs11`. **mkimage 2025.04 ignores
+   `-G` entirely in its `-N pkcs11` code path** (`lib/rsa/rsa-sign.c`
+   does not reference `params.keyfile` for the pkcs11 engine), and the
+   `-k` path only uses the URI verbatim when it already contains
+   `object=`. For any other URI form (`id=`, `token=` without
+   `object=`), mkimage rewrites it as
+   `pkcs11:<keydir>;object=<key-name-hint>;type=private` — broken
+   unless the FIT hint happens to equal a real libykcs11 object label.
+   The default URI is therefore object-anchored to libykcs11's
+   hardcoded slot 9a label:
+   `pkcs11:object=Private%20key%20for%20PIV%20Authentication`.
+   Slot-anchored URIs (`pkcs11:id=%01;type=private`) require a signer
+   that calls OpenSSL directly rather than through mkimage's
+   `-N pkcs11` path. PIN is prompted on the terminal; touch is
+   required per slot 9a's touch policy (`CACHED` covers a multi-config
+   signing call with one tap).
 3. **Success detection + structural verify** — captures mkimage's
    output; requires at least one `Signature written` log line.
    Deterministic RSA-PKCS#1 v1.5 over the FIT signed range makes

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -343,35 +343,25 @@ Inspect the deployed DTB:
 
 ```bash
 DTB=build/tmp-glibc/deploy/images/raspberrypi5/bcm2712-rpi-5-b.dtb
-fdtdump "$DTB" | sed -n '/signature {/,/};/p'
+fdtget -l "$DTB" /signature
+fdtget    "$DTB" /signature required-mode
 ```
 
-Expected structure:
+Expected output:
 
-```dts
-signature {
-    required-mode = "any";
-    key-iotgw-fit-dev {
-        required = "conf";
-        algo = "sha256,rsa2048";
-        rsa,num-bits = <0x800>;
-        rsa,modulus = [ ... ];
-        ...
-    };
-    key-iotgw-fit-yk-2026 {
-        required = "conf";
-        algo = "sha256,rsa2048";
-        rsa,num-bits = <0x800>;
-        rsa,modulus = [ ... ];
-        ...
-    };
-};
+```
+key-iotgw-fit-dev
+key-iotgw-fit-yk-2026
+any
 ```
 
 Both `key-*` subnodes present, `required-mode = "any"`. If
 `required-mode` is missing or set to `"all"` and both keys are
 `required = "conf"`, a FIT signed by only one key will be rejected at
 boot.
+
+`fdtget -l` is preferred over `fdtdump | sed` because the latter can
+silently truncate at the first `};` and hide a second key node.
 
 ### On-target verification
 

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -82,6 +82,38 @@ local_conf_header:
     # Keep this aligned with simple-ota-server CA used to sign server/device certs.
     RAUC_OTA_CA_DIR = "${IOTGW_RAUC_KEY_DIR}/ota-dev-ca"
 
+  fit_dtb_yk_pubkey_trust: |
+    # Optional: U-Boot control-FDT trust rotation for FIT signing keys.
+    #
+    # The kernel-fit recipe injects FIT public keys into the deployed
+    # DTB so U-Boot's control FDT exposes /signature/key-<NAME> nodes
+    # and enforces signed-FIT boot at runtime. Two trust roots can be
+    # injected side-by-side during a key rotation:
+    #
+    #   - File-key (default ON): legacy build-time signing key, located
+    #     at ${UBOOT_SIGN_KEYDIR}/${UBOOT_SIGN_KEYNAME}.{crt,key}. The
+    #     FIT itself is signed with this key during bitbake.
+    #   - YubiKey (off by default): public certificate exported from
+    #     PIV slot 9a, located at ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt.
+    #     No private key required on the build host. The FIT itself is
+    #     post-build resigned via scripts/sign-fit.sh against the
+    #     hardware-resident private key.
+    #
+    # Image B (transition): both gates ON. DTB carries both pubkeys
+    # and /signature/required-mode = "any" so a FIT signed by either
+    # root verifies. Required during the rotation window where some
+    # bundles are file-signed and some are HSM-signed.
+    #
+    # Image C (cutover): IOTGW_FIT_TRUST_FILE_KEY=0, only YK trusted.
+    # Operator pre-flight: export slot 9a public cert with
+    # `ykman piv certificates export 9a ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt`.
+    #
+    # Setting both gates to 0 is a build-time error.
+    # IOTGW_FIT_TRUST_FILE_KEY:fitflow = "1"
+    # IOTGW_FIT_TRUST_YK_KEY:fitflow = "1"
+    # IOTGW_FIT_YK_KEYDIR:fitflow = "${IOTGW_RAUC_KEY_DIR}/rauc-ca/fit"
+    # IOTGW_FIT_YK_KEYNAME:fitflow = "iotgw-fit-yk-2026"
+
   fit_custom_its_strategy_a: |
     # Optional: Strategy A for FIT recovery kernel.
     # Uses an independent kernel payload for kernel-2/conf-recovery.

--- a/meta-iot-gateway/recipes-bsp/u-boot/u-boot-tools_%.bbappend
+++ b/meta-iot-gateway/recipes-bsp/u-boot/u-boot-tools_%.bbappend
@@ -1,0 +1,14 @@
+# Upstream u-boot-tools builds fdt_add_pubkey as part of `make cross_tools`
+# but only installs mkimage, mkenvimage, dumpimage, and fit_check_sign.
+#
+# We need fdt_add_pubkey at ${STAGING_BINDIR_NATIVE}/fdt_add_pubkey for the
+# FIT DTB key-rotation step in linux-iotgw-mainline-fit_6.18.bb, which adds
+# a YubiKey-resident public certificate to the runtime control FDT without
+# requiring the corresponding private key on the build host.
+
+do_install:append() {
+    install -m 0755 tools/fdt_add_pubkey ${D}${bindir}/uboot-fdt_add_pubkey
+    ln -sf uboot-fdt_add_pubkey ${D}${bindir}/fdt_add_pubkey
+}
+
+FILES:${PN}-mkimage += "${bindir}/uboot-fdt_add_pubkey ${bindir}/fdt_add_pubkey"

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
@@ -29,6 +29,20 @@ IOTGW_FIT_RECOVERY_KERNEL_PATH ?= "${DEPLOY_DIR_IMAGE}/linux-recovery.bin"
 
 IOTGW_FIT_CUSTOM_ITS_KERNEL2_PATH_COMP_ALG ?= "none"
 
+# FIT DTB trust roots — see kas/local.yml.example fit_dtb_yk_pubkey_trust
+# block for the rotation pattern. Both gates default to a file-key-only
+# transition image; flip IOTGW_FIT_TRUST_YK_KEY=1 in kas/local.yml to add
+# the YubiKey public certificate as a second trust root.
+IOTGW_FIT_TRUST_FILE_KEY ?= "1"
+IOTGW_FIT_TRUST_YK_KEY   ?= "0"
+IOTGW_FIT_YK_KEYDIR      ?= ""
+IOTGW_FIT_YK_KEYNAME     ?= "iotgw-fit-yk-2026"
+
+# fdt_add_pubkey lands in the native sysroot via meta-iot-gateway's
+# u-boot-tools bbappend; mirrors the UBOOT_MKIMAGE_SIGN naming used by
+# kernel-fitimage.bbclass.
+UBOOT_FDT_ADD_PUBKEY ?= "${STAGING_BINDIR_NATIVE}/fdt_add_pubkey"
+
 python () {
     if d.getVar("IOTGW_FIT_STRATEGY_A_RECOVERY_KERNEL") != "1":
         return
@@ -43,15 +57,46 @@ python () {
 # Raspberry Pi firmware passes a runtime-prepared DTB to U-Boot. Inject FIT
 # public keys into deployed firmware DTBs so U-Boot control FDT can expose
 # /signature and enforce FIT config signatures on target.
+#
+# Two trust roots can be injected side-by-side via the IOTGW_FIT_TRUST_*
+# gates. When both are enabled, /signature/required-mode is set to "any"
+# so a FIT signed by either root verifies — the rotation window mode.
+# Setting both gates to 0 with UBOOT_SIGN_ENABLE=1 is fatal: a signed-FIT
+# enforced device with no trust roots would brick on first boot.
 do_deploy:append() {
     if [ "${UBOOT_SIGN_ENABLE}" != "1" ]; then
         bbnote "FIT DTB key injection skipped: UBOOT_SIGN_ENABLE=${UBOOT_SIGN_ENABLE}"
         return
     fi
 
-    if [ -z "${UBOOT_SIGN_KEYDIR}" ] || [ ! -d "${UBOOT_SIGN_KEYDIR}" ]; then
-        bbwarn "FIT DTB key injection skipped: missing UBOOT_SIGN_KEYDIR='${UBOOT_SIGN_KEYDIR}'"
-        return
+    trust_file="${IOTGW_FIT_TRUST_FILE_KEY}"
+    trust_yk="${IOTGW_FIT_TRUST_YK_KEY}"
+
+    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ]; then
+        bbfatal "FIT DTB trust misconfigured: IOTGW_FIT_TRUST_FILE_KEY=0 and IOTGW_FIT_TRUST_YK_KEY=0 with UBOOT_SIGN_ENABLE=1 would brick the device. Enable at least one trust root."
+    fi
+
+    if [ "${trust_file}" = "1" ]; then
+        if [ -z "${UBOOT_SIGN_KEYDIR}" ] || [ ! -d "${UBOOT_SIGN_KEYDIR}" ]; then
+            bbwarn "FIT DTB file-key injection skipped: missing UBOOT_SIGN_KEYDIR='${UBOOT_SIGN_KEYDIR}'"
+            trust_file="0"
+        fi
+    fi
+
+    if [ "${trust_yk}" = "1" ]; then
+        if [ -z "${IOTGW_FIT_YK_KEYDIR}" ] || [ ! -d "${IOTGW_FIT_YK_KEYDIR}" ]; then
+            bbfatal "FIT DTB YK-key injection requires IOTGW_FIT_YK_KEYDIR pointing to a directory holding ${IOTGW_FIT_YK_KEYNAME}.crt (got: '${IOTGW_FIT_YK_KEYDIR}')"
+        fi
+        if [ ! -f "${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt" ]; then
+            bbfatal "FIT DTB YK-key injection requires public certificate at ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt — export with: ykman piv certificates export 9a <path>"
+        fi
+        if [ ! -x "${UBOOT_FDT_ADD_PUBKEY}" ]; then
+            bbfatal "fdt_add_pubkey not found at '${UBOOT_FDT_ADD_PUBKEY}' — ensure u-boot-tools-native installs it (see meta-iot-gateway/recipes-bsp/u-boot/u-boot-tools_%.bbappend)"
+        fi
+    fi
+
+    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ]; then
+        bbfatal "FIT DTB trust resolved to zero roots after validation — refusing to deploy unsigned-trust DTBs with UBOOT_SIGN_ENABLE=1"
     fi
 
     deploy_dir="${DEPLOYDIR}"
@@ -70,6 +115,8 @@ do_deploy:append() {
         return
     fi
 
+    bbnote "FIT DTB trust roots: file=${trust_file} yk=${trust_yk} algo=${FIT_HASH_ALG},${FIT_SIGN_ALG}"
+
     for dtb in ${RPI_KERNEL_DEVICETREE}; do
         dtb_base="${dtb##*/}"
         dtb_path=""
@@ -83,12 +130,31 @@ do_deploy:append() {
             continue
         fi
 
-        bbnote "Injecting FIT public keys into ${dtb_path}"
-        ${UBOOT_MKIMAGE_SIGN} \
-            ${@'-D "${UBOOT_MKIMAGE_DTCOPTS}"' if d.getVar('UBOOT_MKIMAGE_DTCOPTS') else ''} \
-            -F -k "${UBOOT_SIGN_KEYDIR}" \
-            -K "${dtb_path}" \
-            -r "${fit_path}" \
-            ${UBOOT_MKIMAGE_SIGN_ARGS}
+        if [ "${trust_file}" = "1" ]; then
+            bbnote "Injecting file-key (${UBOOT_SIGN_KEYNAME}) into ${dtb_path}"
+            ${UBOOT_MKIMAGE_SIGN} \
+                ${@'-D "${UBOOT_MKIMAGE_DTCOPTS}"' if d.getVar('UBOOT_MKIMAGE_DTCOPTS') else ''} \
+                -F -k "${UBOOT_SIGN_KEYDIR}" \
+                -K "${dtb_path}" \
+                -r "${fit_path}" \
+                ${UBOOT_MKIMAGE_SIGN_ARGS}
+        fi
+
+        if [ "${trust_yk}" = "1" ]; then
+            bbnote "Injecting YK pubkey (${IOTGW_FIT_YK_KEYNAME}) into ${dtb_path}"
+            ${UBOOT_FDT_ADD_PUBKEY} \
+                -a "${FIT_HASH_ALG},${FIT_SIGN_ALG}" \
+                -k "${IOTGW_FIT_YK_KEYDIR}" \
+                -n "${IOTGW_FIT_YK_KEYNAME}" \
+                -r conf \
+                "${dtb_path}"
+
+            # required-mode = "any" lets a FIT signed by either trust
+            # root verify. Without this, multiple required = "conf"
+            # keys make U-Boot require ALL of them, rejecting any FIT
+            # signed by only one root — the bricking case.
+            bbnote "Setting /signature/required-mode=any on ${dtb_path}"
+            fdtput -t s "${dtb_path}" /signature required-mode any
+        fi
     done
 }

--- a/scripts/sign-bootfiles-fit.sh
+++ b/scripts/sign-bootfiles-fit.sh
@@ -68,7 +68,7 @@ Usage: sign-bootfiles-fit.sh [--archive PATH] [-- <sign-fit.sh args>...]
   -h, --help       Show this help and exit.
 
 All arguments after '--' are forwarded to sign-fit.sh. Useful
-forwards: --uri, --key-label, --engine-conf, --verify.
+forwards: --key-name-hint, --uri, --engine-conf, --verify.
 
 Example:
   sign-bootfiles-fit.sh -- --verify
@@ -117,18 +117,23 @@ log "pre  sha256: ${PRE_SHA}"
 # favours an in-artifact signal over a sidecar trust file that does
 # not travel across machines. Use --force to override.
 #
-# Effective KEY_LABEL is what sign-fit.sh will use: parse from
-# PASSTHROUGH for an explicit --key-label, otherwise fall back to
-# sign-fit.sh's documented default.
-DEFAULT_HSM_LABEL="Private key for PIV Authentication"
-EFFECTIVE_LABEL="${DEFAULT_HSM_LABEL}"
+# Effective FIT key-name-hint is what sign-fit.sh will write: parse
+# PASSTHROUGH for an explicit --key-name-hint, fall back to the
+# deprecated --key-label alias if present, otherwise use sign-fit.sh's
+# documented default (kept in sync with DEFAULT_KEY_NAME_HINT there).
+DEFAULT_KEY_NAME_HINT="iotgw-fit-yk-2026"
+EFFECTIVE_HINT="${DEFAULT_KEY_NAME_HINT}"
 for ((i=0; i<${#PASSTHROUGH[@]}; i++)); do
-    if [[ "${PASSTHROUGH[i]}" == "--key-label" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
-        EFFECTIVE_LABEL="${PASSTHROUGH[i+1]}"
+    if [[ "${PASSTHROUGH[i]}" == "--key-name-hint" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
+        EFFECTIVE_HINT="${PASSTHROUGH[i+1]}"
         break
     fi
+    if [[ "${PASSTHROUGH[i]}" == "--key-label" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
+        EFFECTIVE_HINT="${PASSTHROUGH[i+1]}"
+        # don't break — a later --key-name-hint should still win
+    fi
 done
-EXPECTED_ALGO="sha256,rsa2048:${EFFECTIVE_LABEL}"
+EXPECTED_ALGO="sha256,rsa2048:${EFFECTIVE_HINT}"
 
 if [[ "${FORCE}" -eq 0 ]]; then
     peek_dir="$(mktemp -d -t sign-bootfiles-peek.XXXXXX)"

--- a/scripts/sign-fit.sh
+++ b/scripts/sign-fit.sh
@@ -15,9 +15,15 @@
 # absent in the silent no-op case.
 #
 # The FIT's `key-name-hint` is metadata only — it determines the
-# audit string in `Sign algo: <alg>:<hint>`; the actual key lookup is
-# driven by the PKCS#11 URI passed via `-G`. fdtput rewrites the hint
-# before signing so the audit line reflects the HSM-resident key.
+# audit string in `Sign algo: <alg>:<hint>` and must match the
+# `/signature/key-<hint>` node in U-Boot's control FDT for the
+# device to actually verify the signature. The actual key lookup
+# during signing is driven by the PKCS#11 URI passed via `-G`,
+# which is decoupled from the hint (libykcs11 exposes slot 9a's
+# private object under a fixed label "Private key for PIV
+# Authentication", independent of the project-controlled FIT hint).
+# fdtput rewrites the hint before signing so the audit line and the
+# DTB key-node lookup line up.
 #
 # WARNING: mutates --fit in place. Run against a copy of the deploy
 # artifact, not the deploy artifact directly. The script writes a
@@ -28,13 +34,21 @@
 
 set -euo pipefail
 
-DEFAULT_KEY_LABEL="Private key for PIV Authentication"
+# Project-controlled FIT key-name-hint. Must match the /signature/key-<hint>
+# node injected into U-Boot's control FDT by the kernel-fit recipe.
+DEFAULT_KEY_NAME_HINT="iotgw-fit-yk-2026"
+
+# PIV slot 9a → PKCS#11 ID 01 via libykcs11. Slot-anchored URI is stable
+# across libykcs11 versions; the human-readable label is not.
+DEFAULT_URI="pkcs11:id=%01;type=private"
+
 DEFAULT_ENGINE_CONF="${HOME}/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
 
 FIT=""
 ENGINE_CONF="${DEFAULT_ENGINE_CONF}"
-KEY_LABEL="${DEFAULT_KEY_LABEL}"
+KEY_NAME_HINT=""
 URI=""
+KEY_LABEL_LEGACY=""
 VERIFY=0
 REWRITE_ONLY=0
 VERBOSE=0
@@ -83,23 +97,29 @@ Usage: sign-fit.sh --fit PATH [OPTIONS]
   --engine-conf PATH   OpenSSL engine config that loads engine_pkcs11
                        against the PKCS#11 module.
                        Default: ${DEFAULT_ENGINE_CONF}
-  --key-label NAME     FIT key-name-hint to write before re-signing.
-                       Metadata only — drives the resulting
-                       'Sign algo:' audit line, not the key lookup.
-                       Should match the CKA_LABEL exposed by the
-                       PKCS#11 token when --uri is omitted (the
-                       default URI is built from this label).
-                       Default: "${DEFAULT_KEY_LABEL}"
+  --key-name-hint NAME FIT key-name-hint to write before re-signing.
+                       Drives the 'Sign algo:' audit line AND must
+                       match the /signature/key-<NAME> node in
+                       U-Boot's control FDT — devices reject FITs
+                       whose hint doesn't resolve to a trusted key.
+                       Default: "${DEFAULT_KEY_NAME_HINT}"
   --uri URI            PKCS#11 URI passed to mkimage via -G. Without
                        this (or -k), mkimage -F silently skips
-                       signing. Default is built from --key-label as
-                       pkcs11:object=<url-encoded label>;type=private.
+                       signing. Default selects PIV slot 9a via
+                       libykcs11 by ID, which is stable across
+                       libykcs11 versions and YubiKey firmware.
                        Override for token-anchored URIs, e.g.
                        'pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;id=%01;type=private'.
+                       Default: "${DEFAULT_URI}"
+  --key-label NAME     DEPRECATED alias. Equivalent to
+                       '--key-name-hint NAME --uri pkcs11:object=
+                       <urlencoded NAME>;type=private'. Kept for
+                       back-compat with existing tooling that paired
+                       the libykcs11 object label with FIT metadata.
   --verify             Structural check after signing (NOT a crypto
                        verification). Asserts every signature node
-                       has algo 'sha256,rsa2048:<KEY_LABEL>' and a
-                       non-empty Sign value (rejects "unavailable").
+                       has algo 'sha256,rsa2048:<KEY_NAME_HINT>' and
+                       a non-empty Sign value (rejects "unavailable").
                        For cryptographic verification, run
                        'mkimage -V' against a DTB carrying the
                        expected public key.
@@ -118,10 +138,11 @@ EOF
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
-        --fit)          [[ $# -ge 2 ]] || die "--fit needs a value"; FIT="$2"; shift 2 ;;
-        --engine-conf)  [[ $# -ge 2 ]] || die "--engine-conf needs a value"; ENGINE_CONF="$2"; shift 2 ;;
-        --key-label)    [[ $# -ge 2 ]] || die "--key-label needs a value"; KEY_LABEL="$2"; shift 2 ;;
-        --uri)          [[ $# -ge 2 ]] || die "--uri needs a value"; URI="$2"; shift 2 ;;
+        --fit)            [[ $# -ge 2 ]] || die "--fit needs a value"; FIT="$2"; shift 2 ;;
+        --engine-conf)    [[ $# -ge 2 ]] || die "--engine-conf needs a value"; ENGINE_CONF="$2"; shift 2 ;;
+        --key-name-hint)  [[ $# -ge 2 ]] || die "--key-name-hint needs a value"; KEY_NAME_HINT="$2"; shift 2 ;;
+        --uri)            [[ $# -ge 2 ]] || die "--uri needs a value"; URI="$2"; shift 2 ;;
+        --key-label)      [[ $# -ge 2 ]] || die "--key-label needs a value"; KEY_LABEL_LEGACY="$2"; shift 2 ;;
         --verify)       VERIFY=1; shift ;;
         --rewrite-only) REWRITE_ONLY=1; shift ;;
         --verbose)      VERBOSE=1; shift ;;
@@ -133,7 +154,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 [[ -n "${FIT}" ]]         || { usage >&2; die "--fit is required"; }
-[[ -n "${KEY_LABEL}" ]]   || die "--key-label must not be empty"
 [[ -n "${ENGINE_CONF}" ]] || die "--engine-conf must not be empty"
 [[ -f "${FIT}" ]]         || die "fitImage not found: ${FIT}"
 [[ -w "${FIT}" ]]         || die "fitImage not writable: ${FIT}"
@@ -141,10 +161,20 @@ FIT_DIR="$(dirname -- "${FIT}")"
 [[ -w "${FIT_DIR}" ]]     || die "cannot write backup next to ${FIT} (directory not writable: ${FIT_DIR})"
 [[ -f "${ENGINE_CONF}" ]] || die "engine conf not found: ${ENGINE_CONF}"
 
-if [[ -z "${URI}" ]]; then
-    URI="pkcs11:object=$(url_encode "${KEY_LABEL}");type=private"
+if [[ -n "${KEY_LABEL_LEGACY}" ]]; then
+    warn "--key-label is deprecated; pass --key-name-hint and --uri explicitly"
+    [[ -z "${KEY_NAME_HINT}" ]] || die "--key-label and --key-name-hint are mutually exclusive"
+    KEY_NAME_HINT="${KEY_LABEL_LEGACY}"
+    if [[ -z "${URI}" ]]; then
+        URI="pkcs11:object=$(url_encode "${KEY_LABEL_LEGACY}");type=private"
+    fi
 fi
-[[ "${URI}" == pkcs11:* ]] || die "URI must start with 'pkcs11:': ${URI}"
+
+KEY_NAME_HINT="${KEY_NAME_HINT:-${DEFAULT_KEY_NAME_HINT}}"
+URI="${URI:-${DEFAULT_URI}}"
+
+[[ -n "${KEY_NAME_HINT}" ]] || die "--key-name-hint must not be empty"
+[[ "${URI}" == pkcs11:* ]]  || die "URI must start with 'pkcs11:': ${URI}"
 
 for tool in fdtget fdtput mkimage; do
     command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
@@ -201,7 +231,7 @@ for conf in "${CONFS[@]}"; do
             signature*)
                 MUTATED=1
                 fdtput -t s "${FIT}" "/configurations/${conf}/${child}" \
-                    key-name-hint "${KEY_LABEL}" \
+                    key-name-hint "${KEY_NAME_HINT}" \
                     || die "fdtput failed on /configurations/${conf}/${child}"
                 sig_found=$((sig_found+1))
                 TOTAL_SIGS=$((TOTAL_SIGS+1))
@@ -210,7 +240,7 @@ for conf in "${CONFS[@]}"; do
     done
     [[ "${sig_found}" -gt 0 ]] || die "no signature* nodes under /configurations/${conf}"
 done
-log "rewrote key-name-hint to '${KEY_LABEL}' on ${TOTAL_SIGS} signature node(s) across ${#CONFS[@]} configuration(s)"
+log "rewrote key-name-hint to '${KEY_NAME_HINT}' on ${TOTAL_SIGS} signature node(s) across ${#CONFS[@]} configuration(s)"
 
 if [[ "${REWRITE_ONLY}" -eq 1 ]]; then
     log "rewrite-only: FIT key-name-hint rewritten in place; skipping mkimage"
@@ -269,7 +299,7 @@ if [[ "${VERIFY}" -eq 1 ]]; then
     if ! dump_out="$(dumpimage -l "${FIT}" 2>&1)"; then
         die "dumpimage failed during --verify: ${dump_out}"
     fi
-    expected_algo="sha256,rsa2048:${KEY_LABEL}"
+    expected_algo="sha256,rsa2048:${KEY_NAME_HINT}"
 
     algo_count=$(printf '%s\n' "${dump_out}" | grep -c -F 'Sign algo:' || true)
     match_count=$(printf '%s\n' "${dump_out}" | grep -c -F "${expected_algo}" || true)
@@ -306,7 +336,7 @@ fi
 echo
 echo "================ sign-fit summary ================"
 printf "  FIT image       : %s\n" "${FIT}"
-printf "  Key label       : %s\n" "${KEY_LABEL}"
+printf "  Key name hint   : %s\n" "${KEY_NAME_HINT}"
 printf "  PKCS#11 URI     : %s\n" "${URI}"
 printf "  Engine conf     : %s\n" "${ENGINE_CONF}"
 printf "  Configurations  : %d\n" "${#CONFS[@]}"

--- a/scripts/sign-fit.sh
+++ b/scripts/sign-fit.sh
@@ -38,9 +38,17 @@ set -euo pipefail
 # node injected into U-Boot's control FDT by the kernel-fit recipe.
 DEFAULT_KEY_NAME_HINT="iotgw-fit-yk-2026"
 
-# PIV slot 9a → PKCS#11 ID 01 via libykcs11. Slot-anchored URI is stable
-# across libykcs11 versions; the human-readable label is not.
-DEFAULT_URI="pkcs11:id=%01;type=private"
+# PKCS#11 URI passed to mkimage as -k (NOT -G). U-Boot 2025.04's mkimage
+# ignores -G in its `-N pkcs11` code path (lib/rsa/rsa-sign.c does not
+# reference params.keyfile for the pkcs11 engine) and synthesizes the
+# URI from the FIT's key-name-hint unless -k is supplied with a URI
+# that already contains `object=`. libykcs11 hardcodes slot 9a's
+# private-object label to "Private key for PIV Authentication", so the
+# only URI form mkimage will accept verbatim for that slot is
+# object-anchored to this label. Other URI forms (id=, token= without
+# object=) require a signer that calls OpenSSL directly rather than
+# going through mkimage's -N pkcs11 path.
+DEFAULT_URI="pkcs11:object=Private%20key%20for%20PIV%20Authentication"
 
 DEFAULT_ENGINE_CONF="${HOME}/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
 
@@ -103,19 +111,24 @@ Usage: sign-fit.sh --fit PATH [OPTIONS]
                        U-Boot's control FDT — devices reject FITs
                        whose hint doesn't resolve to a trusted key.
                        Default: "${DEFAULT_KEY_NAME_HINT}"
-  --uri URI            PKCS#11 URI passed to mkimage via -G. Without
-                       this (or -k), mkimage -F silently skips
-                       signing. Default selects PIV slot 9a via
-                       libykcs11 by ID, which is stable across
-                       libykcs11 versions and YubiKey firmware.
-                       Override for token-anchored URIs, e.g.
-                       'pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;id=%01;type=private'.
+  --uri URI            PKCS#11 URI passed to mkimage via -k (NOT -G;
+                       see comment near DEFAULT_URI). The URI MUST
+                       contain 'object=<libykcs11-label>' because
+                       mkimage 2025.04 only uses -k verbatim when the
+                       legacy URI form is detected via that substring;
+                       any other form (e.g. id=) is rewritten with an
+                       appended object=<key-name-hint> which will not
+                       match a real libykcs11 object. The default
+                       targets slot 9a via libykcs11's hardcoded
+                       private-object label. Token-anchored override
+                       example:
+                       'pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;object=Private%20key%20for%20PIV%20Authentication'.
                        Default: "${DEFAULT_URI}"
   --key-label NAME     DEPRECATED alias. Equivalent to
                        '--key-name-hint NAME --uri pkcs11:object=
-                       <urlencoded NAME>;type=private'. Kept for
-                       back-compat with existing tooling that paired
-                       the libykcs11 object label with FIT metadata.
+                       <urlencoded NAME>'. Kept for back-compat with
+                       existing tooling that paired the libykcs11
+                       object label with FIT metadata.
   --verify             Structural check after signing (NOT a crypto
                        verification). Asserts every signature node
                        has algo 'sha256,rsa2048:<KEY_NAME_HINT>' and
@@ -166,7 +179,7 @@ if [[ -n "${KEY_LABEL_LEGACY}" ]]; then
     [[ -z "${KEY_NAME_HINT}" ]] || die "--key-label and --key-name-hint are mutually exclusive"
     KEY_NAME_HINT="${KEY_LABEL_LEGACY}"
     if [[ -z "${URI}" ]]; then
-        URI="pkcs11:object=$(url_encode "${KEY_LABEL_LEGACY}");type=private"
+        URI="pkcs11:object=$(url_encode "${KEY_LABEL_LEGACY}")"
     fi
 fi
 
@@ -175,6 +188,12 @@ URI="${URI:-${DEFAULT_URI}}"
 
 [[ -n "${KEY_NAME_HINT}" ]] || die "--key-name-hint must not be empty"
 [[ "${URI}" == pkcs11:* ]]  || die "URI must start with 'pkcs11:': ${URI}"
+# mkimage 2025.04's -k path keeps the URI verbatim only when it contains
+# 'object='. Without that substring, mkimage appends ';object=<hint>'
+# which then will not match a real libykcs11 object — silent sign
+# failure. Refuse early instead.
+[[ "${URI}" == *"object="* ]] \
+    || die "URI must contain 'object=<libykcs11-label>': mkimage 2025.04's -N pkcs11 path rewrites URIs without object= and will not find slot 9a — got: ${URI}"
 
 for tool in fdtget fdtput mkimage; do
     command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
@@ -260,16 +279,19 @@ else
     # over the FIT signed range is deterministic — re-signing the
     # same FIT with the same key produces byte-identical signatures
     # and would false-positive a pre/post bytes-changed guard.
+    # U-Boot 2025.04 ignores -G/keyfile in the pkcs11 RSA path.
+    # Passing -k pkcs11:object=<label> is the only way to decouple
+    # private-key lookup from the FIT key-name-hint.
     mk_log="$(mktemp)"
     trap 'rm -f "${mk_log}"; cleanup' EXIT
     set +e
     if [[ "${VERBOSE}" -eq 1 ]]; then
         OPENSSL_CONF="${ENGINE_CONF}" \
-            mkimage -F -N pkcs11 -G "${URI}" "${FIT}" 2>&1 | tee "${mk_log}"
+            mkimage -F -N pkcs11 -k "${URI}" "${FIT}" 2>&1 | tee "${mk_log}"
         mk_rc=${PIPESTATUS[0]}
     else
         OPENSSL_CONF="${ENGINE_CONF}" \
-            mkimage -F -N pkcs11 -G "${URI}" "${FIT}" >"${mk_log}" 2>&1
+            mkimage -F -N pkcs11 -k "${URI}" "${FIT}" >"${mk_log}" 2>&1
         mk_rc=$?
     fi
     set -e

--- a/scripts/sign-fit.sh
+++ b/scripts/sign-fit.sh
@@ -6,24 +6,27 @@
 # FIT with a file-based key; this wrapper overwrites that signature in
 # place against an HSM-resident key.
 #
-# mkimage gotcha: `mkimage -F -N pkcs11 <fit>` without `-G` is a
-# silent no-op for the signing step. It repacks the FDT, regenerates
-# hashes, exits 0, and leaves the original signature bytes untouched.
-# This script always passes `-G <uri>` and additionally guards
-# against the trap by capturing mkimage's stdout/stderr and
-# requiring at least one "Signature written" log line — that line is
-# absent in the silent no-op case.
+# mkimage gotcha: `mkimage -F -N pkcs11 <fit>` without a `-k <URI>`
+# carrying `object=<label>` is a silent no-op for the signing step.
+# It repacks the FDT, regenerates hashes, exits 0, and leaves the
+# original signature bytes untouched. This script always passes
+# `-k pkcs11:object=<label>` and additionally guards against the
+# trap by capturing mkimage's stdout/stderr and requiring at least
+# one "Signature written" log line — that line is absent in the
+# silent no-op case.
 #
-# The FIT's `key-name-hint` is metadata only — it determines the
-# audit string in `Sign algo: <alg>:<hint>` and must match the
+# The FIT's `key-name-hint` is metadata for the audit string in
+# `Sign algo: <alg>:<hint>` and must match the
 # `/signature/key-<hint>` node in U-Boot's control FDT for the
-# device to actually verify the signature. The actual key lookup
-# during signing is driven by the PKCS#11 URI passed via `-G`,
-# which is decoupled from the hint (libykcs11 exposes slot 9a's
-# private object under a fixed label "Private key for PIV
-# Authentication", independent of the project-controlled FIT hint).
-# fdtput rewrites the hint before signing so the audit line and the
-# DTB key-node lookup line up.
+# device to verify the signature. The PKCS#11 lookup for signing
+# is driven by the `-k <URI>` value: mkimage 2025.04's pkcs11
+# code path uses the URI verbatim when it contains `object=`, so
+# the URI's object label is the actual key selector. libykcs11
+# exposes slot 9a's private object under a fixed label
+# "Private key for PIV Authentication", so that label appears in
+# the URI even though the FIT hint and DTB node name stay
+# project-controlled. fdtput rewrites the hint before signing so
+# the audit line and the DTB key-node lookup line up.
 #
 # WARNING: mutates --fit in place. Run against a copy of the deploy
 # artifact, not the deploy artifact directly. The script writes a
@@ -309,7 +312,7 @@ else
         cat "${mk_log}" >&2
         echo "------------------------" >&2
         rm -f "${mk_log}"
-        die "mkimage exited 0 but emitted no 'Signature written' line — signing was a silent no-op (check engine config and that -G reached mkimage)"
+        die "mkimage exited 0 but emitted no 'Signature written' line — signing was a silent no-op (check engine config and that -k carries a 'pkcs11:object=<label>' URI)"
     fi
     rm -f "${mk_log}"
     trap cleanup EXIT


### PR DESCRIPTION
## Summary

Adds a second trust root to the U-Boot control FDT so devices can verify FIT images signed by either a file-based RSA key (legacy build-time signing) or a YubiKey-resident RSA-2048 private key in PIV slot 9a (post-build HSM signing). `/signature/required-mode = "any"` lets a FIT signed by either root verify, which is the bridge step before retiring the file key in a follow-up PR.

Also includes a workaround for a mkimage 2025.04 `-N pkcs11` bug surfaced during validation: `-G/keyfile` is silently ignored, so the only URI form that reaches `libykcs11` is `-k pkcs11:object=<libykcs11-label>` taken verbatim. Documented in `docs/FIT_BOOT_SIGNING.md` alongside the existing PKCS#11 quirks.

## Hardware validation

Both signing paths verified end-to-end on a single RPi5 against the same dual-trust DTB.

File-key-signed FIT — U-Boot iterates the DTB's `/signature/key-*` nodes; first attempt against the YubiKey pubkey fails (FIT was file-key signed), second attempt against the file-key node succeeds. This is the expected `required-mode = "any"` behaviour:

```
   Verifying Hash Integrity ... sha256,rsa2048:iotgw-fit-dev-  error!
Verification failed for '<NULL>' hash node in 'conf-primary' config node
sha256,rsa2048:iotgw-fit-dev+ OK
```

YubiKey-signed FIT (post-build resigned via `make sign-bootfiles-fit-yk`) — first-attempt success because the YK key is first in DTB tree order and the FIT's `key-name-hint` matches:

```
   Verifying Hash Integrity ... sha256,rsa2048:iotgw-fit-yk-2026+ OK
   Verifying Hash Integrity ... sha256+ OK
   Booting using the fdt blob at 0x2eff9300
```

A/B slot rotation healthy across both installs; no rollback triggered.

## Out of scope

- Retiring the file key (separate follow-up PR after fleet rollout).
- Slot-anchored PKCS#11 URIs (`pkcs11:id=%01;type=private`) — would require a signer that calls OpenSSL directly rather than going through mkimage's `-N pkcs11` path.
- Adjusting `iotgw-uboot-prod-key-guard` for YK-named keys — revisited when `UBOOT_SIGN_KEYNAME` itself changes.

## Test plan

- [x] Built DTB carries both `/signature/key-*` subnodes + `required-mode = "any"` (verified via `dtc -I dtb -O dts`)
- [x] File-key-signed bundle installs via RAUC and boots cleanly
- [x] `make sign-bootfiles-fit-yk` + `make bundle-dev-full-fit-resign` produce a YK-signed bundle; structural verify passes on both configurations
- [x] YK-signed bundle installs via RAUC and boots with U-Boot verifying against the YubiKey pubkey on first attempt
- [x] On-target running FDT exposes both trust roots (`/sys/firmware/devicetree/base/signature/`)