### PR TITLE
feat(fit): add profile-based signing tool with softhsm dev flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,9 +6,13 @@ build/
 DL_SHARED/
 SSTATE/
 
-# Python virtual environment
+# Python virtual environment + bytecode caches
 .venv/
 venv/
+__pycache__/
+*.pyc
+.pytest_cache/
+.hypothesis/
 
 # Editor files
 .vscode/

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 .PHONY: help base dev prod desktop \
-        bundle-dev bundle-dev-full bundle-dev-full-fit sign-bootfiles-fit-yk bundle-dev-full-fit-resign bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        bundle-dev bundle-dev-full bundle-dev-full-fit sign-bootfiles-fit-yk sign-bootfiles-fit-softhsm bundle-dev-full-fit-resign bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        tools-venv test-sign-fit test-sign-fit-softhsm \
         layers parse clean-lock
 
 KAS ?= kas
@@ -28,6 +29,11 @@ help:
 	@echo "  make bundle-dev-full-fit  # FIT bundle from dev image"
 	@echo "  -- HSM-signing flow (detached; CI-friendly) --"
 	@echo "  make sign-bootfiles-fit-yk    # Re-sign FIT in deploy tarball on YubiKey (interactive)"
+	@echo "  make sign-bootfiles-fit-softhsm # Re-sign FIT in deploy tarball via SoftHSM (dev only)"
+	@echo "  -- Host-side test environment (uv-based, reproducible) --"
+	@echo "  make tools-venv              # Sync .venv via uv (run once or after dep bumps)"
+	@echo "  make test-sign-fit           # Run signing-tool tests (no SoftHSM required)"
+	@echo "  make test-sign-fit-softhsm   # Run full suite incl. SoftHSM integration tests"
 	@echo "  make bundle-dev-full-fit-resign  # Re-assemble bundle with HSM-signed FIT (unattended)"
 	@echo "  make bundle-base-full-fit-fast # FIT bundle from base image (OTBR off, faster)"
 	@echo "  make bundle-prod-full     # Bundle from prod image"
@@ -122,15 +128,37 @@ bundle-dev-full-fit:
 #   - Operator:  fetch artifacts → make sign-bootfiles-fit-yk → publish signed tarball
 #   - CI/Op:     make bundle-dev-full-fit-resign      → publish final signed .raucb
 #
-# SIGN_BOOTFILES_ARGS  → passed to sign-bootfiles-fit.sh (e.g. --force,
-#                       --archive PATH). Goes BEFORE '--'.
-# SIGN_FIT_ARGS        → forwarded to sign-fit.sh (e.g. --verify,
-#                       --verbose, --key-label NAME, --uri URI). Goes
-#                       AFTER '--'. Defaults to '--verify'.
+# SIGN_BOOTFILES_ARGS  → bootfiles-archive specific flags
+#                       (e.g. --force, --archive PATH).
+# SIGN_FIT_ARGS        → signing flags (e.g. --verify, --verbose,
+#                       --key-name-hint NAME, --uri URI). Defaults to '--verify'.
+#                       Both are passed to `sign_fit.py sign-bootfiles`
+#                       which now accepts them inline (no '--' separator).
 SIGN_BOOTFILES_ARGS ?=
 SIGN_FIT_ARGS ?= --verify
 sign-bootfiles-fit-yk:
-	bash scripts/sign-bootfiles-fit.sh $(SIGN_BOOTFILES_ARGS) -- $(SIGN_FIT_ARGS)
+	python3 scripts/sign_fit.py sign-bootfiles --profile yubikey-9a $(SIGN_BOOTFILES_ARGS) $(SIGN_FIT_ARGS)
+
+# Dev signing variant for engineers without a YubiKey. Requires a
+# provisioned SoftHSM token holding the iotgw-fit-softhsm-dev keypair;
+# see docs/FIT_BOOT_SIGNING.md for the provisioning runbook. Only
+# usable against an image that enables IOTGW_FIT_TRUST_SOFTHSM_KEY in
+# kas/local.yml — never against a production Image C build.
+sign-bootfiles-fit-softhsm:
+	python3 scripts/sign_fit.py sign-bootfiles --profile softhsm-dev $(SIGN_BOOTFILES_ARGS) $(SIGN_FIT_ARGS)
+
+# Host-side Python test environment (uv-based). Not used by Yocto
+# builds or by the operator signing targets above; those keep running
+# against the system Python with a distro-installed `python3-yaml`.
+UV ?= uv
+tools-venv:
+	$(UV) sync
+
+test-sign-fit:
+	$(UV) run pytest scripts/tests/
+
+test-sign-fit-softhsm:
+	SOFTHSM_AVAILABLE=1 $(UV) run pytest scripts/tests/
 
 bundle-dev-full-fit-resign:
 	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -259,6 +259,184 @@ Expected failure symptoms in U-Boot log:
 - Do not commit keys into repository.
 - Keep RAUC signing keys and FIT signing keys separate.
 
+## Signing tooling
+
+FIT signing is driven by `scripts/sign_fit.py`. The Python tool replaces
+the earlier bash wrappers (`sign-fit.sh`, `sign-bootfiles-fit.sh`),
+which now remain as compatibility shims so existing operator runbooks
+and Make targets keep working unchanged.
+
+### Subcommands
+
+```
+sign_fit.py sign-fit          --profile NAME --fit PATH       [--verify] [--rewrite-only]
+sign_fit.py sign-bootfiles    --profile NAME --archive PATH   [--force]  [--verify]
+sign_fit.py verify            --fit PATH --dtb PATH           [--fit-check-sign-path PATH]
+sign_fit.py print-profile     --profile NAME                  [--profile-config PATH]
+```
+
+`sign-fit` and `sign-bootfiles` invoke
+`mkimage -F -N pkcs11 -k <profile.uri>` under the hood; `verify` calls
+`fit_check_sign` against a supplied DTB for a real RSA signature check
+(distinct from the structural `--verify` flag, which only inspects
+audit metadata).
+
+### Signing profiles
+
+Each profile bundles the FIT key-name-hint, the PKCS#11 lookup URI, and
+the OpenSSL engine_pkcs11 config. Defaults ship in
+`scripts/fit-signing-profiles.yml` (YAML is used here for consistency
+with the kas overlay files):
+
+```yaml
+fit_signing_profiles:
+  yubikey-9a:
+    key_name_hint: "iotgw-fit-yk-2026"
+    uri: "pkcs11:object=Private%20key%20for%20PIV%20Authentication"
+    engine_conf: "~/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
+
+  softhsm-dev:
+    key_name_hint: "iotgw-fit-softhsm-dev"
+    uri: "pkcs11:object=iotgw-fit-softhsm-dev"
+    engine_conf: "~/rauc-keys/softhsm/fit/openssl-engine.cnf"
+```
+
+Override the config file path with `--profile-config <path>` or the
+`IOTGW_FIT_SIGNING_PROFILES` environment variable. Individual fields
+can be overridden with `--key-name-hint`, `--uri`, `--engine-conf`.
+`--print-profile` resolves a profile (with overrides applied) and
+prints it without signing — useful for diagnostics.
+
+PyYAML is the only Python runtime dependency. Install via the distro
+package (`apt install python3-yaml` on Debian/Ubuntu,
+`dnf install python3-pyyaml` on Fedora) or `pip install pyyaml`.
+
+### Reproducible test environment (optional)
+
+For running the test suite under `scripts/tests/` we ship a
+[uv](https://docs.astral.sh/uv/)-managed Python environment so PyYAML
+and pytest versions are pinned via `uv.lock`. This does NOT replace
+the operator-facing CLI — `scripts/sign_fit.py` keeps working against
+the system Python and a distro-installed `python3-yaml`. Yocto/BitBake
+builds do not depend on uv.
+
+```bash
+# One-time setup (Ubuntu 24.04 — uv ships via apt; see uv docs for
+# other distros or the official install method).
+sudo apt install uv
+
+# Sync the venv (.venv at the repo root, gitignored). Run after a
+# fresh clone or after bumping pyproject.toml / uv.lock.
+make tools-venv
+
+# Run the test suite. SoftHSM tests skip cleanly when no SoftHSM
+# token is on the host.
+make test-sign-fit
+
+# Run the full suite including SoftHSM integration tests. Requires
+# `softhsm2` + `libengine-pkcs11-openssl` on the host.
+make test-sign-fit-softhsm
+```
+
+### Make targets
+
+| Target | Profile | When to use |
+|--------|---------|-------------|
+| `make sign-bootfiles-fit-yk` | `yubikey-9a` | Production release flow. Requires a YubiKey with slot 9a provisioned. Prompts for PIN, requires touch. |
+| `make sign-bootfiles-fit-softhsm` | `softhsm-dev` | Dev flow for engineers without a YubiKey. Requires the SoftHSM dev key provisioned (see below). |
+
+Both targets accept `SIGN_BOOTFILES_ARGS` and `SIGN_FIT_ARGS` env vars
+for ad-hoc flags. Example:
+
+```bash
+make sign-bootfiles-fit-yk SIGN_FIT_ARGS=--verify
+make sign-bootfiles-fit-softhsm SIGN_BOOTFILES_ARGS=--force
+```
+
+### SoftHSM dev provisioning (one-time, dev-only)
+
+SoftHSM is a software PKCS#11 token — keys live on disk, not in
+hardware. It enables YubiKey-free dev signing for engineers without
+hardware tokens. **Never use SoftHSM-signed artifacts on production
+images**; the corresponding DTB trust gate
+(`IOTGW_FIT_TRUST_SOFTHSM_KEY`) is dev-only.
+
+The distro `softhsm2` package (Debian/Ubuntu/Fedora 2.6.x) is
+sufficient. Engineers building SoftHSM 2.7.0 locally point the
+operator tooling at it by editing the `MODULE_PATH` line in the
+profile's engine config file (`~/rauc-keys/softhsm/fit/openssl-engine.cnf`
+in the default profile). `sign_fit.py` consumes the path indirectly
+via OpenSSL's engine_pkcs11 — there is no Python-side env var that
+overrides it.
+
+(`IOTGW_SOFTHSM_MODULE` is consulted only by the pytest suite in
+`scripts/tests/conftest.py` for SoftHSM module discovery when
+running tests against a non-distro build. It does not affect the
+operator-facing `sign_fit.py`.)
+
+Initial provisioning:
+
+```bash
+# 1. Isolated token store under the operator vault.
+SOFTHSM_BASE="$HOME/rauc-keys/softhsm"
+install -d -m 700 "$SOFTHSM_BASE/tokens" "$SOFTHSM_BASE/fit"
+cat > "$SOFTHSM_BASE/softhsm2.conf" <<EOF
+directories.tokendir = $SOFTHSM_BASE/tokens
+objectstore.backend = file
+EOF
+export SOFTHSM2_CONF="$SOFTHSM_BASE/softhsm2.conf"
+
+# Locate the distro module (Debian/Ubuntu path; adjust for other distros).
+SOFTHSM_MOD=/usr/lib/softhsm/libsofthsm2.so
+
+# 2. Init a token.
+softhsm2-util --module "$SOFTHSM_MOD" --init-token --free \
+    --label iotgw-fit-dev --pin 1234 --so-pin 123456
+
+# 3. Generate the dev signing keypair on the token.
+pkcs11-tool --module "$SOFTHSM_MOD" --token-label iotgw-fit-dev \
+    --login --pin 1234 \
+    --keypairgen --key-type rsa:2048 \
+    --label iotgw-fit-softhsm-dev --id 01
+
+# 4. OpenSSL engine_pkcs11 config.
+cat > "$SOFTHSM_BASE/fit/openssl-engine.cnf" <<EOF
+openssl_conf = openssl_init
+
+[openssl_init]
+engines = engine_section
+
+[engine_section]
+pkcs11 = pkcs11_section
+
+[pkcs11_section]
+engine_id = pkcs11
+dynamic_path = /usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so
+MODULE_PATH = $SOFTHSM_MOD
+init = 0
+EOF
+
+# 5. Self-sign a cert against the on-token key (no private key on disk).
+OPENSSL_CONF="$SOFTHSM_BASE/fit/openssl-engine.cnf" \
+openssl req -new -x509 \
+    -engine pkcs11 -keyform engine \
+    -key "pkcs11:object=iotgw-fit-softhsm-dev;type=private;pin-value=1234" \
+    -days 3650 \
+    -subj "/CN=iotgw-fit-softhsm-dev/O=iotgw-dev" \
+    -out "$SOFTHSM_BASE/fit/iotgw-fit-softhsm-dev.crt"
+```
+
+After provisioning, persist `SOFTHSM2_CONF` in your shell init so every
+subsequent `make sign-bootfiles-fit-softhsm` invocation finds the
+token.
+
+The default profile expects the engine config at
+`~/rauc-keys/softhsm/fit/openssl-engine.cnf` and the cert at
+`~/rauc-keys/softhsm/fit/iotgw-fit-softhsm-dev.crt`. To use a
+different layout, copy `scripts/fit-signing-profiles.yml` to a vault
+location, edit the SoftHSM profile, and export
+`IOTGW_FIT_SIGNING_PROFILES=<path>`.
+
 ## DTB trust rotation: file key → YubiKey
 
 The U-Boot **control FDT** (the runtime DTB the RPi firmware passes to
@@ -268,19 +446,29 @@ hardware-resident YubiKey pubkey is the second leg of FIT-signing
 adoption: PR-side HSM signing produces FITs that only verify on devices
 whose control FDT carries the corresponding pubkey.
 
-This project ships a three-image rotation pattern modelled after the
-RAUC PKI rotation (see `docs/RAUC_PKI.md`):
+This project ships a three-stage rotation pattern modelled after the
+RAUC PKI rotation (see `docs/RAUC_PKI.md`), plus an optional dev variant
+that adds a SoftHSM-resident trust root for engineers without a
+YubiKey:
 
-| Image | DTB trust roots | FIT signing key | Notes |
+| Stage | DTB trust roots | FIT signing key | Notes |
 |-------|-----------------|-----------------|-------|
-| A (legacy) | file key only | file key | Status quo before this rotation. |
-| **B (transition)** | **file key + YK pubkey** | file key (build) or YK (post-build, optional) | DTB carries both pubkeys with `/signature/required-mode = "any"`. A FIT signed by either root verifies. |
-| C (cutover) | YK pubkey only | YK (post-build, mandatory) | File key retired. `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. |
+| Legacy baseline | file key only | file key | Status quo before this rotation. |
+| **Rotation window** | **file key + YK pubkey** | file key (build) or YK (post-build, optional) | DTB carries both pubkeys with `/signature/required-mode = "any"`. A FIT signed by either root verifies. |
+| Production cutover | YK pubkey only | YK (post-build, mandatory) | File key retired. `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. |
+| Dev variant (optional) | adds SoftHSM dev pubkey alongside any of the above | YK (production) or SoftHSM (dev) | `IOTGW_FIT_TRUST_SOFTHSM_KEY = "1"`. **Dev hardware only — never ship.** |
 
-Image B is the only image that should ship while operators still hold
-the legacy file-key private material. Devices that boot Image B will
-accept any future YK-signed FIT, so the rotation can proceed without
-re-flashing.
+The rotation-window build is the only one that should ship while
+operators still hold the legacy file-key private material. Devices
+that boot it will accept any future YK-signed FIT, so the rotation can
+proceed without re-flashing.
+
+The Dev variant is a dev-loop tool: enable
+`IOTGW_FIT_TRUST_SOFTHSM_KEY` alongside the YK gate to build an image
+that boots either a real YK-signed FIT or a SoftHSM-signed FIT — useful
+for shared dev hardware between YK-equipped and YK-less engineers.
+No production build should carry the SoftHSM trust gate — devices in
+the field must trust only YubiKey-backed roots.
 
 ### Operator pre-flight: export the YK public certificate
 
@@ -299,9 +487,10 @@ The certificate filename is `<IOTGW_FIT_YK_KEYNAME>.crt`; renaming the
 YubiKey hint string in the project requires renaming this file in
 lockstep. The default `iotgw-fit-yk-2026` is intentionally year-tagged
 so a future rotation lands at `iotgw-fit-yk-<NEW_YEAR>` without
-clobbering existing trust anchors on already-deployed Image B devices.
+clobbering existing trust anchors on already-deployed rotation-window
+devices.
 
-### Build-time configuration (Image B)
+### Build-time configuration (rotation window)
 
 In `kas/local.yml`, enable both trust roots:
 
@@ -327,15 +516,21 @@ The kernel-fit recipe's `do_deploy:append` block:
 - When `IOTGW_FIT_TRUST_FILE_KEY = "1"`: runs `mkimage -F -k -K -r` to
   sign the FIT with the file key AND inject the file-key public key
   into the DTB under `/signature/key-<UBOOT_SIGN_KEYNAME>`.
-- When `IOTGW_FIT_TRUST_YK_KEY = "1"`: runs `fdt_add_pubkey -a
-  ${FIT_HASH_ALG},${FIT_SIGN_ALG} -k <yk-keydir> -n <yk-keyname>
-  -r conf` to add a second key node under
-  `/signature/key-<IOTGW_FIT_YK_KEYNAME>` (no private key required), then
-  sets `/signature/required-mode = "any"` via `fdtput` so a FIT signed by
-  either root verifies.
+- When `IOTGW_FIT_TRUST_YK_KEY = "1"`: runs
+  `fdt_add_pubkey -a ${FIT_HASH_ALG},${FIT_SIGN_ALG} -k <yk-keydir> -n <yk-keyname> -r conf`
+  to add a second key node under `/signature/key-<IOTGW_FIT_YK_KEYNAME>`
+  (no private key required).
+- When `IOTGW_FIT_TRUST_SOFTHSM_KEY = "1"`: same shape as the YK
+  injection but using `<softhsm-keydir>` and `<softhsm-keyname>`. Dev
+  builds only.
+- Counts how many of the three trust gates are enabled. If more than
+  one, sets `/signature/required-mode = "any"` via `fdtput` so a FIT
+  signed by any one root verifies. With exactly one trust root,
+  `required-mode` is left unset — U-Boot's default semantics handle the
+  single-required-key case.
 
-Setting both gates to `"0"` with `UBOOT_SIGN_ENABLE=1` is fatal — the
-recipe refuses to deploy unsigned-trust DTBs.
+All three gates off with `UBOOT_SIGN_ENABLE=1` is fatal — the recipe
+refuses to deploy unsigned-trust DTBs.
 
 ### Verifying the DTB build output
 
@@ -365,7 +560,7 @@ silently truncate at the first `};` and hide a second key node.
 
 ### On-target verification
 
-After flashing Image B and booting:
+After flashing a rotation-window build and booting:
 
 ```bash
 # Confirm both trust roots are live in U-Boot's control FDT.
@@ -377,8 +572,8 @@ Expected: `any` on stdout, and two `key-*` directories.
 
 Test both signing paths sequentially:
 
-1. **File-key-signed FIT path** — flash the Image B build, boot, check
-   U-Boot log for FIT verification success against
+1. **File-key-signed FIT path** — flash the rotation-window build,
+   boot, check U-Boot log for FIT verification success against
    `key-${UBOOT_SIGN_KEYNAME}`. Normal `iotgw-rauc-install` flow works
    as it did pre-rotation.
 2. **YK-signed FIT path** — run `make sign-bootfiles-fit-yk` against the
@@ -387,17 +582,19 @@ Test both signing paths sequentially:
    step 1, reboot. U-Boot must accept the FIT against
    `key-iotgw-fit-yk-2026`.
 
-Both paths must boot cleanly on the same device before promoting Image
-B to fleet rollout, and before scoping Image C.
+Both paths must boot cleanly on the same device before promoting the
+rotation-window build to fleet rollout, and before scoping the
+production cutover.
 
-### Cutover (Image C, separate PR)
+### Production cutover (separate change)
 
-Image C drops `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. The
-recipe then injects only the YK pubkey; `required-mode = "any"` is
-still set (harmless with one key). The bundle FIT MUST be HSM-signed
-before release; a file-key-signed FIT would be rejected by every
-fielded Image C device. Image C is scoped to a separate PR after
-Image B is validated on hardware.
+The cutover build drops `IOTGW_FIT_TRUST_FILE_KEY = "0"` in
+`kas/local.yml`. The recipe then injects only the YK pubkey, and with
+a single trust root the recipe omits `required-mode` so U-Boot's
+default single-required-key verification applies. The bundle FIT MUST
+be HSM-signed before release; a file-key-signed FIT would be rejected
+by every fielded device. The cutover is scoped to a separate change
+once the rotation-window build is validated on hardware.
 
 ## Signing FIT against a PKCS#11 token (YubiKey)
 
@@ -442,9 +639,11 @@ post-Scarthgap provides native PKCS#11 FIT signing support and is the
 intended migration target once this project moves beyond its current
 Scarthgap layer set.
 
-### How `scripts/sign-fit.sh` works
+### How `scripts/sign_fit.py sign-fit` works
 
-The wrapper does three things, in order:
+`scripts/sign-fit.sh` is a compatibility shim that calls
+`scripts/sign_fit.py sign-fit ...`. The Python implementation does three
+things, in order:
 
 1. **`fdtput` rewrite** — walks every
    `/configurations/conf-*/signature*/key-name-hint` and sets it to the

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -99,12 +99,13 @@ local_conf_header:
     #     post-build resigned via scripts/sign-fit.sh against the
     #     hardware-resident private key.
     #
-    # Image B (transition): both gates ON. DTB carries both pubkeys
-    # and /signature/required-mode = "any" so a FIT signed by either
-    # root verifies. Required during the rotation window where some
-    # bundles are file-signed and some are HSM-signed.
+    # Rotation window (both gates ON): DTB carries both pubkeys and
+    # /signature/required-mode = "any" so a FIT signed by either root
+    # verifies. Required while some bundles are file-signed and some
+    # are HSM-signed.
     #
-    # Image C (cutover): IOTGW_FIT_TRUST_FILE_KEY=0, only YK trusted.
+    # Production cutover (IOTGW_FIT_TRUST_FILE_KEY=0, only YK trusted):
+    # the recipe injects only the YK pubkey and omits required-mode.
     # Operator pre-flight: export slot 9a public cert with
     # `ykman piv certificates export 9a ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt`.
     #
@@ -113,6 +114,35 @@ local_conf_header:
     # IOTGW_FIT_TRUST_YK_KEY:fitflow = "1"
     # IOTGW_FIT_YK_KEYDIR:fitflow = "${IOTGW_RAUC_KEY_DIR}/rauc-ca/fit"
     # IOTGW_FIT_YK_KEYNAME:fitflow = "iotgw-fit-yk-2026"
+
+  fit_dtb_softhsm_dev_trust: |
+    # DEV-ONLY: optional SoftHSM-based FIT-signing trust root for engineers
+    # without a YubiKey. SoftHSM stores keys in software, NOT a hardware
+    # token — never enable this gate on a build intended for the field.
+    # Operator provisions the dev key + cert via softhsm2-util + pkcs11-tool;
+    # see docs/FIT_BOOT_SIGNING.md for the runbook.
+    #
+    # Two reasonable dev models:
+    #
+    #   1. Dual dev trust (recommended for shared hardware) — flip both
+    #      YK and SoftHSM gates ON. DTB carries iotgw-fit-yk-2026 AND
+    #      iotgw-fit-softhsm-dev with /signature/required-mode = "any".
+    #      The same image boots either a real YK-signed FIT or a
+    #      SoftHSM-signed FIT, so a YK-less developer and a YK-equipped
+    #      developer can share the device for testing.
+    #
+    #   2. SoftHSM-only dev — leave YK gate OFF, flip SoftHSM gate ON.
+    #      DTB trusts only iotgw-fit-softhsm-dev (single root, no
+    #      required-mode written). Simpler but the device cannot boot
+    #      production-style YK-signed artifacts.
+    #
+    # Any production build must keep IOTGW_FIT_TRUST_SOFTHSM_KEY off so
+    # the device's runtime trust store contains only YubiKey-backed
+    # roots.
+    #
+    # IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "1"
+    # IOTGW_FIT_SOFTHSM_KEYDIR:fitflow = "${IOTGW_RAUC_KEY_DIR}/softhsm/fit"
+    # IOTGW_FIT_SOFTHSM_KEYNAME:fitflow = "iotgw-fit-softhsm-dev"
 
   fit_custom_its_strategy_a: |
     # Optional: Strategy A for FIT recovery kernel.

--- a/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
+++ b/meta-iot-gateway/recipes-kernel/linux/linux-iotgw-mainline-fit_6.18.bb
@@ -29,14 +29,19 @@ IOTGW_FIT_RECOVERY_KERNEL_PATH ?= "${DEPLOY_DIR_IMAGE}/linux-recovery.bin"
 
 IOTGW_FIT_CUSTOM_ITS_KERNEL2_PATH_COMP_ALG ?= "none"
 
-# FIT DTB trust roots — see kas/local.yml.example fit_dtb_yk_pubkey_trust
-# block for the rotation pattern. Both gates default to a file-key-only
-# transition image; flip IOTGW_FIT_TRUST_YK_KEY=1 in kas/local.yml to add
-# the YubiKey public certificate as a second trust root.
-IOTGW_FIT_TRUST_FILE_KEY ?= "1"
-IOTGW_FIT_TRUST_YK_KEY   ?= "0"
-IOTGW_FIT_YK_KEYDIR      ?= ""
-IOTGW_FIT_YK_KEYNAME     ?= "iotgw-fit-yk-2026"
+# FIT DTB trust roots — see kas/local.yml.example fit_dtb_*_trust blocks
+# for the rotation pattern. The file-key gate defaults on so a developer
+# without a YubiKey or SoftHSM can still build normally. The YK and
+# SoftHSM gates default off; flip them on in kas/local.yml only when the
+# corresponding key material is present. The SoftHSM gate is dev-only —
+# do not enable it on production builds.
+IOTGW_FIT_TRUST_FILE_KEY    ?= "1"
+IOTGW_FIT_TRUST_YK_KEY      ?= "0"
+IOTGW_FIT_YK_KEYDIR         ?= ""
+IOTGW_FIT_YK_KEYNAME        ?= "iotgw-fit-yk-2026"
+IOTGW_FIT_TRUST_SOFTHSM_KEY ?= "0"
+IOTGW_FIT_SOFTHSM_KEYDIR    ?= ""
+IOTGW_FIT_SOFTHSM_KEYNAME   ?= "iotgw-fit-softhsm-dev"
 
 # fdt_add_pubkey lands in the native sysroot via meta-iot-gateway's
 # u-boot-tools bbappend; mirrors the UBOOT_MKIMAGE_SIGN naming used by
@@ -55,14 +60,16 @@ python () {
 }
 
 # Raspberry Pi firmware passes a runtime-prepared DTB to U-Boot. Inject FIT
-# public keys into deployed firmware DTBs so U-Boot control FDT can expose
+# public keys into deployed firmware DTBs so U-Boot's control FDT can expose
 # /signature and enforce FIT config signatures on target.
 #
-# Two trust roots can be injected side-by-side via the IOTGW_FIT_TRUST_*
-# gates. When both are enabled, /signature/required-mode is set to "any"
-# so a FIT signed by either root verifies — the rotation window mode.
-# Setting both gates to 0 with UBOOT_SIGN_ENABLE=1 is fatal: a signed-FIT
-# enforced device with no trust roots would brick on first boot.
+# Up to three trust roots can be injected side-by-side via the
+# IOTGW_FIT_TRUST_* gates: file key (legacy build-time signing),
+# YubiKey-resident pubkey (production HSM signing), and SoftHSM pubkey
+# (dev-only, for engineers without a YubiKey). /signature/required-mode
+# is set to "any" only when more than one root is enabled — with a
+# single root, U-Boot's default verify semantics apply. All gates off
+# with UBOOT_SIGN_ENABLE=1 is fatal.
 do_deploy:append() {
     if [ "${UBOOT_SIGN_ENABLE}" != "1" ]; then
         bbnote "FIT DTB key injection skipped: UBOOT_SIGN_ENABLE=${UBOOT_SIGN_ENABLE}"
@@ -71,9 +78,10 @@ do_deploy:append() {
 
     trust_file="${IOTGW_FIT_TRUST_FILE_KEY}"
     trust_yk="${IOTGW_FIT_TRUST_YK_KEY}"
+    trust_softhsm="${IOTGW_FIT_TRUST_SOFTHSM_KEY}"
 
-    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ]; then
-        bbfatal "FIT DTB trust misconfigured: IOTGW_FIT_TRUST_FILE_KEY=0 and IOTGW_FIT_TRUST_YK_KEY=0 with UBOOT_SIGN_ENABLE=1 would brick the device. Enable at least one trust root."
+    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ] && [ "${trust_softhsm}" != "1" ]; then
+        bbfatal "FIT DTB trust misconfigured: all three of IOTGW_FIT_TRUST_FILE_KEY / IOTGW_FIT_TRUST_YK_KEY / IOTGW_FIT_TRUST_SOFTHSM_KEY are off with UBOOT_SIGN_ENABLE=1 — would brick the device. Enable at least one trust root."
     fi
 
     if [ "${trust_file}" = "1" ]; then
@@ -90,14 +98,36 @@ do_deploy:append() {
         if [ ! -f "${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt" ]; then
             bbfatal "FIT DTB YK-key injection requires public certificate at ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt — export with: ykman piv certificates export 9a <path>"
         fi
+    fi
+
+    if [ "${trust_softhsm}" = "1" ]; then
+        if [ -z "${IOTGW_FIT_SOFTHSM_KEYDIR}" ] || [ ! -d "${IOTGW_FIT_SOFTHSM_KEYDIR}" ]; then
+            bbfatal "FIT DTB SoftHSM-key injection requires IOTGW_FIT_SOFTHSM_KEYDIR pointing to a directory holding ${IOTGW_FIT_SOFTHSM_KEYNAME}.crt (got: '${IOTGW_FIT_SOFTHSM_KEYDIR}'). SoftHSM trust is dev-only — see docs/FIT_BOOT_SIGNING.md."
+        fi
+        if [ ! -f "${IOTGW_FIT_SOFTHSM_KEYDIR}/${IOTGW_FIT_SOFTHSM_KEYNAME}.crt" ]; then
+            bbfatal "FIT DTB SoftHSM-key injection requires public certificate at ${IOTGW_FIT_SOFTHSM_KEYDIR}/${IOTGW_FIT_SOFTHSM_KEYNAME}.crt — see docs/FIT_BOOT_SIGNING.md for the SoftHSM provisioning runbook."
+        fi
+    fi
+
+    if [ "${trust_yk}" = "1" ] || [ "${trust_softhsm}" = "1" ]; then
         if [ ! -x "${UBOOT_FDT_ADD_PUBKEY}" ]; then
             bbfatal "fdt_add_pubkey not found at '${UBOOT_FDT_ADD_PUBKEY}' — ensure u-boot-tools-native installs it (see meta-iot-gateway/recipes-bsp/u-boot/u-boot-tools_%.bbappend)"
         fi
     fi
 
-    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ]; then
+    if [ "${trust_file}" != "1" ] && [ "${trust_yk}" != "1" ] && [ "${trust_softhsm}" != "1" ]; then
         bbfatal "FIT DTB trust resolved to zero roots after validation — refusing to deploy unsigned-trust DTBs with UBOOT_SIGN_ENABLE=1"
     fi
+
+    # Count enabled trust roots without shell arithmetic expansion
+    # ($((…)) is unsupported by BitBake's shell parser). The case
+    # pattern matches the file-yk-softhsm gate triple.
+    case "${trust_file}-${trust_yk}-${trust_softhsm}" in
+        1-1-1) trust_count=3 ;;
+        1-1-0|1-0-1|0-1-1) trust_count=2 ;;
+        1-0-0|0-1-0|0-0-1) trust_count=1 ;;
+        *) trust_count=0 ;;
+    esac
 
     deploy_dir="${DEPLOYDIR}"
     if [ -n "${KERNEL_DEPLOYSUBDIR}" ]; then
@@ -115,7 +145,7 @@ do_deploy:append() {
         return
     fi
 
-    bbnote "FIT DTB trust roots: file=${trust_file} yk=${trust_yk} algo=${FIT_HASH_ALG},${FIT_SIGN_ALG}"
+    bbnote "FIT DTB trust roots: file=${trust_file} yk=${trust_yk} softhsm=${trust_softhsm} count=${trust_count} algo=${FIT_HASH_ALG},${FIT_SIGN_ALG}"
 
     for dtb in ${RPI_KERNEL_DEVICETREE}; do
         dtb_base="${dtb##*/}"
@@ -148,13 +178,31 @@ do_deploy:append() {
                 -n "${IOTGW_FIT_YK_KEYNAME}" \
                 -r conf \
                 "${dtb_path}"
+        fi
 
-            # required-mode = "any" lets a FIT signed by either trust
-            # root verify. Without this, multiple required = "conf"
-            # keys make U-Boot require ALL of them, rejecting any FIT
-            # signed by only one root — the bricking case.
-            bbnote "Setting /signature/required-mode=any on ${dtb_path}"
+        if [ "${trust_softhsm}" = "1" ]; then
+            bbnote "Injecting SoftHSM dev pubkey (${IOTGW_FIT_SOFTHSM_KEYNAME}) into ${dtb_path}"
+            ${UBOOT_FDT_ADD_PUBKEY} \
+                -a "${FIT_HASH_ALG},${FIT_SIGN_ALG}" \
+                -k "${IOTGW_FIT_SOFTHSM_KEYDIR}" \
+                -n "${IOTGW_FIT_SOFTHSM_KEYNAME}" \
+                -r conf \
+                "${dtb_path}"
+        fi
+
+        # required-mode = "any" lets a FIT signed by any one of multiple
+        # required trust roots verify. Without this, U-Boot requires ALL
+        # required keys to verify, which would reject any FIT signed by
+        # only one root — the bricking case. With a single trust root,
+        # the property is omitted: U-Boot's default semantics handle a
+        # single required key correctly and a stale "any" from a
+        # previous multi-root build would be inert anyway (the deploy
+        # DTB is rebuilt from the work tree each run).
+        if [ "${trust_count}" -gt 1 ]; then
+            bbnote "Setting /signature/required-mode=any on ${dtb_path} (trust_count=${trust_count})"
             fdtput -t s "${dtb_path}" /signature required-mode any
+        else
+            bbnote "Single trust root (count=1) — leaving /signature/required-mode unset on ${dtb_path}"
         fi
     done
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+# Host-side Python test environment for the rpi5-iot-gw project.
+#
+# This file does NOT define a pip-installable package. Its only purpose
+# is to give `uv` a reproducible runtime + dev environment for running
+# the FIT-signing test suite under scripts/tests/. Yocto/BitBake builds
+# do not depend on uv or on this venv.
+#
+# Operator usage of scripts/sign_fit.py continues to work with the
+# system Python plus a distro-installed `python3-yaml` (see
+# docs/FIT_BOOT_SIGNING.md). The Makefile signing targets do NOT run
+# through `uv run`.
+#
+# Refresh the lockfile with `make tools-venv` (or `uv sync`). Bump deps
+# via `uv lock --upgrade` then re-run `uv sync`.
+
+[project]
+name = "rpi5-iot-gw-host-tools"
+version = "0.1.0"
+description = "Host-side tooling test environment (FIT signing). Not pip-installable."
+requires-python = ">=3.11"
+dependencies = [
+    "pyyaml>=6.0",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=7.0",
+]
+
+[tool.pytest.ini_options]
+testpaths = ["scripts/tests"]
+addopts = ["-ra"]
+
+[tool.uv]
+# Keep the venv out of the source tree; uv default is `.venv` which
+# .gitignore already excludes.
+package = false

--- a/scripts/fit-signing-profiles.yml
+++ b/scripts/fit-signing-profiles.yml
@@ -1,0 +1,24 @@
+# Default signing profiles for scripts/sign_fit.py.
+#
+# Override this file via `--profile-config <path>` or the
+# IOTGW_FIT_SIGNING_PROFILES environment variable. Operator-local
+# engine config paths and keydirs may be customized by copying this
+# file to a vault location and pointing the env var at it; the
+# committed defaults follow the project's `~/rauc-keys/...` convention.
+#
+# Each profile drives `mkimage -F -N pkcs11 -k <uri>`. The URI MUST
+# contain `object=<label>` because mkimage 2025.04 only takes a -k URI
+# verbatim when it sees that substring. Slot-anchored URIs (id=...)
+# require a signer that bypasses mkimage's PKCS#11 path and are out of
+# scope for this tool.
+
+fit_signing_profiles:
+  yubikey-9a:
+    key_name_hint: "iotgw-fit-yk-2026"
+    uri: "pkcs11:object=Private%20key%20for%20PIV%20Authentication"
+    engine_conf: "~/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
+
+  softhsm-dev:
+    key_name_hint: "iotgw-fit-softhsm-dev"
+    uri: "pkcs11:object=iotgw-fit-softhsm-dev"
+    engine_conf: "~/rauc-keys/softhsm/fit/openssl-engine.cnf"

--- a/scripts/sign-bootfiles-fit.sh
+++ b/scripts/sign-bootfiles-fit.sh
@@ -1,215 +1,45 @@
 #!/usr/bin/env bash
-# sign-bootfiles-fit.sh — re-sign the fitImage embedded in a
-# `bootfiles-fit.tar.gz` archive against a PKCS#11-resident key.
+# sign-bootfiles-fit.sh — compatibility shim.
 #
-# Wraps `sign-fit.sh` to operate on the bootfiles tarball that the
-# RAUC bundle recipe consumes. After this script runs, the bundle
-# recipe must be re-driven (e.g. via `bitbake -C do_configure
-# iot-gw-bundle-full-fit`) so the bundle re-packages with the
-# updated tarball.
-#
-# Flow:
-#   1. Snapshot the archive (`<archive>.bak`) for rollback.
-#   2. Extract into a temp dir.
-#   3. Run scripts/sign-fit.sh on the extracted fitImage.
-#   4. Re-pack the tarball in place.
-#   5. Print SHA-256 of old/new archives.
-#
-# WARNING: mutates the bootfiles tarball in place. The script
-# restores the backup if any step after extraction fails.
+# The bootfiles signing logic now lives in scripts/sign_fit.py. This
+# shim preserves the legacy CLI (`--archive`, `--force`, `--` separator
+# for forwarded sign-fit args) so Makefile targets and operator
+# runbooks keep working. New code should call
+# `python3 scripts/sign_fit.py sign-bootfiles ...` directly.
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-SIGN_FIT="${SCRIPT_DIR}/sign-fit.sh"
+PY_TOOL="${SCRIPT_DIR}/sign_fit.py"
 
-DEFAULT_ARCHIVE="build/tmp-glibc/deploy/images/raspberrypi5/bootfiles-fit.tar.gz"
-
-ARCHIVE=""
-PASSTHROUGH=()
-FORCE=0
-
-BACKUP=""
-TMPDIR_WORK=""
-MUTATED=0
-
-die()  { echo "sign-bootfiles-fit.sh: error: $*" >&2; exit 1; }
-warn() { echo "sign-bootfiles-fit.sh: warning: $*" >&2; }
-log()  { echo "sign-bootfiles-fit.sh: $*"; }
-
-cleanup() {
-    local rc=$?
-    if [[ -n "${BACKUP}" && -f "${BACKUP}" ]]; then
-        if [[ ${rc} -ne 0 && ${MUTATED} -eq 1 ]]; then
-            if cp -f -- "${BACKUP}" "${ARCHIVE}" 2>/dev/null; then
-                warn "restored ${ARCHIVE} from ${BACKUP} after failure (exit ${rc})"
-            else
-                warn "FAILED to restore ${ARCHIVE} from ${BACKUP} — inspect manually (exit ${rc})"
-            fi
-        fi
-        rm -f -- "${BACKUP}"
+# Old CLI: `sign-bootfiles-fit.sh [shim-args] -- [signing-args]`.
+# Python subcommand accepts the same flags directly; merge both groups
+# by stripping the `--` separator.
+args=()
+for arg in "$@"; do
+    if [[ "${arg}" == "--" ]]; then
+        continue
     fi
-    if [[ -n "${TMPDIR_WORK}" && -d "${TMPDIR_WORK}" ]]; then
-        rm -rf -- "${TMPDIR_WORK}"
-    fi
-}
-trap cleanup EXIT
+    args+=("${arg}")
+done
 
-usage() {
-    cat <<EOF
-Usage: sign-bootfiles-fit.sh [--archive PATH] [-- <sign-fit.sh args>...]
-
-  --archive PATH   Path to bootfiles-fit.tar.gz.
-                   Default: ${DEFAULT_ARCHIVE}
-  --force          Re-sign even when the inner FIT already advertises
-                   the HSM key-name-hint in its 'Sign algo:' audit
-                   line. Useful when refreshing signature timestamps
-                   or recovering from a tampered audit field.
-  -h, --help       Show this help and exit.
-
-All arguments after '--' are forwarded to sign-fit.sh. Useful
-forwards: --key-name-hint, --uri, --engine-conf, --verify.
-
-Example:
-  sign-bootfiles-fit.sh -- --verify
-  sign-bootfiles-fit.sh --archive /path/to/bootfiles-fit.tar.gz -- \\
-      --uri 'pkcs11:token=<encoded>;id=%01;type=private' --verify
-EOF
-}
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --archive) [[ $# -ge 2 ]] || die "--archive needs a value"; ARCHIVE="$2"; shift 2 ;;
-        --force)   FORCE=1; shift ;;
-        -h|--help) usage; exit 0 ;;
-        --)        shift; PASSTHROUGH=("$@"); break ;;
-        -*)        usage >&2; die "unknown option: $1 (forwards to sign-fit.sh go after '--')" ;;
-        *)         usage >&2; die "unexpected positional argument: $1" ;;
+# Legacy default: the old shell wrapper implicitly targeted the YubiKey
+# slot 9a flow and applied caller-supplied flags as per-field overrides
+# on top of those defaults. Preserve that by always injecting
+# `--profile yubikey-9a` unless the caller selected a profile explicitly
+# via `--profile NAME` or `--profile=NAME`. All other flags override
+# profile fields in Python — they no longer disable injection.
+inject_default=1
+for a in "${args[@]+"${args[@]}"}"; do
+    case "${a}" in
+        --profile|--profile=*)
+            inject_default=0
+            break
+            ;;
     esac
 done
-
-[[ -n "${ARCHIVE}" ]] || ARCHIVE="${DEFAULT_ARCHIVE}"
-[[ -f "${ARCHIVE}" ]] || die "archive not found: ${ARCHIVE}"
-[[ -w "${ARCHIVE}" ]] || die "archive not writable: ${ARCHIVE}"
-[[ -x "${SIGN_FIT}" ]] || die "helper not found or not executable: ${SIGN_FIT}"
-
-# Resolve to absolute path so the repack subshell's `cd` into TMPDIR_WORK
-# cannot break the archive reference.
-ARCHIVE="$(readlink -f -- "${ARCHIVE}")" || die "could not resolve absolute path of ${ARCHIVE}"
-ARCHIVE_DIR="$(dirname -- "${ARCHIVE}")"
-[[ -w "${ARCHIVE_DIR}" ]] || die "archive directory not writable: ${ARCHIVE_DIR}"
-
-for tool in tar sha256sum dumpimage; do
-    command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
-done
-
-PRE_SHA="$(sha256sum -- "${ARCHIVE}" | awk '{print $1}')"
-log "archive: ${ARCHIVE}"
-log "pre  sha256: ${PRE_SHA}"
-
-# Content-based idempotency check: peek at the inner FIT's `Sign algo:`
-# audit line. If it already advertises the HSM key-name-hint we would
-# sign with, skip — this is the signal a downstream consumer
-# (operator, signing service, U-Boot DTB verify) reads. The check is
-# spoofable in principle (someone could rewrite the FIT's
-# key-name-hint without actually signing with the HSM); for the
-# Stage 1 → Stage 2 flow that this script supports, the trade-off
-# favours an in-artifact signal over a sidecar trust file that does
-# not travel across machines. Use --force to override.
-#
-# Effective FIT key-name-hint is what sign-fit.sh will write: parse
-# PASSTHROUGH for an explicit --key-name-hint, fall back to the
-# deprecated --key-label alias if present, otherwise use sign-fit.sh's
-# documented default (kept in sync with DEFAULT_KEY_NAME_HINT there).
-DEFAULT_KEY_NAME_HINT="iotgw-fit-yk-2026"
-EFFECTIVE_HINT="${DEFAULT_KEY_NAME_HINT}"
-for ((i=0; i<${#PASSTHROUGH[@]}; i++)); do
-    if [[ "${PASSTHROUGH[i]}" == "--key-name-hint" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
-        EFFECTIVE_HINT="${PASSTHROUGH[i+1]}"
-        break
-    fi
-    if [[ "${PASSTHROUGH[i]}" == "--key-label" && $((i+1)) -lt ${#PASSTHROUGH[@]} ]]; then
-        EFFECTIVE_HINT="${PASSTHROUGH[i+1]}"
-        # don't break — a later --key-name-hint should still win
-    fi
-done
-EXPECTED_ALGO="sha256,rsa2048:${EFFECTIVE_HINT}"
-
-if [[ "${FORCE}" -eq 0 ]]; then
-    peek_dir="$(mktemp -d -t sign-bootfiles-peek.XXXXXX)"
-    algo_total=0
-    algo_match=0
-    if tar -xzf "${ARCHIVE}" -C "${peek_dir}" ./fitImage 2>/dev/null \
-            && [[ -f "${peek_dir}/fitImage" ]]; then
-        # Skip only if every `Sign algo:` line in the FIT matches the
-        # expected algo. A partial state (one config labelled, another
-        # still showing the file-key label) must NOT skip — that would
-        # ship a mixed-trust bundle silently.
-        mapfile -t algo_lines < <(dumpimage -l "${peek_dir}/fitImage" 2>/dev/null \
-            | grep -F 'Sign algo:' || true)
-        algo_total="${#algo_lines[@]}"
-        for line in "${algo_lines[@]}"; do
-            if [[ "${line}" == *"${EXPECTED_ALGO}"* ]]; then
-                algo_match=$((algo_match + 1))
-            fi
-        done
-    fi
-    rm -rf -- "${peek_dir}"
-    if [[ "${algo_total}" -gt 0 && "${algo_match}" -eq "${algo_total}" ]]; then
-        log "all ${algo_total} signature node(s) in inner FIT already labelled '${EXPECTED_ALGO}'; skipping (use --force to re-sign)"
-        echo
-        echo "============ sign-bootfiles-fit summary ============"
-        printf "  Archive       : %s\n" "${ARCHIVE}"
-        printf "  SHA           : %s\n" "${PRE_SHA}"
-        printf "  Inner FIT     : all %d signature node(s) labelled '%s'\n" "${algo_total}" "${EXPECTED_ALGO}"
-        printf "  Mode          : skipped (use --force to re-sign)\n"
-        printf "  Timestamp     : %s\n" "$(date -u +%FT%TZ)"
-        echo "===================================================="
-        exit 0
-    fi
-    if [[ "${algo_total}" -gt 0 && "${algo_match}" -gt 0 ]]; then
-        log "inner FIT is partially labelled (${algo_match} of ${algo_total} signature node(s) match '${EXPECTED_ALGO}'); proceeding to re-sign all"
-    fi
+if [[ "${inject_default}" -eq 1 ]]; then
+    args=("--profile" "yubikey-9a" "${args[@]+"${args[@]}"}")
 fi
 
-BACKUP="${ARCHIVE}.bak"
-cp -f -- "${ARCHIVE}" "${BACKUP}" || die "failed to write backup at ${BACKUP}"
-
-TMPDIR_WORK="$(mktemp -d -t sign-bootfiles-fit.XXXXXX)"
-log "extracting into ${TMPDIR_WORK}"
-tar -xzf "${ARCHIVE}" -C "${TMPDIR_WORK}" || die "tar extract failed"
-
-EXTRACTED_FIT="${TMPDIR_WORK}/fitImage"
-[[ -f "${EXTRACTED_FIT}" ]] || die "fitImage not found in archive (looked at ${EXTRACTED_FIT})"
-
-log "invoking sign-fit.sh on extracted fitImage"
-MUTATED=1
-"${SIGN_FIT}" --fit "${EXTRACTED_FIT}" "${PASSTHROUGH[@]}"
-
-log "repacking ${ARCHIVE}"
-# Re-pack from TMPDIR_WORK with the same ./<files> layout the original
-# archive used (verified to start with './' entries by the bundle recipe).
-( cd "${TMPDIR_WORK}" && tar -czf "${ARCHIVE}.new" . ) \
-    || die "tar repack failed"
-mv -f -- "${ARCHIVE}.new" "${ARCHIVE}" \
-    || die "failed to replace ${ARCHIVE} with repacked archive"
-
-POST_SHA="$(sha256sum -- "${ARCHIVE}" | awk '{print $1}')"
-log "post sha256: ${POST_SHA}"
-
-if [[ "${PRE_SHA}" == "${POST_SHA}" ]]; then
-    die "archive SHA unchanged after repack — sign-fit.sh likely no-op'd; check args (need --verify or signing args after '--')"
-fi
-
-echo
-echo "============ sign-bootfiles-fit summary ============"
-printf "  Archive   : %s\n" "${ARCHIVE}"
-printf "  Pre  SHA  : %s\n" "${PRE_SHA}"
-printf "  Post SHA  : %s\n" "${POST_SHA}"
-printf "  Inner FIT : signed (audit line '%s')\n" "${EXPECTED_ALGO}"
-printf "  Timestamp : %s\n" "$(date -u +%FT%TZ)"
-echo
-echo "Next step: re-drive the bundle recipe so it picks up the new"
-echo "tarball. With this project's KAS+make wrapper, that is:"
-echo "  make bundle-dev-full-fit-resign"
-echo "===================================================="
+exec python3 "${PY_TOOL}" sign-bootfiles "${args[@]+"${args[@]}"}"

--- a/scripts/sign-fit.sh
+++ b/scripts/sign-fit.sh
@@ -1,372 +1,47 @@
 #!/usr/bin/env bash
-# sign-fit.sh — re-sign a U-Boot FIT image using a key on a PKCS#11
-# token (typically a YubiKey PIV slot) via OpenSSL's engine_pkcs11.
+# sign-fit.sh — compatibility shim.
 #
-# Intended as a post-build release step: the build system signs the
-# FIT with a file-based key; this wrapper overwrites that signature in
-# place against an HSM-resident key.
-#
-# mkimage gotcha: `mkimage -F -N pkcs11 <fit>` without a `-k <URI>`
-# carrying `object=<label>` is a silent no-op for the signing step.
-# It repacks the FDT, regenerates hashes, exits 0, and leaves the
-# original signature bytes untouched. This script always passes
-# `-k pkcs11:object=<label>` and additionally guards against the
-# trap by capturing mkimage's stdout/stderr and requiring at least
-# one "Signature written" log line — that line is absent in the
-# silent no-op case.
-#
-# The FIT's `key-name-hint` is metadata for the audit string in
-# `Sign algo: <alg>:<hint>` and must match the
-# `/signature/key-<hint>` node in U-Boot's control FDT for the
-# device to verify the signature. The PKCS#11 lookup for signing
-# is driven by the `-k <URI>` value: mkimage 2025.04's pkcs11
-# code path uses the URI verbatim when it contains `object=`, so
-# the URI's object label is the actual key selector. libykcs11
-# exposes slot 9a's private object under a fixed label
-# "Private key for PIV Authentication", so that label appears in
-# the URI even though the FIT hint and DTB node name stay
-# project-controlled. fdtput rewrites the hint before signing so
-# the audit line and the DTB key-node lookup line up.
-#
-# WARNING: mutates --fit in place. Run against a copy of the deploy
-# artifact, not the deploy artifact directly. The script writes a
-# `<fit>.bak` next to the target before any mutation and restores it
-# on failure, but a successful sign-then-fail-elsewhere flow can
-# still leave a partially-updated bundle pipeline if the script is
-# pointed at the live deploy path.
+# The signing logic now lives in scripts/sign_fit.py. This shim
+# preserves the legacy CLI (`--fit`, `--key-name-hint`, `--uri`,
+# `--engine-conf`, `--verify`, `--rewrite-only`, `--verbose`,
+# `--key-label`) so Makefile targets, operator runbooks, and
+# external automation keep working. New code should call
+# `python3 scripts/sign_fit.py sign-fit ...` directly.
 
 set -euo pipefail
 
-# Project-controlled FIT key-name-hint. Must match the /signature/key-<hint>
-# node injected into U-Boot's control FDT by the kernel-fit recipe.
-DEFAULT_KEY_NAME_HINT="iotgw-fit-yk-2026"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+PY_TOOL="${SCRIPT_DIR}/sign_fit.py"
 
-# PKCS#11 URI passed to mkimage as -k (NOT -G). U-Boot 2025.04's mkimage
-# ignores -G in its `-N pkcs11` code path (lib/rsa/rsa-sign.c does not
-# reference params.keyfile for the pkcs11 engine) and synthesizes the
-# URI from the FIT's key-name-hint unless -k is supplied with a URI
-# that already contains `object=`. libykcs11 hardcodes slot 9a's
-# private-object label to "Private key for PIV Authentication", so the
-# only URI form mkimage will accept verbatim for that slot is
-# object-anchored to this label. Other URI forms (id=, token= without
-# object=) require a signer that calls OpenSSL directly rather than
-# going through mkimage's -N pkcs11 path.
-DEFAULT_URI="pkcs11:object=Private%20key%20for%20PIV%20Authentication"
-
-DEFAULT_ENGINE_CONF="${HOME}/rauc-keys/rauc-ca/fit/openssl-engine.cnf"
-
-FIT=""
-ENGINE_CONF="${DEFAULT_ENGINE_CONF}"
-KEY_NAME_HINT=""
-URI=""
-KEY_LABEL_LEGACY=""
-VERIFY=0
-REWRITE_ONLY=0
-VERBOSE=0
-
-BACKUP=""
-MUTATED=0
-
-die()  { echo "sign-fit.sh: error: $*" >&2; exit 1; }
-warn() { echo "sign-fit.sh: warning: $*" >&2; }
-log()  { echo "sign-fit.sh: $*"; }
-
-cleanup() {
-    local rc=$?
-    if [[ -n "${BACKUP}" && -f "${BACKUP}" ]]; then
-        if [[ ${rc} -ne 0 && ${MUTATED} -eq 1 ]]; then
-            if cp -f -- "${BACKUP}" "${FIT}" 2>/dev/null; then
-                warn "restored ${FIT} from ${BACKUP} after failure (exit ${rc})"
-            else
-                warn "FAILED to restore ${FIT} from ${BACKUP} — inspect manually (exit ${rc})"
-                return
-            fi
-        fi
-        rm -f -- "${BACKUP}"
+# Pass through everything except the legacy bare `--` terminator: in
+# the old script anything after `--` was silently discarded.
+args=()
+for arg in "$@"; do
+    if [[ "${arg}" == "--" ]]; then
+        break
     fi
-}
-trap cleanup EXIT
+    args+=("${arg}")
+done
 
-# URL-encode anything outside the RFC 7512 pk11-unreserved subset.
-url_encode() {
-    local s="$1" i c out=""
-    for (( i=0; i<${#s}; i++ )); do
-        c="${s:i:1}"
-        case "$c" in
-            [a-zA-Z0-9._~-]) out+="$c" ;;
-            *)               printf -v c '%%%02X' "'$c"; out+="$c" ;;
-        esac
-    done
-    printf '%s' "$out"
-}
-
-usage() {
-    cat <<EOF
-Usage: sign-fit.sh --fit PATH [OPTIONS]
-
-  --fit PATH           Path to fitImage (required).
-  --engine-conf PATH   OpenSSL engine config that loads engine_pkcs11
-                       against the PKCS#11 module.
-                       Default: ${DEFAULT_ENGINE_CONF}
-  --key-name-hint NAME FIT key-name-hint to write before re-signing.
-                       Drives the 'Sign algo:' audit line AND must
-                       match the /signature/key-<NAME> node in
-                       U-Boot's control FDT — devices reject FITs
-                       whose hint doesn't resolve to a trusted key.
-                       Default: "${DEFAULT_KEY_NAME_HINT}"
-  --uri URI            PKCS#11 URI passed to mkimage via -k (NOT -G;
-                       see comment near DEFAULT_URI). The URI MUST
-                       contain 'object=<libykcs11-label>' because
-                       mkimage 2025.04 only uses -k verbatim when the
-                       legacy URI form is detected via that substring;
-                       any other form (e.g. id=) is rewritten with an
-                       appended object=<key-name-hint> which will not
-                       match a real libykcs11 object. The default
-                       targets slot 9a via libykcs11's hardcoded
-                       private-object label. Token-anchored override
-                       example:
-                       'pkcs11:token=YubiKey%20PIV%20%23<SERIAL>;object=Private%20key%20for%20PIV%20Authentication'.
-                       Default: "${DEFAULT_URI}"
-  --key-label NAME     DEPRECATED alias. Equivalent to
-                       '--key-name-hint NAME --uri pkcs11:object=
-                       <urlencoded NAME>'. Kept for back-compat with
-                       existing tooling that paired the libykcs11
-                       object label with FIT metadata.
-  --verify             Structural check after signing (NOT a crypto
-                       verification). Asserts every signature node
-                       has algo 'sha256,rsa2048:<KEY_NAME_HINT>' and
-                       a non-empty Sign value (rejects "unavailable").
-                       For cryptographic verification, run
-                       'mkimage -V' against a DTB carrying the
-                       expected public key.
-  --rewrite-only       Mutating: rewrite the FIT key-name-hint and
-                       stop before mkimage. Useful for plumbing
-                       tests without touching the token. The FIT is
-                       still modified — run on a copy.
-  --verbose            Forward mkimage's full stdout (FIT listing,
-                       per-image hashes) to the terminal. Default
-                       suppresses it; on mkimage failure the
-                       captured output is printed to stderr for
-                       diagnostics regardless of this flag.
-  -h, --help           Show this help and exit.
-EOF
-}
-
-while [[ $# -gt 0 ]]; do
-    case "$1" in
-        --fit)            [[ $# -ge 2 ]] || die "--fit needs a value"; FIT="$2"; shift 2 ;;
-        --engine-conf)    [[ $# -ge 2 ]] || die "--engine-conf needs a value"; ENGINE_CONF="$2"; shift 2 ;;
-        --key-name-hint)  [[ $# -ge 2 ]] || die "--key-name-hint needs a value"; KEY_NAME_HINT="$2"; shift 2 ;;
-        --uri)            [[ $# -ge 2 ]] || die "--uri needs a value"; URI="$2"; shift 2 ;;
-        --key-label)      [[ $# -ge 2 ]] || die "--key-label needs a value"; KEY_LABEL_LEGACY="$2"; shift 2 ;;
-        --verify)       VERIFY=1; shift ;;
-        --rewrite-only) REWRITE_ONLY=1; shift ;;
-        --verbose)      VERBOSE=1; shift ;;
-        -h|--help)      usage; exit 0 ;;
-        --)             shift; break ;;
-        -*)             usage >&2; die "unknown option: $1" ;;
-        *)              usage >&2; die "unexpected positional argument: $1" ;;
+# Legacy default: the old shell script implicitly targeted the YubiKey
+# slot 9a flow and applied caller-supplied flags as per-field overrides
+# on top of those defaults (e.g. `--engine-conf /alt.cnf` only changed
+# the engine config, key hint and URI kept the YK defaults). Preserve
+# that by always injecting `--profile yubikey-9a` unless the caller
+# selected a profile explicitly via `--profile NAME` or `--profile=NAME`.
+# All other flags (--key-name-hint / --key-label / --uri / --engine-conf)
+# override profile fields in Python — they no longer disable injection.
+inject_default=1
+for a in "${args[@]+"${args[@]}"}"; do
+    case "${a}" in
+        --profile|--profile=*)
+            inject_default=0
+            break
+            ;;
     esac
 done
-
-[[ -n "${FIT}" ]]         || { usage >&2; die "--fit is required"; }
-[[ -n "${ENGINE_CONF}" ]] || die "--engine-conf must not be empty"
-[[ -f "${FIT}" ]]         || die "fitImage not found: ${FIT}"
-[[ -w "${FIT}" ]]         || die "fitImage not writable: ${FIT}"
-FIT_DIR="$(dirname -- "${FIT}")"
-[[ -w "${FIT_DIR}" ]]     || die "cannot write backup next to ${FIT} (directory not writable: ${FIT_DIR})"
-[[ -f "${ENGINE_CONF}" ]] || die "engine conf not found: ${ENGINE_CONF}"
-
-if [[ -n "${KEY_LABEL_LEGACY}" ]]; then
-    warn "--key-label is deprecated; pass --key-name-hint and --uri explicitly"
-    [[ -z "${KEY_NAME_HINT}" ]] || die "--key-label and --key-name-hint are mutually exclusive"
-    KEY_NAME_HINT="${KEY_LABEL_LEGACY}"
-    if [[ -z "${URI}" ]]; then
-        URI="pkcs11:object=$(url_encode "${KEY_LABEL_LEGACY}")"
-    fi
+if [[ "${inject_default}" -eq 1 ]]; then
+    args=("--profile" "yubikey-9a" "${args[@]+"${args[@]}"}")
 fi
 
-KEY_NAME_HINT="${KEY_NAME_HINT:-${DEFAULT_KEY_NAME_HINT}}"
-URI="${URI:-${DEFAULT_URI}}"
-
-[[ -n "${KEY_NAME_HINT}" ]] || die "--key-name-hint must not be empty"
-[[ "${URI}" == pkcs11:* ]]  || die "URI must start with 'pkcs11:': ${URI}"
-# mkimage 2025.04's -k path keeps the URI verbatim only when it contains
-# 'object='. Without that substring, mkimage appends ';object=<hint>'
-# which then will not match a real libykcs11 object — silent sign
-# failure. Refuse early instead.
-[[ "${URI}" == *"object="* ]] \
-    || die "URI must contain 'object=<libykcs11-label>': mkimage 2025.04's -N pkcs11 path rewrites URIs without object= and will not find slot 9a — got: ${URI}"
-
-for tool in fdtget fdtput mkimage; do
-    command -v "${tool}" >/dev/null 2>&1 || die "required tool missing on PATH: ${tool}"
-done
-if [[ "${REWRITE_ONLY}" -eq 0 || "${VERIFY}" -eq 1 ]]; then
-    command -v dumpimage >/dev/null 2>&1 \
-        || die "dumpimage required for signing and --verify (not on PATH)"
-fi
-
-# Token presence check (best-effort; engine_pkcs11 has no serial-anchor
-# CLI flag, so multi-token setups are inherently ambiguous unless --uri
-# carries token=...).
-if [[ "${REWRITE_ONLY}" -eq 0 ]] && command -v ykman >/dev/null 2>&1; then
-    if ! ykman_out="$(ykman list 2>&1)"; then
-        warn "ykman list failed (${ykman_out%%$'\n'*}) — skipping presence check"
-    else
-        mapfile -t yk_tokens < <(printf '%s' "${ykman_out}" | grep -v '^[[:space:]]*$' || true)
-        case "${#yk_tokens[@]}" in
-            0) die "no YubiKey detected on the bus (use --rewrite-only to skip signing)" ;;
-            1) : ;;
-            *) warn "${#yk_tokens[@]} YubiKeys detected — without 'token=' in --uri, engine_pkcs11 selects whichever it sees first" ;;
-        esac
-    fi
-fi
-
-# Take backup before any mutation so the EXIT trap can restore on
-# failure. From here on, MUTATED=1 means the on-disk FIT differs from
-# the backup.
-BACKUP="${FIT}.bak"
-cp -f -- "${FIT}" "${BACKUP}" || die "failed to write backup at ${BACKUP}"
-
-# Enumerate /configurations subnodes. fdtget -l prints one subnode per
-# line; properties (e.g. 'default') are not listed.
-if ! confs_raw="$(fdtget -l "${FIT}" /configurations 2>&1)"; then
-    die "fdtget failed to list /configurations: ${confs_raw}"
-fi
-mapfile -t CONFS < <(printf '%s\n' "${confs_raw}")
-# Strip empties (mapfile can yield a trailing empty element).
-filtered=()
-for c in "${CONFS[@]}"; do [[ -n "${c}" ]] && filtered+=("${c}"); done
-CONFS=("${filtered[@]}")
-[[ "${#CONFS[@]}" -gt 0 ]] || die "no configuration nodes under /configurations in ${FIT}"
-
-TOTAL_SIGS=0
-for conf in "${CONFS[@]}"; do
-    if ! children_raw="$(fdtget -l "${FIT}" "/configurations/${conf}" 2>&1)"; then
-        die "fdtget failed to list /configurations/${conf}: ${children_raw}"
-    fi
-    mapfile -t CHILDREN < <(printf '%s\n' "${children_raw}")
-    sig_found=0
-    for child in "${CHILDREN[@]}"; do
-        [[ -n "${child}" ]] || continue
-        case "${child}" in
-            signature*)
-                MUTATED=1
-                fdtput -t s "${FIT}" "/configurations/${conf}/${child}" \
-                    key-name-hint "${KEY_NAME_HINT}" \
-                    || die "fdtput failed on /configurations/${conf}/${child}"
-                sig_found=$((sig_found+1))
-                TOTAL_SIGS=$((TOTAL_SIGS+1))
-                ;;
-        esac
-    done
-    [[ "${sig_found}" -gt 0 ]] || die "no signature* nodes under /configurations/${conf}"
-done
-log "rewrote key-name-hint to '${KEY_NAME_HINT}' on ${TOTAL_SIGS} signature node(s) across ${#CONFS[@]} configuration(s)"
-
-if [[ "${REWRITE_ONLY}" -eq 1 ]]; then
-    log "rewrite-only: FIT key-name-hint rewritten in place; skipping mkimage"
-else
-    log "signing FIT via engine_pkcs11 (PIN/touch may be required)"
-    log "  URI: ${URI}"
-
-    # Capture mkimage output to detect the explicit "Signature
-    # written" success line. Default is quiet — mkimage's own
-    # FIT-listing dump is suppressed; on failure it is dumped to
-    # stderr for diagnostics. --verbose forwards the listing live.
-    #
-    # PIN prompts from engine_pkcs11 are not affected: OpenSSL's UI
-    # writes them to /dev/tty, bypassing stdout/stderr redirection.
-    #
-    # Detection by log line, not byte comparison: RSA-PKCS#1 v1.5
-    # over the FIT signed range is deterministic — re-signing the
-    # same FIT with the same key produces byte-identical signatures
-    # and would false-positive a pre/post bytes-changed guard.
-    # U-Boot 2025.04 ignores -G/keyfile in the pkcs11 RSA path.
-    # Passing -k pkcs11:object=<label> is the only way to decouple
-    # private-key lookup from the FIT key-name-hint.
-    mk_log="$(mktemp)"
-    trap 'rm -f "${mk_log}"; cleanup' EXIT
-    set +e
-    if [[ "${VERBOSE}" -eq 1 ]]; then
-        OPENSSL_CONF="${ENGINE_CONF}" \
-            mkimage -F -N pkcs11 -k "${URI}" "${FIT}" 2>&1 | tee "${mk_log}"
-        mk_rc=${PIPESTATUS[0]}
-    else
-        OPENSSL_CONF="${ENGINE_CONF}" \
-            mkimage -F -N pkcs11 -k "${URI}" "${FIT}" >"${mk_log}" 2>&1
-        mk_rc=$?
-    fi
-    set -e
-    if [[ "${mk_rc}" -ne 0 ]]; then
-        echo "---- mkimage output ----" >&2
-        cat "${mk_log}" >&2
-        echo "------------------------" >&2
-        rm -f "${mk_log}"
-        die "mkimage -F failed (exit ${mk_rc})"
-    fi
-
-    sig_written_count=$(grep -c -F 'Signature written' "${mk_log}" || true)
-    if [[ "${sig_written_count}" -eq 0 ]]; then
-        echo "---- mkimage output ----" >&2
-        cat "${mk_log}" >&2
-        echo "------------------------" >&2
-        rm -f "${mk_log}"
-        die "mkimage exited 0 but emitted no 'Signature written' line — signing was a silent no-op (check engine config and that -k carries a 'pkcs11:object=<label>' URI)"
-    fi
-    rm -f "${mk_log}"
-    trap cleanup EXIT
-    log "mkimage signed (${sig_written_count} 'Signature written' line(s) observed)"
-fi
-
-VERIFY_RESULT="skipped"
-if [[ "${VERIFY}" -eq 1 ]]; then
-    if ! dump_out="$(dumpimage -l "${FIT}" 2>&1)"; then
-        die "dumpimage failed during --verify: ${dump_out}"
-    fi
-    expected_algo="sha256,rsa2048:${KEY_NAME_HINT}"
-
-    algo_count=$(printf '%s\n' "${dump_out}" | grep -c -F 'Sign algo:' || true)
-    match_count=$(printf '%s\n' "${dump_out}" | grep -c -F "${expected_algo}" || true)
-
-    if [[ "${algo_count}" -lt "${TOTAL_SIGS}" || "${match_count}" -lt "${TOTAL_SIGS}" ]]; then
-        printf '%s\n' "${dump_out}" >&2
-        die "verify failed: expected ${TOTAL_SIGS} signature(s) with algo '${expected_algo}', found ${match_count}"
-    fi
-
-    bad_sigs=0
-    while IFS= read -r line; do
-        val="${line#*Sign value:}"
-        val="$(printf '%s' "${val}" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')"
-        if [[ -z "${val}" || "${val}" == "unavailable" ]]; then
-            bad_sigs=$((bad_sigs+1))
-        fi
-    done < <(printf '%s\n' "${dump_out}" | grep -F 'Sign value:')
-
-    if [[ "${bad_sigs}" -gt 0 ]]; then
-        printf '%s\n' "${dump_out}" >&2
-        die "verify failed: ${bad_sigs} signature node(s) have empty or 'unavailable' Sign value"
-    fi
-
-    VERIFY_RESULT="PASS (${match_count} signature(s) matched '${expected_algo}')"
-    log "verify: ${VERIFY_RESULT}"
-fi
-
-if [[ "${REWRITE_ONLY}" -eq 1 ]]; then
-    MODE="rewrite-only (FIT mutated, mkimage skipped)"
-else
-    MODE="signed via engine_pkcs11"
-fi
-
-echo
-echo "================ sign-fit summary ================"
-printf "  FIT image       : %s\n" "${FIT}"
-printf "  Key name hint   : %s\n" "${KEY_NAME_HINT}"
-printf "  PKCS#11 URI     : %s\n" "${URI}"
-printf "  Engine conf     : %s\n" "${ENGINE_CONF}"
-printf "  Configurations  : %d\n" "${#CONFS[@]}"
-printf "  Signature nodes : %d\n" "${TOTAL_SIGS}"
-printf "  Mode            : %s\n" "${MODE}"
-printf "  Verify          : %s\n" "${VERIFY_RESULT}"
-printf "  Timestamp       : %s\n" "$(date -u +%FT%TZ)"
-echo "=================================================="
+exec python3 "${PY_TOOL}" sign-fit "${args[@]+"${args[@]}"}"

--- a/scripts/sign_fit.py
+++ b/scripts/sign_fit.py
@@ -1,0 +1,915 @@
+#!/usr/bin/env python3
+"""sign_fit.py — sign U-Boot FIT images via mkimage + engine_pkcs11.
+
+Subcommands:
+    sign-fit         Sign a raw fitImage in place.
+    sign-bootfiles   Sign the fitImage inside a bootfiles-fit.tar.gz archive.
+    verify           fit_check_sign cryptographic verify against a DTB.
+    print-profile    Print a resolved profile (diagnostic; no signing).
+
+Profiles live in `scripts/fit-signing-profiles.yml` (or the file pointed
+at by --profile-config / IOTGW_FIT_SIGNING_PROFILES). Each profile maps a
+short name (yubikey-9a, softhsm-dev) to a (key-name-hint, URI, engine
+config) tuple. Explicit --key-name-hint / --uri / --engine-conf flags
+override the profile.
+
+mkimage 2025.04 quirks worked around here:
+  - `-G` is silently ignored in the `-N pkcs11` code path; the tool
+    always uses `-k <URI>` with a URI that must contain `object=`.
+  - `mkimage -F -N pkcs11 <fit>` without a working keydir is a silent
+    no-op (FIT repacked, signature bytes intact). This tool requires at
+    least one `Signature written` line in mkimage's output before
+    declaring success.
+
+Slot-anchored URIs (pkcs11:id=...) are out of scope — they require a
+signer that calls OpenSSL directly rather than through mkimage's
+-N pkcs11 path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import logging
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.parse
+from typing import Iterable, Optional, Sequence
+
+try:
+    import yaml
+except ImportError as e:
+    sys.stderr.write(
+        "sign_fit: PyYAML is required (Debian/Ubuntu: apt install python3-yaml; "
+        "Fedora: dnf install python3-pyyaml; pip: pip install pyyaml)\n"
+    )
+    raise
+
+log = logging.getLogger("sign_fit")
+
+SCRIPT_DIR = pathlib.Path(__file__).resolve().parent
+DEFAULT_PROFILE_CONFIG = SCRIPT_DIR / "fit-signing-profiles.yml"
+DEFAULT_BOOTFILES_ARCHIVE = pathlib.Path(
+    "build/tmp-glibc/deploy/images/raspberrypi5/bootfiles-fit.tar.gz"
+)
+
+
+class SignFitError(Exception):
+    """Raised for any user-visible failure."""
+
+
+def die(msg: str) -> "NoReturn":  # type: ignore[name-defined]
+    log.error(msg)
+    sys.exit(1)
+
+
+# ---------------------------------------------------------------------------
+# Profile loading
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass(frozen=True)
+class Profile:
+    name: str
+    key_name_hint: str
+    uri: str
+    engine_conf: pathlib.Path
+
+    @classmethod
+    def from_dict(cls, name: str, d: dict, *, engine_conf_override: Optional[pathlib.Path] = None) -> "Profile":
+        try:
+            engine_conf = engine_conf_override or pathlib.Path(
+                os.path.expanduser(d["engine_conf"])
+            )
+            return cls(
+                name=name,
+                key_name_hint=d["key_name_hint"],
+                uri=d["uri"],
+                engine_conf=engine_conf,
+            )
+        except KeyError as e:
+            raise SignFitError(
+                f"profile '{name}' missing required field: {e.args[0]}"
+            ) from e
+
+
+def resolve_profile_config(cli_path: Optional[str]) -> pathlib.Path:
+    if cli_path:
+        return pathlib.Path(os.path.expanduser(cli_path))
+    env = os.environ.get("IOTGW_FIT_SIGNING_PROFILES")
+    if env:
+        return pathlib.Path(os.path.expanduser(env))
+    return DEFAULT_PROFILE_CONFIG
+
+
+def load_profiles(config_path: pathlib.Path) -> dict[str, dict]:
+    if not config_path.is_file():
+        raise SignFitError(f"profile config not found: {config_path}")
+    with config_path.open("r") as f:
+        try:
+            data = yaml.safe_load(f) or {}
+        except yaml.YAMLError as e:
+            raise SignFitError(f"YAML parse error in {config_path}: {e}") from e
+    profiles = data.get("fit_signing_profiles", {})
+    if not profiles:
+        raise SignFitError(
+            f"no fit_signing_profiles entries in {config_path}"
+        )
+    return profiles
+
+
+def build_profile(
+    *,
+    name: Optional[str],
+    config_path: pathlib.Path,
+    key_name_hint_override: Optional[str],
+    uri_override: Optional[str],
+    engine_conf_override: Optional[str],
+    key_label_legacy: Optional[str] = None,
+) -> Profile:
+    """Resolve a profile from config + per-flag overrides.
+
+    If --profile is not given, all three of --key-name-hint / --uri /
+    --engine-conf must be supplied explicitly. --key-label is a
+    deprecated alias that pre-dates the hint/URI split: it sets the
+    FIT key-name-hint AND, if --uri is not supplied, derives the URI
+    as pkcs11:object=<urlencoded label>. Combining --key-label with
+    --key-name-hint is a fatal error.
+    """
+    if key_label_legacy is not None:
+        log.warning(
+            "--key-label is deprecated; use --key-name-hint (and --uri) explicitly"
+        )
+        if key_name_hint_override is not None:
+            raise SignFitError(
+                "--key-label and --key-name-hint are mutually exclusive"
+            )
+        key_name_hint_override = key_label_legacy
+        if uri_override is None:
+            uri_override = (
+                "pkcs11:object=" + urllib.parse.quote(key_label_legacy, safe="")
+            )
+
+    if name:
+        profiles = load_profiles(config_path)
+        if name not in profiles:
+            available = ", ".join(sorted(profiles.keys())) or "(none)"
+            raise SignFitError(
+                f"unknown profile: {name!r}; available: {available}"
+            )
+        engine_conf = (
+            pathlib.Path(os.path.expanduser(engine_conf_override))
+            if engine_conf_override
+            else None
+        )
+        base = Profile.from_dict(name, profiles[name], engine_conf_override=engine_conf)
+    else:
+        missing = [
+            flag
+            for flag, val in [
+                ("--key-name-hint", key_name_hint_override),
+                ("--uri", uri_override),
+                ("--engine-conf", engine_conf_override),
+            ]
+            if not val
+        ]
+        if missing:
+            raise SignFitError(
+                "either --profile or all of "
+                "--key-name-hint/--uri/--engine-conf are required; missing: "
+                + ", ".join(missing)
+            )
+        base = Profile(
+            name="(explicit)",
+            key_name_hint=key_name_hint_override,
+            uri=uri_override,
+            engine_conf=pathlib.Path(os.path.expanduser(engine_conf_override)),
+        )
+
+    # Per-flag overrides on top of profile values
+    return Profile(
+        name=base.name,
+        key_name_hint=key_name_hint_override or base.key_name_hint,
+        uri=uri_override or base.uri,
+        engine_conf=(
+            pathlib.Path(os.path.expanduser(engine_conf_override))
+            if engine_conf_override
+            else base.engine_conf
+        ),
+    )
+
+
+def validate_profile(profile: Profile, *, require_engine_conf: bool = True) -> None:
+    if "object=" not in profile.uri:
+        raise SignFitError(
+            f"URI must contain 'object=<libykcs11-label>' "
+            f"(mkimage 2025.04's -N pkcs11 path rewrites URIs without object= "
+            f"into a non-matching synthesized URI). got: {profile.uri}"
+        )
+    if not profile.uri.startswith("pkcs11:"):
+        raise SignFitError(f"URI must start with 'pkcs11:': {profile.uri}")
+    if require_engine_conf and not profile.engine_conf.is_file():
+        raise SignFitError(f"engine conf not found: {profile.engine_conf}")
+
+
+# ---------------------------------------------------------------------------
+# Tool discovery
+# ---------------------------------------------------------------------------
+
+
+def require_tool(name: str) -> str:
+    path = shutil.which(name)
+    if not path:
+        raise SignFitError(f"required tool missing on PATH: {name}")
+    return path
+
+
+def find_fit_check_sign(cli_path: Optional[str]) -> str:
+    if cli_path:
+        if not pathlib.Path(cli_path).is_file():
+            raise SignFitError(
+                f"fit_check_sign not at --fit-check-sign-path: {cli_path}"
+            )
+        return cli_path
+    env = os.environ.get("IOTGW_FIT_CHECK_SIGN")
+    if env:
+        if not pathlib.Path(env).is_file():
+            raise SignFitError(
+                f"fit_check_sign not at IOTGW_FIT_CHECK_SIGN: {env}"
+            )
+        return env
+    on_path = shutil.which("fit_check_sign")
+    if on_path:
+        return on_path
+
+    # Project-local discovery: the build sysroot installs fit_check_sign
+    # via meta-iot-gateway's u-boot-tools_%.bbappend. Walk the most
+    # common project-build paths.
+    project_root = pathlib.Path.cwd()
+    candidates: list[pathlib.Path] = []
+    candidates.extend(
+        sorted(
+            project_root.glob(
+                "build/tmp-glibc/work/x86_64-linux/u-boot-tools-native/*/"
+                "recipe-sysroot-native/usr/bin/fit_check_sign"
+            )
+        )
+    )
+    candidates.extend(
+        sorted(
+            project_root.glob(
+                "build/tmp-glibc/sysroots-components/x86_64/u-boot-tools-native/"
+                "usr/bin/fit_check_sign"
+            )
+        )
+    )
+    for c in candidates:
+        if c.is_file():
+            return str(c)
+
+    raise SignFitError(
+        "fit_check_sign not found. Install u-boot-tools that ship it, "
+        "or point to the project build sysroot:\n"
+        "  export IOTGW_FIT_CHECK_SIGN=$(find build -name fit_check_sign | head -1)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# FIT signing
+# ---------------------------------------------------------------------------
+
+
+def _list_subnodes(fit: pathlib.Path, node: str) -> list[str]:
+    """fdtget -l <fit> <node> as a list of children names."""
+    fdtget = require_tool("fdtget")
+    result = subprocess.run(
+        [fdtget, "-l", str(fit), node],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SignFitError(
+            f"fdtget -l failed on {node}: {result.stderr.strip()}"
+        )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _rewrite_key_name_hints(fit: pathlib.Path, key_name_hint: str) -> int:
+    """Walk /configurations/*/signature* and set key-name-hint. Returns count."""
+    fdtput = require_tool("fdtput")
+    confs = _list_subnodes(fit, "/configurations")
+    if not confs:
+        raise SignFitError(f"no /configurations subnodes in {fit}")
+    total = 0
+    for conf in confs:
+        children = _list_subnodes(fit, f"/configurations/{conf}")
+        sig_count = 0
+        for child in children:
+            if not child.startswith("signature"):
+                continue
+            path = f"/configurations/{conf}/{child}"
+            r = subprocess.run(
+                [fdtput, "-t", "s", str(fit), path, "key-name-hint", key_name_hint],
+                capture_output=True,
+                text=True,
+            )
+            if r.returncode != 0:
+                raise SignFitError(
+                    f"fdtput failed on {path}: {r.stderr.strip()}"
+                )
+            sig_count += 1
+            total += 1
+        if sig_count == 0:
+            raise SignFitError(
+                f"no signature* nodes under /configurations/{conf}"
+            )
+    log.info(
+        "rewrote key-name-hint to %r on %d signature node(s) across %d configuration(s)",
+        key_name_hint,
+        total,
+        len(confs),
+    )
+    return total
+
+
+def _run_mkimage_sign(fit: pathlib.Path, profile: Profile, *, verbose: bool) -> int:
+    """Invoke mkimage -F -N pkcs11 -k <URI> <fit>. Returns number of `Signature written` lines."""
+    mkimage = require_tool("mkimage")
+    log.info("signing FIT via engine_pkcs11 (PIN/touch may be required)")
+    log.info("  URI: %s", profile.uri)
+
+    env = os.environ.copy()
+    env["OPENSSL_CONF"] = str(profile.engine_conf)
+
+    # U-Boot 2025.04 ignores -G/keyfile in the pkcs11 RSA path.
+    # Passing -k pkcs11:object=<label> is the only way to decouple
+    # private-key lookup from the FIT key-name-hint.
+    cmd = [mkimage, "-F", "-N", "pkcs11", "-k", profile.uri, str(fit)]
+
+    # Always capture mkimage output. PIN prompts from engine_pkcs11 are
+    # written by OpenSSL's UI to /dev/tty and bypass stdout/stderr
+    # redirection, so capturing here does not silence the PIN prompt.
+    # Capturing is mandatory for the silent-no-op guard (the
+    # `Signature written` line is the authoritative success signal).
+    # In verbose mode we additionally tee the captured output to stderr
+    # so the operator sees what mkimage produced.
+    result = subprocess.run(cmd, env=env, capture_output=True, text=True)
+
+    if verbose:
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+
+    def _dump_for_diagnostics() -> None:
+        # When --verbose already showed the output, skip the framed
+        # second copy to keep the terminal readable.
+        if verbose:
+            return
+        sys.stderr.write("---- mkimage output ----\n")
+        sys.stderr.write(result.stdout)
+        sys.stderr.write(result.stderr)
+        sys.stderr.write("------------------------\n")
+
+    if result.returncode != 0:
+        _dump_for_diagnostics()
+        raise SignFitError(f"mkimage -F failed (exit {result.returncode})")
+
+    sig_written = sum(1 for line in result.stdout.splitlines() if "Signature written" in line)
+    if sig_written == 0:
+        _dump_for_diagnostics()
+        raise SignFitError(
+            "mkimage exited 0 but emitted no 'Signature written' line — "
+            "signing was a silent no-op (check engine config and that -k "
+            "carries a 'pkcs11:object=<label>' URI)"
+        )
+    log.info("mkimage signed (%d 'Signature written' line(s) observed)", sig_written)
+    return sig_written
+
+
+def _structural_verify(fit: pathlib.Path, profile: Profile, total_sigs: int) -> str:
+    """Replicate sign-fit.sh's --verify check: dumpimage -l audit on each sig node."""
+    dumpimage = require_tool("dumpimage")
+    expected_algo = f"sha256,rsa2048:{profile.key_name_hint}"
+    result = subprocess.run(
+        [dumpimage, "-l", str(fit)],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise SignFitError(
+            f"dumpimage failed during verify: {result.stderr.strip()}"
+        )
+    out = result.stdout
+    algo_lines = [l for l in out.splitlines() if "Sign algo:" in l]
+    match_count = sum(1 for l in algo_lines if expected_algo in l)
+    if len(algo_lines) < total_sigs or match_count < total_sigs:
+        sys.stderr.write(out)
+        raise SignFitError(
+            f"verify failed: expected {total_sigs} signature(s) with algo "
+            f"{expected_algo!r}, found {match_count}"
+        )
+    bad_sigs = 0
+    for line in out.splitlines():
+        if "Sign value:" in line:
+            val = line.split("Sign value:", 1)[1].strip()
+            if not val or val == "unavailable":
+                bad_sigs += 1
+    if bad_sigs:
+        sys.stderr.write(out)
+        raise SignFitError(
+            f"verify failed: {bad_sigs} signature node(s) have empty or 'unavailable' Sign value"
+        )
+    msg = f"PASS ({match_count} signature(s) matched {expected_algo!r})"
+    log.info("verify: %s", msg)
+    return msg
+
+
+def sign_fit_file(
+    fit: pathlib.Path,
+    profile: Profile,
+    *,
+    verify: bool,
+    rewrite_only: bool,
+    verbose: bool,
+) -> dict:
+    """Top-level: backup, rewrite hints, sign, optional verify. Returns summary dict."""
+    if not fit.is_file():
+        raise SignFitError(f"fitImage not found: {fit}")
+    if not os.access(fit, os.W_OK):
+        raise SignFitError(f"fitImage not writable: {fit}")
+    fit_dir = fit.parent
+    if not os.access(fit_dir, os.W_OK):
+        raise SignFitError(f"cannot write backup next to {fit} (directory not writable)")
+
+    # Tool presence checks for the planned operation set.
+    for tool in ("fdtget", "fdtput", "mkimage"):
+        require_tool(tool)
+    if not rewrite_only or verify:
+        require_tool("dumpimage")
+
+    backup = fit.with_suffix(fit.suffix + ".bak")
+    shutil.copy2(fit, backup)
+    mutated = False
+    try:
+        total_sigs = _rewrite_key_name_hints(fit, profile.key_name_hint)
+        mutated = True
+
+        verify_result = "skipped"
+        if rewrite_only:
+            log.info("rewrite-only: FIT key-name-hint rewritten in place; skipping mkimage")
+            mode = "rewrite-only (FIT mutated, mkimage skipped)"
+        else:
+            _run_mkimage_sign(fit, profile, verbose=verbose)
+            mode = "signed via engine_pkcs11"
+            if verify:
+                verify_result = _structural_verify(fit, profile, total_sigs)
+
+        return {
+            "fit": str(fit),
+            "key_name_hint": profile.key_name_hint,
+            "uri": profile.uri,
+            "engine_conf": str(profile.engine_conf),
+            "configurations": len(_list_subnodes(fit, "/configurations")),
+            "signature_nodes": total_sigs,
+            "mode": mode,
+            "verify": verify_result,
+        }
+    except Exception:
+        if mutated and backup.is_file():
+            try:
+                shutil.copy2(backup, fit)
+                log.warning("restored %s from %s after failure", fit, backup)
+            except Exception as restore_err:
+                log.error(
+                    "FAILED to restore %s from %s — inspect manually: %s",
+                    fit,
+                    backup,
+                    restore_err,
+                )
+        raise
+    finally:
+        backup.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# bootfiles-fit.tar.gz handling
+# ---------------------------------------------------------------------------
+
+
+def _sha256(p: pathlib.Path) -> str:
+    import hashlib
+
+    h = hashlib.sha256()
+    with p.open("rb") as f:
+        for chunk in iter(lambda: f.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _peek_inner_fit_algo_status(
+    archive: pathlib.Path, expected_algo: str
+) -> tuple[int, int]:
+    """Return (total_algo_lines, matching_count) without mutating the archive."""
+    dumpimage = require_tool("dumpimage")
+    with tempfile.TemporaryDirectory(prefix="sign-bootfiles-peek-") as td:
+        try:
+            with tarfile.open(archive, "r:gz") as tf:
+                try:
+                    # `filter='data'` rejects absolute paths, .. traversal,
+                    # special files, etc. — Python 3.12+ tarfile safety
+                    # default (PEP 706).
+                    tf.extract("./fitImage", td, filter="data")
+                except KeyError:
+                    return (0, 0)
+        except tarfile.TarError:
+            return (0, 0)
+        fit_path = pathlib.Path(td) / "fitImage"
+        if not fit_path.is_file():
+            return (0, 0)
+        result = subprocess.run(
+            [dumpimage, "-l", str(fit_path)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            return (0, 0)
+        algo_lines = [l for l in result.stdout.splitlines() if "Sign algo:" in l]
+        return (len(algo_lines), sum(1 for l in algo_lines if expected_algo in l))
+
+
+def sign_bootfiles_archive(
+    archive: pathlib.Path,
+    profile: Profile,
+    *,
+    force: bool,
+    verify: bool,
+    verbose: bool,
+) -> dict:
+    """Extract → sign inner FIT → repack."""
+    if not archive.is_file():
+        raise SignFitError(f"archive not found: {archive}")
+    if not os.access(archive, os.W_OK):
+        raise SignFitError(f"archive not writable: {archive}")
+    archive = archive.resolve()
+    archive_dir = archive.parent
+    if not os.access(archive_dir, os.W_OK):
+        raise SignFitError(f"archive directory not writable: {archive_dir}")
+
+    require_tool("tar")
+    require_tool("dumpimage")
+
+    expected_algo = f"sha256,rsa2048:{profile.key_name_hint}"
+    pre_sha = _sha256(archive)
+    log.info("archive: %s", archive)
+    log.info("pre  sha256: %s", pre_sha)
+
+    if not force:
+        total, match = _peek_inner_fit_algo_status(archive, expected_algo)
+        if total > 0 and match == total:
+            log.info(
+                "all %d signature node(s) in inner FIT already labelled %r; "
+                "skipping (use --force to re-sign)",
+                total,
+                expected_algo,
+            )
+            return {
+                "archive": str(archive),
+                "pre_sha": pre_sha,
+                "post_sha": pre_sha,
+                "inner_fit_algo": expected_algo,
+                "inner_fit_total": total,
+                "mode": "skipped (already labelled)",
+            }
+        if total > 0 and 0 < match < total:
+            log.info(
+                "inner FIT is partially labelled (%d of %d match %r); "
+                "proceeding to re-sign all",
+                match,
+                total,
+                expected_algo,
+            )
+
+    backup = archive.with_suffix(archive.suffix + ".bak")
+    shutil.copy2(archive, backup)
+    mutated = False
+    tmpdir = tempfile.mkdtemp(prefix="sign-bootfiles-fit.")
+    try:
+        log.info("extracting into %s", tmpdir)
+        with tarfile.open(archive, "r:gz") as tf:
+            # `filter='data'` is PEP 706's safe default: rejects
+            # absolute paths, parent-dir traversal, devices, setuid,
+            # symlinks pointing outside the destination. The bootfiles
+            # archive is Yocto-produced and trusted, but the filter
+            # costs nothing and protects against future supply-chain
+            # surprises.
+            tf.extractall(tmpdir, filter="data")
+        extracted_fit = pathlib.Path(tmpdir) / "fitImage"
+        if not extracted_fit.is_file():
+            raise SignFitError(f"fitImage not found in archive (looked at {extracted_fit})")
+
+        log.info("invoking signing on extracted fitImage")
+        mutated = True
+        sign_fit_file(
+            extracted_fit,
+            profile,
+            verify=verify,
+            rewrite_only=False,
+            verbose=verbose,
+        )
+
+        log.info("repacking %s", archive)
+        new_archive = archive.with_suffix(archive.suffix + ".new")
+        # Match the original layout (entries start with `./`).
+        with tarfile.open(new_archive, "w:gz") as tf:
+            for entry in sorted(pathlib.Path(tmpdir).iterdir()):
+                tf.add(entry, arcname=f"./{entry.name}")
+        new_archive.replace(archive)
+
+        post_sha = _sha256(archive)
+        log.info("post sha256: %s", post_sha)
+        if pre_sha == post_sha:
+            raise SignFitError(
+                "archive SHA unchanged after repack — signing likely no-op'd"
+            )
+
+        return {
+            "archive": str(archive),
+            "pre_sha": pre_sha,
+            "post_sha": post_sha,
+            "inner_fit_algo": expected_algo,
+            "mode": "signed",
+        }
+    except Exception:
+        if mutated and backup.is_file():
+            try:
+                shutil.copy2(backup, archive)
+                log.warning("restored %s from %s after failure", archive, backup)
+            except Exception as restore_err:
+                log.error(
+                    "FAILED to restore %s from %s — inspect manually: %s",
+                    archive,
+                    backup,
+                    restore_err,
+                )
+        raise
+    finally:
+        backup.unlink(missing_ok=True)
+        shutil.rmtree(tmpdir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# fit_check_sign verify
+# ---------------------------------------------------------------------------
+
+
+def crypto_verify_fit(fit: pathlib.Path, dtb: pathlib.Path, *, tool: str) -> dict:
+    """Run fit_check_sign -f <fit> -k <dtb> for real RSA verify."""
+    if not fit.is_file():
+        raise SignFitError(f"fitImage not found: {fit}")
+    if not dtb.is_file():
+        raise SignFitError(f"DTB not found: {dtb}")
+
+    log.info("crypto-verifying %s against %s", fit, dtb)
+    log.info("  fit_check_sign: %s", tool)
+    result = subprocess.run(
+        [tool, "-f", str(fit), "-k", str(dtb)],
+        capture_output=True,
+        text=True,
+    )
+    output = result.stdout + result.stderr
+    if result.returncode != 0:
+        sys.stderr.write(output)
+        raise SignFitError(f"fit_check_sign failed (exit {result.returncode})")
+    log.info("verify: PASS")
+    return {
+        "fit": str(fit),
+        "dtb": str(dtb),
+        "tool": tool,
+        "output": output.strip(),
+        "result": "PASS",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Subcommand handlers
+# ---------------------------------------------------------------------------
+
+
+def _print_summary(title: str, fields: dict) -> None:
+    sys.stdout.write("\n")
+    sys.stdout.write(f"================ {title} ================\n")
+    for k, v in fields.items():
+        sys.stdout.write(f"  {k:<16}: {v}\n")
+    sys.stdout.write("=" * (len(title) + 34) + "\n")
+
+
+def cmd_sign_fit(args: argparse.Namespace) -> int:
+    config_path = resolve_profile_config(args.profile_config)
+    profile = build_profile(
+        name=args.profile,
+        config_path=config_path,
+        key_name_hint_override=args.key_name_hint,
+        uri_override=args.uri,
+        engine_conf_override=args.engine_conf,
+        key_label_legacy=args.key_label,
+    )
+    validate_profile(profile, require_engine_conf=not args.rewrite_only)
+    summary = sign_fit_file(
+        pathlib.Path(args.fit),
+        profile,
+        verify=args.verify,
+        rewrite_only=args.rewrite_only,
+        verbose=args.verbose,
+    )
+    _print_summary("sign-fit summary", summary)
+    return 0
+
+
+def cmd_sign_bootfiles(args: argparse.Namespace) -> int:
+    config_path = resolve_profile_config(args.profile_config)
+    profile = build_profile(
+        name=args.profile,
+        config_path=config_path,
+        key_name_hint_override=args.key_name_hint,
+        uri_override=args.uri,
+        engine_conf_override=args.engine_conf,
+        key_label_legacy=args.key_label,
+    )
+    validate_profile(profile, require_engine_conf=True)
+    archive = pathlib.Path(args.archive) if args.archive else DEFAULT_BOOTFILES_ARCHIVE
+    summary = sign_bootfiles_archive(
+        archive,
+        profile,
+        force=args.force,
+        verify=args.verify,
+        verbose=args.verbose,
+    )
+    _print_summary("sign-bootfiles summary", summary)
+    if "post_sha" in summary and summary["post_sha"] != summary["pre_sha"]:
+        sys.stdout.write(
+            "\nNext step: re-drive the bundle recipe so it picks up the new\n"
+            "tarball. With this project's KAS+make wrapper, that is:\n"
+            "  make bundle-dev-full-fit-resign\n"
+        )
+    return 0
+
+
+def cmd_verify(args: argparse.Namespace) -> int:
+    tool = find_fit_check_sign(args.fit_check_sign_path)
+    summary = crypto_verify_fit(
+        pathlib.Path(args.fit),
+        pathlib.Path(args.dtb),
+        tool=tool,
+    )
+    _print_summary("verify summary", summary)
+    return 0
+
+
+def cmd_print_profile(args: argparse.Namespace) -> int:
+    config_path = resolve_profile_config(args.profile_config)
+    profile = build_profile(
+        name=args.profile,
+        config_path=config_path,
+        key_name_hint_override=args.key_name_hint,
+        uri_override=args.uri,
+        engine_conf_override=args.engine_conf,
+        key_label_legacy=args.key_label,
+    )
+    # Don't validate engine_conf existence here; --print-profile is a
+    # diagnostic and may be useful even when the engine config is
+    # not yet on disk.
+    sys.stdout.write(f"profile        : {profile.name}\n")
+    sys.stdout.write(f"key_name_hint  : {profile.key_name_hint}\n")
+    sys.stdout.write(f"uri            : {profile.uri}\n")
+    sys.stdout.write(f"engine_conf    : {profile.engine_conf}\n")
+    sys.stdout.write(f"config_source  : {config_path}\n")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Argparse wiring
+# ---------------------------------------------------------------------------
+
+
+def _add_profile_args(sp: argparse.ArgumentParser) -> None:
+    sp.add_argument(
+        "--profile",
+        help="Signing profile name from the profile config (e.g. yubikey-9a, softhsm-dev).",
+    )
+    sp.add_argument(
+        "--profile-config",
+        help=(
+            "Path to a YAML profile file. Defaults to scripts/fit-signing-profiles.yml "
+            "or $IOTGW_FIT_SIGNING_PROFILES if set."
+        ),
+    )
+    sp.add_argument(
+        "--key-name-hint",
+        help="Override profile's FIT key-name-hint.",
+    )
+    sp.add_argument(
+        "--uri",
+        help="Override profile's PKCS#11 URI (must contain object=<label>).",
+    )
+    sp.add_argument(
+        "--engine-conf",
+        help="Override profile's OpenSSL engine_pkcs11 config path.",
+    )
+    sp.add_argument(
+        "--key-label",
+        help=(
+            "DEPRECATED alias: sets --key-name-hint and, if --uri is not given, "
+            "derives uri=pkcs11:object=<urlencoded NAME>. Mutually exclusive "
+            "with --key-name-hint."
+        ),
+    )
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="sign_fit.py",
+        description=__doc__.split("\n\n", 1)[0],
+    )
+    p.add_argument("-v", "--verbose-log", action="store_true", help="Debug logging.")
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    sp_sign = sub.add_parser("sign-fit", help="Sign a raw fitImage in place.")
+    _add_profile_args(sp_sign)
+    sp_sign.add_argument("--fit", required=True, help="Path to fitImage.")
+    sp_sign.add_argument(
+        "--verify",
+        action="store_true",
+        help="Run structural audit (not crypto) after signing.",
+    )
+    sp_sign.add_argument(
+        "--rewrite-only",
+        action="store_true",
+        help="Rewrite key-name-hint and stop before mkimage. The FIT is still mutated.",
+    )
+    sp_sign.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Forward mkimage's full stdout to the terminal (disables silent no-op detection).",
+    )
+    sp_sign.set_defaults(func=cmd_sign_fit)
+
+    sp_arch = sub.add_parser(
+        "sign-bootfiles",
+        help="Sign the fitImage inside a bootfiles-fit.tar.gz archive.",
+    )
+    _add_profile_args(sp_arch)
+    sp_arch.add_argument(
+        "--archive",
+        help=f"Path to bootfiles-fit.tar.gz. Default: {DEFAULT_BOOTFILES_ARCHIVE}",
+    )
+    sp_arch.add_argument(
+        "--force",
+        action="store_true",
+        help="Re-sign even when the inner FIT already advertises the expected algo.",
+    )
+    sp_arch.add_argument("--verify", action="store_true", help="Structural verify after signing.")
+    sp_arch.add_argument("--verbose", action="store_true", help="Forward mkimage stdout.")
+    sp_arch.set_defaults(func=cmd_sign_bootfiles)
+
+    sp_verify = sub.add_parser(
+        "verify",
+        help="Run fit_check_sign for cryptographic verification against a DTB.",
+    )
+    sp_verify.add_argument("--fit", required=True, help="Path to fitImage.")
+    sp_verify.add_argument("--dtb", required=True, help="Path to DTB carrying the pubkey.")
+    sp_verify.add_argument(
+        "--fit-check-sign-path",
+        help="Override the fit_check_sign binary location.",
+    )
+    sp_verify.set_defaults(func=cmd_verify)
+
+    sp_print = sub.add_parser(
+        "print-profile",
+        help="Resolve a profile (with overrides) and print it. No signing.",
+    )
+    _add_profile_args(sp_print)
+    sp_print.set_defaults(func=cmd_print_profile)
+
+    return p
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose_log else logging.INFO,
+        format="%(name)s: %(message)s",
+    )
+    try:
+        return args.func(args)
+    except SignFitError as e:
+        log.error("%s", e)
+        return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/conftest.py
+++ b/scripts/tests/conftest.py
@@ -1,0 +1,426 @@
+"""Pytest fixtures for sign_fit.py tests.
+
+SoftHSM fixtures mirror the patterns from
+meta-openembedded/meta-oe/classes/signing.bbclass (workspace-isolated
+SOFTHSM2_CONF + tokendir, `db` backend, `--free` slot init) but stay
+independent of any Yocto/BitBake infrastructure — the host runs them
+directly via pytest.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+import subprocess
+import sys
+import tempfile
+import textwrap
+from typing import Optional
+
+import pytest
+
+SCRIPTS_DIR = pathlib.Path(__file__).resolve().parent.parent
+SIGN_FIT_PY = SCRIPTS_DIR / "sign_fit.py"
+
+SOFTHSM_TOKEN_LABEL = "iotgw-fit-test"
+SOFTHSM_PIN = "1234"
+SOFTHSM_SO_PIN = "123456"
+SOFTHSM_KEY_LABEL = "iotgw-fit-softhsm-dev"
+
+# Module path candidates. IOTGW_SOFTHSM_MODULE env var takes precedence
+# so a developer running against a locally-built SoftHSM 2.7.0 can
+# point the tests at it without editing files.
+SOFTHSM_MODULE_CANDIDATES = (
+    "/usr/lib/softhsm/libsofthsm2.so",
+    "/usr/lib/x86_64-linux-gnu/softhsm/libsofthsm2.so",
+    "/usr/lib/aarch64-linux-gnu/softhsm/libsofthsm2.so",
+)
+
+# OpenSSL engine_pkcs11 candidates (Debian/Ubuntu 22.04+ ships in engines-3/).
+ENGINE_PKCS11_CANDIDATES = (
+    "/usr/lib/x86_64-linux-gnu/engines-3/pkcs11.so",
+    "/usr/lib/aarch64-linux-gnu/engines-3/pkcs11.so",
+)
+
+
+def _find_module(env_var: str, candidates: tuple[str, ...]) -> Optional[str]:
+    env_val = os.environ.get(env_var, "").strip()
+    if env_val:
+        return env_val if pathlib.Path(env_val).is_file() else None
+    for c in candidates:
+        if pathlib.Path(c).is_file():
+            return c
+    return None
+
+
+def _softhsm_module() -> Optional[str]:
+    return _find_module("IOTGW_SOFTHSM_MODULE", SOFTHSM_MODULE_CANDIDATES)
+
+
+def _engine_pkcs11_module() -> Optional[str]:
+    return _find_module("IOTGW_ENGINE_PKCS11", ENGINE_PKCS11_CANDIDATES)
+
+
+def _softhsm_available() -> bool:
+    if os.environ.get("SOFTHSM_AVAILABLE", "").strip() == "0":
+        return False
+    return (
+        shutil.which("softhsm2-util") is not None
+        and shutil.which("pkcs11-tool") is not None
+        and _softhsm_module() is not None
+        and _engine_pkcs11_module() is not None
+    )
+
+
+@pytest.fixture(scope="session")
+def softhsm_workspace(tmp_path_factory):
+    """Isolated SoftHSM workspace — fresh token store per pytest session.
+
+    Skips the entire test if SoftHSM/engine_pkcs11 aren't usable. The
+    fixture leaves SOFTHSM2_CONF and the tokendir under tmp; pytest's
+    tmp_path_factory handles teardown.
+    """
+    if not _softhsm_available():
+        pytest.skip(
+            "SoftHSM/engine_pkcs11 not available — install softhsm2 + "
+            "libengine-pkcs11-openssl, or set SOFTHSM_AVAILABLE=0 to skip"
+        )
+
+    work = tmp_path_factory.mktemp("softhsm")
+    conf = work / "softhsm2.conf"
+    tokens = work / "tokens"
+    tokens.mkdir()
+    # `file` backend works on the distro SoftHSM 2.6.1 builds shipped
+    # by Debian/Ubuntu/Fedora. `db` requires SQLite compiled in, which
+    # the distro packages typically don't ship — only meta-oe's
+    # softhsm-native enables it.
+    conf.write_text(
+        f"directories.tokendir = {tokens}\nobjectstore.backend = file\n"
+    )
+
+    module = _softhsm_module()
+    env = {**os.environ, "SOFTHSM2_CONF": str(conf)}
+
+    subprocess.run(
+        [
+            "softhsm2-util",
+            "--module", module,
+            "--init-token", "--free",
+            "--label", SOFTHSM_TOKEN_LABEL,
+            "--pin", SOFTHSM_PIN,
+            "--so-pin", SOFTHSM_SO_PIN,
+        ],
+        check=True,
+        env=env,
+        capture_output=True,
+    )
+
+    return {
+        "conf": conf,
+        "module": module,
+        "engine_pkcs11_module": _engine_pkcs11_module(),
+        "token_label": SOFTHSM_TOKEN_LABEL,
+        "pin": SOFTHSM_PIN,
+        "so_pin": SOFTHSM_SO_PIN,
+        "work": work,
+        "env": {"SOFTHSM2_CONF": str(conf)},
+    }
+
+
+@pytest.fixture(scope="session")
+def softhsm_dev_key(softhsm_workspace):
+    """Generate iotgw-fit-softhsm-dev RSA-2048 keypair + self-signed cert.
+
+    Builds an OpenSSL engine_pkcs11 config pointing at the workspace's
+    SoftHSM module and uses it to self-sign a cert against the
+    on-token key. The result is what the kernel-fit recipe's
+    fdt_add_pubkey step would consume (`<keydir>/<keyname>.crt`).
+    """
+    env = {**os.environ, **softhsm_workspace["env"]}
+    work = softhsm_workspace["work"]
+
+    subprocess.run(
+        [
+            "pkcs11-tool",
+            "--module", softhsm_workspace["module"],
+            "--token-label", softhsm_workspace["token_label"],
+            "--login", "--pin", softhsm_workspace["pin"],
+            "--keypairgen", "--key-type", "rsa:2048",
+            "--label", SOFTHSM_KEY_LABEL,
+            "--id", "01",
+        ],
+        check=True,
+        env=env,
+        capture_output=True,
+    )
+
+    engine_conf = work / "openssl-engine.cnf"
+    engine_conf.write_text(
+        textwrap.dedent(
+            f"""\
+            openssl_conf = openssl_init
+
+            [openssl_init]
+            engines = engine_section
+
+            [engine_section]
+            pkcs11 = pkcs11_section
+
+            [pkcs11_section]
+            engine_id = pkcs11
+            dynamic_path = {softhsm_workspace["engine_pkcs11_module"]}
+            MODULE_PATH = {softhsm_workspace["module"]}
+            init = 0
+            """
+        )
+    )
+
+    cert_dir = work / "fit"
+    cert_dir.mkdir(exist_ok=True)
+    cert_path = cert_dir / f"{SOFTHSM_KEY_LABEL}.crt"
+    sign_uri = (
+        f"pkcs11:token={softhsm_workspace['token_label']};"
+        f"object={SOFTHSM_KEY_LABEL};type=private;"
+        f"pin-value={softhsm_workspace['pin']}"
+    )
+    subprocess.run(
+        [
+            "openssl", "req", "-new", "-x509",
+            "-engine", "pkcs11", "-keyform", "engine",
+            "-key", sign_uri,
+            "-days", "3650",
+            "-subj", f"/CN={SOFTHSM_KEY_LABEL}/O=iotgw-test",
+            "-out", str(cert_path),
+        ],
+        check=True,
+        env={**env, "OPENSSL_CONF": str(engine_conf)},
+        capture_output=True,
+    )
+
+    # Profile config the Python tool can load with --profile-config.
+    # Embed the PIN inline via pin-value= so the test doesn't prompt.
+    profile_uri = (
+        f"pkcs11:token={softhsm_workspace['token_label']};"
+        f"object={SOFTHSM_KEY_LABEL};pin-value={softhsm_workspace['pin']}"
+    )
+    profile_config = work / "test-profiles.yml"
+    profile_config.write_text(
+        textwrap.dedent(
+            f"""\
+            fit_signing_profiles:
+              softhsm-test:
+                key_name_hint: "{SOFTHSM_KEY_LABEL}"
+                uri: "{profile_uri}"
+                engine_conf: "{engine_conf}"
+            """
+        )
+    )
+
+    return {
+        "key_label": SOFTHSM_KEY_LABEL,
+        "cert_path": cert_path,
+        "engine_conf": engine_conf,
+        "profile_config": profile_config,
+        "uri": profile_uri,
+        "env": env,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixture FIT generation
+# ---------------------------------------------------------------------------
+
+
+FIXTURE_ITS = """\
+/dts-v1/;
+/ {
+    description = "test fixture FIT";
+    #address-cells = <1>;
+
+    images {
+        kernel-1 {
+            description = "kernel";
+            data = /incbin/("kernel.bin");
+            type = "kernel";
+            arch = "arm64";
+            os = "linux";
+            compression = "none";
+            load = <0x80000>;
+            entry = <0x80000>;
+            hash-1 {
+                algo = "sha256";
+            };
+        };
+        fdt-1 {
+            description = "dtb";
+            data = /incbin/("dummy.dtb");
+            type = "flat_dt";
+            arch = "arm64";
+            compression = "none";
+            hash-1 {
+                algo = "sha256";
+            };
+        };
+    };
+
+    configurations {
+        default = "conf-1";
+        conf-1 {
+            description = "conf-1";
+            kernel = "kernel-1";
+            fdt = "fdt-1";
+            signature-1 {
+                algo = "sha256,rsa2048";
+                key-name-hint = "placeholder";
+                sign-images = "kernel", "fdt";
+            };
+        };
+    };
+};
+"""
+
+FIXTURE_DTS = """\
+/dts-v1/;
+/ {
+    compatible = "test,fixture";
+    #address-cells = <1>;
+    #size-cells = <0>;
+    chosen { };
+};
+"""
+
+
+def _build_fixture_dtb(work: pathlib.Path) -> pathlib.Path:
+    """Compile FIXTURE_DTS into a tiny DTB at work/dummy.dtb."""
+    dts = work / "dummy.dts"
+    dtb = work / "dummy.dtb"
+    dts.write_text(FIXTURE_DTS)
+    subprocess.run(
+        ["dtc", "-I", "dts", "-O", "dtb", "-o", str(dtb), str(dts)],
+        check=True,
+        capture_output=True,
+    )
+    return dtb
+
+
+@pytest.fixture
+def fixture_fit(tmp_path):
+    """Build a fresh fitImage in tmp_path for each test that needs one."""
+    (tmp_path / "kernel.bin").write_bytes(b"\xAA" * 1024)
+    _build_fixture_dtb(tmp_path)
+    its = tmp_path / "test.its"
+    its.write_text(FIXTURE_ITS)
+    fit = tmp_path / "fitImage"
+    subprocess.run(
+        ["mkimage", "-f", str(its), str(fit)],
+        check=True,
+        cwd=str(tmp_path),
+        capture_output=True,
+    )
+    return fit
+
+
+@pytest.fixture
+def fixture_dtb_with_pubkey(tmp_path, softhsm_dev_key):
+    """A DTB that trusts the SoftHSM dev pubkey — for fit_check_sign verify.
+
+    Uses fdt_add_pubkey to inject the dev cert into a fresh DTB so the
+    verify subcommand has a trust root to check the signed FIT against.
+    """
+    fit_check_dtb = tmp_path / "trust.dtb"
+    # Start from the same minimal DTS.
+    dts = tmp_path / "trust.dts"
+    dts.write_text(FIXTURE_DTS)
+    subprocess.run(
+        ["dtc", "-I", "dts", "-O", "dtb", "-o", str(fit_check_dtb), str(dts)],
+        check=True,
+        capture_output=True,
+    )
+
+    cert_dir = softhsm_dev_key["cert_path"].parent
+    fdt_add_pubkey = _find_fdt_add_pubkey()
+    if fdt_add_pubkey is None:
+        pytest.skip(
+            "fdt_add_pubkey not found on host or in build sysroot; "
+            "set IOTGW_FIT_CHECK_SIGN/PATH or build u-boot-tools-native first"
+        )
+    subprocess.run(
+        [
+            fdt_add_pubkey,
+            "-a", "sha256,rsa2048",
+            "-k", str(cert_dir),
+            "-n", softhsm_dev_key["key_label"],
+            "-r", "conf",
+            str(fit_check_dtb),
+        ],
+        check=True,
+        capture_output=True,
+    )
+    return fit_check_dtb
+
+
+_SYSROOT_GLOBS = (
+    "build/tmp-glibc/sysroots-components/x86_64/u-boot-tools-native/"
+    "usr/bin/{tool}",
+    "build/tmp-glibc/work/x86_64-linux/u-boot-tools-native/*/"
+    "recipe-sysroot-native/usr/bin/{tool}",
+)
+
+
+def _find_in_build_sysroot(tool: str) -> Optional[str]:
+    project_root = pathlib.Path.cwd()
+    for tmpl in _SYSROOT_GLOBS:
+        for c in sorted(project_root.glob(tmpl.format(tool=tool))):
+            if c.is_file():
+                return str(c)
+    return None
+
+
+def _find_fdt_add_pubkey() -> Optional[str]:
+    """Mirror sign_fit.py's discovery: PATH → env → project build sysroot."""
+    env = os.environ.get("IOTGW_FDT_ADD_PUBKEY", "").strip()
+    if env and pathlib.Path(env).is_file():
+        return env
+    on_path = shutil.which("fdt_add_pubkey")
+    if on_path:
+        return on_path
+    return _find_in_build_sysroot("fdt_add_pubkey")
+
+
+def _find_fit_check_sign() -> Optional[str]:
+    """Equivalent discovery for fit_check_sign."""
+    env = os.environ.get("IOTGW_FIT_CHECK_SIGN", "").strip()
+    if env and pathlib.Path(env).is_file():
+        return env
+    on_path = shutil.which("fit_check_sign")
+    if on_path:
+        return on_path
+    return _find_in_build_sysroot("fit_check_sign")
+
+
+@pytest.fixture
+def fit_check_sign_tool() -> str:
+    tool = _find_fit_check_sign()
+    if tool is None:
+        pytest.skip(
+            "fit_check_sign not found on host or in build sysroot; "
+            "build u-boot-tools-native or set IOTGW_FIT_CHECK_SIGN"
+        )
+    return tool
+
+
+# ---------------------------------------------------------------------------
+# Shared command runner
+# ---------------------------------------------------------------------------
+
+
+def run_sign_fit(*args: str, env: Optional[dict] = None, check: bool = True) -> subprocess.CompletedProcess:
+    """Invoke the Python tool as a subprocess, returning the completed process."""
+    return subprocess.run(
+        [sys.executable, str(SIGN_FIT_PY), *args],
+        env={**os.environ, **(env or {})},
+        capture_output=True,
+        text=True,
+        check=check,
+    )

--- a/scripts/tests/test_sign_fit_softhsm.py
+++ b/scripts/tests/test_sign_fit_softhsm.py
@@ -1,0 +1,144 @@
+"""SoftHSM-gated integration tests for sign_fit.py.
+
+Skipped unless SoftHSM/engine_pkcs11 are usable on the host. Exercises
+the full sign + verify flow without requiring any YubiKey hardware.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import subprocess
+import sys
+
+import pytest
+
+from conftest import run_sign_fit
+
+
+def test_sign_fit_against_softhsm(fixture_fit, softhsm_dev_key):
+    """sign-fit subcommand signs a fixture FIT via the SoftHSM token."""
+    r = run_sign_fit(
+        "sign-fit",
+        "--profile", "softhsm-test",
+        "--profile-config", str(softhsm_dev_key["profile_config"]),
+        "--fit", str(fixture_fit),
+        "--verify",
+        env=softhsm_dev_key["env"],
+    )
+    assert r.returncode == 0, f"stdout: {r.stdout}\nstderr: {r.stderr}"
+    combined = r.stdout + r.stderr
+    assert "mkimage signed" in combined or "Signature written" in combined
+    assert "PASS" in combined
+
+    # The structural verify already asserted the expected algo string;
+    # cross-check via dumpimage that the FIT carries a Sign value.
+    out = subprocess.run(
+        ["dumpimage", "-l", str(fixture_fit)],
+        capture_output=True, text=True, check=True,
+    )
+    assert "sha256,rsa2048:iotgw-fit-softhsm-dev" in out.stdout
+    assert "Sign value:" in out.stdout
+
+
+def test_verify_fit_against_dtb(
+    fixture_fit, softhsm_dev_key, fixture_dtb_with_pubkey, fit_check_sign_tool,
+):
+    """verify subcommand runs fit_check_sign and accepts a properly signed FIT."""
+    # First sign the FIT with the SoftHSM key.
+    sign_result = run_sign_fit(
+        "sign-fit",
+        "--profile", "softhsm-test",
+        "--profile-config", str(softhsm_dev_key["profile_config"]),
+        "--fit", str(fixture_fit),
+        env=softhsm_dev_key["env"],
+    )
+    assert sign_result.returncode == 0, sign_result.stderr
+
+    # Then verify it against the DTB carrying the matching pubkey.
+    verify_result = run_sign_fit(
+        "verify",
+        "--fit", str(fixture_fit),
+        "--dtb", str(fixture_dtb_with_pubkey),
+        "--fit-check-sign-path", fit_check_sign_tool,
+    )
+    assert verify_result.returncode == 0, (
+        f"stdout: {verify_result.stdout}\nstderr: {verify_result.stderr}"
+    )
+    assert "PASS" in verify_result.stdout
+
+
+def test_verify_fails_on_unsigned_fit(
+    fixture_fit, fixture_dtb_with_pubkey, fit_check_sign_tool, softhsm_dev_key,
+):
+    """fit_check_sign must reject a FIT that was never signed against this key."""
+    # Don't sign — leave fixture_fit with its placeholder hint and no
+    # signature value. fit_check_sign should fail.
+    r = run_sign_fit(
+        "verify",
+        "--fit", str(fixture_fit),
+        "--dtb", str(fixture_dtb_with_pubkey),
+        "--fit-check-sign-path", fit_check_sign_tool,
+        check=False,
+    )
+    assert r.returncode != 0
+
+
+def test_sign_fit_verbose_preserves_no_op_guard(fixture_fit, softhsm_dev_key, tmp_path):
+    """--verbose must still enforce the Signature-written guard.
+
+    Re-runs the silent-no-op scenario with --verbose to confirm the
+    capture-then-tee logic does not skip the success-line check.
+    """
+    bad_cfg = tmp_path / "bad-verbose.yml"
+    bad_cfg.write_text(
+        f'''
+fit_signing_profiles:
+  bad:
+    key_name_hint: "iotgw-fit-softhsm-dev"
+    uri: "pkcs11:token=iotgw-fit-test;object=does-not-exist-verbose;pin-value=1234"
+    engine_conf: "{softhsm_dev_key['engine_conf']}"
+'''
+    )
+    r = run_sign_fit(
+        "sign-fit",
+        "--profile", "bad",
+        "--profile-config", str(bad_cfg),
+        "--fit", str(fixture_fit),
+        "--verbose",
+        env=softhsm_dev_key["env"],
+        check=False,
+    )
+    assert r.returncode == 1
+    # Verbose mode tees mkimage output, so we should see mkimage's own
+    # error trail in stderr (proves the verbose path executed).
+    assert (
+        "PKCS11" in r.stderr or "Failure" in r.stderr
+        or "Bad parameters" in r.stderr or "object not found" in r.stderr
+    ), f"verbose mode should expose mkimage output; got stderr: {r.stderr!r}"
+
+
+def test_sign_fit_silent_no_op_guard(fixture_fit, softhsm_dev_key, tmp_path):
+    """A URI that mkimage can't resolve should be detected via the
+    `Signature written` log line check, not silently succeed."""
+    # Build a profile config that points at a non-existent SoftHSM object
+    # but still passes our object= validation. mkimage will fail to find
+    # the key.
+    bad_cfg = tmp_path / "bad.yml"
+    bad_cfg.write_text(
+        f'''
+fit_signing_profiles:
+  bad:
+    key_name_hint: "iotgw-fit-softhsm-dev"
+    uri: "pkcs11:token={softhsm_dev_key['env'].get('SOFTHSM2_CONF', 'unknown')};object=does-not-exist;pin-value=1234"
+    engine_conf: "{softhsm_dev_key['engine_conf']}"
+'''
+    )
+    r = run_sign_fit(
+        "sign-fit",
+        "--profile", "bad",
+        "--profile-config", str(bad_cfg),
+        "--fit", str(fixture_fit),
+        env=softhsm_dev_key["env"],
+        check=False,
+    )
+    assert r.returncode == 1

--- a/scripts/tests/test_sign_fit_unit.py
+++ b/scripts/tests/test_sign_fit_unit.py
@@ -1,0 +1,344 @@
+"""Unit tests for sign_fit.py — exercise argparse, profile loading,
+and validation paths without needing SoftHSM or any signing token.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+import pytest
+
+from conftest import SIGN_FIT_PY, run_sign_fit
+
+
+def test_help_prints_subcommands():
+    r = run_sign_fit("--help")
+    assert "sign-fit" in r.stdout
+    assert "sign-bootfiles" in r.stdout
+    assert "verify" in r.stdout
+    assert "print-profile" in r.stdout
+
+
+def test_print_profile_yubikey(tmp_path):
+    r = run_sign_fit("print-profile", "--profile", "yubikey-9a")
+    assert r.returncode == 0
+    assert "yubikey-9a" in r.stdout
+    assert "iotgw-fit-yk-2026" in r.stdout
+    assert "pkcs11:object=Private%20key%20for%20PIV%20Authentication" in r.stdout
+
+
+def test_print_profile_softhsm(tmp_path):
+    r = run_sign_fit("print-profile", "--profile", "softhsm-dev")
+    assert r.returncode == 0
+    assert "softhsm-dev" in r.stdout
+    assert "iotgw-fit-softhsm-dev" in r.stdout
+    assert "pkcs11:object=iotgw-fit-softhsm-dev" in r.stdout
+
+
+def test_print_profile_custom_config(tmp_path):
+    cfg = tmp_path / "custom.yml"
+    cfg.write_text(
+        textwrap.dedent(
+            """\
+            fit_signing_profiles:
+              custom:
+                key_name_hint: "custom-hint"
+                uri: "pkcs11:object=custom-label"
+                engine_conf: "/tmp/does-not-need-to-exist.cnf"
+            """
+        )
+    )
+    r = run_sign_fit("print-profile", "--profile", "custom", "--profile-config", str(cfg))
+    assert r.returncode == 0
+    assert "custom-hint" in r.stdout
+    assert "custom-label" in r.stdout
+
+
+def test_unknown_profile_is_fatal():
+    r = run_sign_fit("print-profile", "--profile", "does-not-exist", check=False)
+    assert r.returncode == 1
+    assert "unknown profile" in r.stderr
+
+
+def test_explicit_overrides_without_profile(tmp_path):
+    """--key-name-hint + --uri + --engine-conf can replace --profile."""
+    r = run_sign_fit(
+        "print-profile",
+        "--key-name-hint", "manual-hint",
+        "--uri", "pkcs11:object=manual",
+        "--engine-conf", "/tmp/none.cnf",
+    )
+    assert r.returncode == 0
+    assert "manual-hint" in r.stdout
+    assert "pkcs11:object=manual" in r.stdout
+
+
+def test_missing_explicit_overrides_is_fatal():
+    """No --profile and incomplete overrides should fail clearly."""
+    r = run_sign_fit("print-profile", "--key-name-hint", "x", check=False)
+    assert r.returncode == 1
+    assert "--profile" in r.stderr or "required" in r.stderr
+
+
+def test_uri_without_object_rejected(tmp_path, fixture_fit):
+    """sign-fit must reject URIs without object= (mkimage URI synthesis trap)."""
+    r = run_sign_fit(
+        "sign-fit",
+        "--fit", str(fixture_fit),
+        "--key-name-hint", "test-key",
+        "--uri", "pkcs11:id=%01;type=private",  # missing object=
+        "--engine-conf", "/tmp/none.cnf",
+        check=False,
+    )
+    assert r.returncode == 1
+    assert "object=" in r.stderr
+
+
+def test_non_pkcs11_uri_rejected(fixture_fit):
+    r = run_sign_fit(
+        "sign-fit",
+        "--fit", str(fixture_fit),
+        "--key-name-hint", "test-key",
+        "--uri", "file:///some/path?object=x",
+        "--engine-conf", "/tmp/none.cnf",
+        check=False,
+    )
+    assert r.returncode == 1
+    assert "pkcs11:" in r.stderr
+
+
+def test_rewrite_only_mutates_fit(fixture_fit, tmp_path):
+    """--rewrite-only should change the FIT's key-name-hint but not sign."""
+    new_hint = "rewritten-hint"
+    # Use rewrite-only so we don't need an engine_conf or token. The
+    # validate path requires engine_conf only when signing.
+    r = run_sign_fit(
+        "sign-fit",
+        "--fit", str(fixture_fit),
+        "--key-name-hint", new_hint,
+        "--uri", "pkcs11:object=anything",
+        "--engine-conf", "/tmp/none.cnf",
+        "--rewrite-only",
+    )
+    assert r.returncode == 0, f"stderr: {r.stderr}\nstdout: {r.stdout}"
+
+    # Confirm the hint was rewritten via fdtget.
+    got = subprocess.run(
+        ["fdtget", str(fixture_fit), "/configurations/conf-1/signature-1", "key-name-hint"],
+        capture_output=True, text=True, check=True,
+    )
+    assert got.stdout.strip() == new_hint
+
+
+def test_fit_check_sign_discovery_via_env(tmp_path, monkeypatch):
+    """verify subcommand respects IOTGW_FIT_CHECK_SIGN override."""
+    # Provide a fake binary that doesn't exist; we just want the error
+    # to come from there (proves the env var is consulted).
+    monkeypatch.setenv("IOTGW_FIT_CHECK_SIGN", "/nonexistent/fit_check_sign")
+    r = run_sign_fit("verify", "--fit", "/tmp/x", "--dtb", "/tmp/y", check=False)
+    assert r.returncode == 1
+    assert "IOTGW_FIT_CHECK_SIGN" in r.stderr or "not at" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Shim default profile injection
+# ---------------------------------------------------------------------------
+
+
+import subprocess as _subprocess
+from conftest import SCRIPTS_DIR
+
+
+def _run_shim(shim: str, *args: str) -> _subprocess.CompletedProcess:
+    return _subprocess.run(
+        ["bash", str(SCRIPTS_DIR / shim), *args],
+        capture_output=True, text=True, check=False,
+    )
+
+
+def test_sign_fit_shim_defaults_to_yubikey_profile(tmp_path):
+    """`sign-fit.sh --fit <missing>` must fail on FIT lookup, not on missing profile.
+
+    Reproduces the legacy invocation pattern: a bare shim call with no
+    --profile and no signing-identity flags should resolve to the
+    YubiKey slot 9a profile by default. Reaching the FIT-lookup stage
+    proves the profile loaded; failing earlier (e.g. "either --profile
+    or ... required") would mean the default was never injected.
+    """
+    missing = tmp_path / "nonexistent-fit"
+    r = _run_shim("sign-fit.sh", "--fit", str(missing))
+    assert r.returncode == 1
+    assert "fitImage not found" in r.stderr
+    # Negative assertion: the build_profile "required-flags-missing"
+    # error must NOT have triggered.
+    assert "either --profile" not in r.stderr
+
+
+def test_sign_bootfiles_shim_defaults_to_yubikey_profile(tmp_path):
+    """`sign-bootfiles-fit.sh -- --verify` with no archive must fail on archive lookup."""
+    missing_archive = tmp_path / "nonexistent.tar.gz"
+    r = _run_shim(
+        "sign-bootfiles-fit.sh",
+        "--archive", str(missing_archive),
+        "--", "--verify",
+    )
+    assert r.returncode == 1
+    assert "archive not found" in r.stderr
+
+
+def _assert_explicit_profile_not_overridden(stderr: str) -> None:
+    """Structural invariants for explicit --profile shim test cases.
+
+    Tests must not assume the host's SoftHSM provisioning state. The
+    only things we can portably assert:
+      - the failure must not be "either --profile or … required"
+        (that would mean the shim stripped --profile and failed to
+        inject any default either)
+      - the failure must not mention the yubikey-9a engine_conf path
+        (that would mean the shim wrongly injected --profile
+        yubikey-9a on top of the explicit profile)
+      - the failure must be one of the two benign downstream errors:
+        missing FIT (engine_conf exists) or missing engine_conf (no
+        SoftHSM provisioned). Either proves the profile loaded and
+        validation got past the URI/profile stage.
+    """
+    assert "either --profile" not in stderr, (
+        f"explicit --profile was dropped before reaching Python; stderr: {stderr!r}"
+    )
+    assert "rauc-ca/fit/openssl-engine.cnf" not in stderr, (
+        f"yubikey-9a engine_conf path appeared — shim injected the wrong default; "
+        f"stderr: {stderr!r}"
+    )
+    assert "fitImage not found" in stderr or "engine conf not found" in stderr, (
+        f"expected benign downstream failure, got: {stderr!r}"
+    )
+
+
+def test_shim_respects_explicit_profile(tmp_path):
+    """`--profile softhsm-dev` must reach Python without yubikey-9a injection."""
+    missing = tmp_path / "nonexistent-fit"
+    r = _run_shim(
+        "sign-fit.sh",
+        "--profile", "softhsm-dev",
+        "--fit", str(missing),
+    )
+    assert r.returncode == 1
+    _assert_explicit_profile_not_overridden(r.stderr)
+
+
+def test_shim_respects_explicit_profile_eq(tmp_path):
+    """Same as above but with the `--profile=NAME` long-option form."""
+    missing = tmp_path / "nonexistent-fit"
+    r = _run_shim(
+        "sign-fit.sh",
+        "--profile=softhsm-dev",
+        "--fit", str(missing),
+    )
+    assert r.returncode == 1
+    _assert_explicit_profile_not_overridden(r.stderr)
+
+
+def test_shim_partial_override_engine_conf(tmp_path):
+    """`--engine-conf <path>` alone must inherit the yubikey-9a profile's other fields.
+
+    Old bash behavior: a caller could override just engine_conf and
+    keep the default key hint + URI. With the shim always injecting
+    `--profile yubikey-9a`, Python applies engine_conf as a per-field
+    override on top, then proceeds to FIT validation.
+    """
+    missing = tmp_path / "nonexistent-fit"
+    fake_engine = tmp_path / "fake-engine.cnf"
+    fake_engine.write_text("# placeholder\n")  # exists so engine_conf validation passes
+    r = _run_shim(
+        "sign-fit.sh",
+        "--engine-conf", str(fake_engine),
+        "--fit", str(missing),
+    )
+    assert r.returncode == 1
+    # Must fail on the missing FIT, NOT on "profile required" or
+    # "either --profile or ... required".
+    assert "fitImage not found" in r.stderr, (
+        f"partial --engine-conf override regressed; stderr: {r.stderr!r}"
+    )
+
+
+def test_shim_partial_override_uri(tmp_path):
+    """`--uri <pkcs11:object=...>` alone must inherit the yubikey-9a profile's other fields."""
+    missing = tmp_path / "nonexistent-fit"
+    r = _run_shim(
+        "sign-fit.sh",
+        "--uri", "pkcs11:object=alternate-label",
+        "--fit", str(missing),
+    )
+    assert r.returncode == 1
+    assert "fitImage not found" in r.stderr
+
+
+def test_shim_partial_override_key_label(tmp_path):
+    """`--key-label <NAME>` alone must inherit the yubikey-9a profile's engine_conf.
+
+    The legacy alias derives uri=pkcs11:object=<urlencoded NAME>, but
+    engine_conf must come from the yubikey-9a profile default.
+    """
+    missing = tmp_path / "nonexistent-fit"
+    r = _run_shim(
+        "sign-fit.sh",
+        "--key-label", "custom-label",
+        "--fit", str(missing),
+    )
+    assert r.returncode == 1
+    # Either fitImage-not-found (engine_conf exists on operator host) or
+    # engine_conf-not-found (yubikey-9a default missing on this host).
+    # The deprecation warning must surface either way.
+    assert "--key-label is deprecated" in r.stderr
+    assert "fitImage not found" in r.stderr or "engine conf not found" in r.stderr
+
+
+# ---------------------------------------------------------------------------
+# Legacy --key-label behavior
+# ---------------------------------------------------------------------------
+
+
+def test_key_label_print_profile_derives_uri(tmp_path):
+    """--key-label sets the hint and derives uri=pkcs11:object=<encoded>."""
+    r = run_sign_fit(
+        "print-profile",
+        "--key-label", "Private key for PIV Authentication",
+        "--engine-conf", "/tmp/none.cnf",
+    )
+    assert r.returncode == 0
+    assert "key_name_hint  : Private key for PIV Authentication" in r.stdout
+    # URL-encoded spaces.
+    assert "pkcs11:object=Private%20key%20for%20PIV%20Authentication" in r.stdout
+    # Deprecation warning surfaces via the logging stream (stderr).
+    assert "--key-label is deprecated" in r.stderr
+
+
+def test_key_label_conflicts_with_key_name_hint():
+    r = run_sign_fit(
+        "print-profile",
+        "--key-label", "x",
+        "--key-name-hint", "y",
+        "--engine-conf", "/tmp/none.cnf",
+        check=False,
+    )
+    assert r.returncode == 1
+    assert "mutually exclusive" in r.stderr
+
+
+def test_key_label_uri_override_wins(tmp_path):
+    """If --uri is explicitly supplied alongside --key-label, --uri wins."""
+    r = run_sign_fit(
+        "print-profile",
+        "--key-label", "label",
+        "--uri", "pkcs11:object=explicit",
+        "--engine-conf", "/tmp/none.cnf",
+    )
+    assert r.returncode == 0
+    assert "pkcs11:object=explicit" in r.stdout
+    assert "pkcs11:object=label" not in r.stdout

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,138 @@
+version = 1
+revision = 2
+requires-python = ">=3.11"
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6d/16/a95b6757765b7b031c9374925bb718d55e0a9ba8a1b6a12d25962ea44347/pyyaml-6.0.3-cp311-cp311-macosx_10_13_x86_64.whl", hash = "sha256:44edc647873928551a01e7a563d7452ccdebee747728c1080d881d68af7b997e", size = 185826, upload-time = "2025-09-25T21:31:58.655Z" },
+    { url = "https://files.pythonhosted.org/packages/16/19/13de8e4377ed53079ee996e1ab0a9c33ec2faf808a4647b7b4c0d46dd239/pyyaml-6.0.3-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:652cb6edd41e718550aad172851962662ff2681490a8a711af6a4d288dd96824", size = 175577, upload-time = "2025-09-25T21:32:00.088Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/62/d2eb46264d4b157dae1275b573017abec435397aa59cbcdab6fc978a8af4/pyyaml-6.0.3-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:10892704fc220243f5305762e276552a0395f7beb4dbf9b14ec8fd43b57f126c", size = 775556, upload-time = "2025-09-25T21:32:01.31Z" },
+    { url = "https://files.pythonhosted.org/packages/10/cb/16c3f2cf3266edd25aaa00d6c4350381c8b012ed6f5276675b9eba8d9ff4/pyyaml-6.0.3-cp311-cp311-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:850774a7879607d3a6f50d36d04f00ee69e7fc816450e5f7e58d7f17f1ae5c00", size = 882114, upload-time = "2025-09-25T21:32:03.376Z" },
+    { url = "https://files.pythonhosted.org/packages/71/60/917329f640924b18ff085ab889a11c763e0b573da888e8404ff486657602/pyyaml-6.0.3-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b8bb0864c5a28024fac8a632c443c87c5aa6f215c0b126c449ae1a150412f31d", size = 806638, upload-time = "2025-09-25T21:32:04.553Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/6f/529b0f316a9fd167281a6c3826b5583e6192dba792dd55e3203d3f8e655a/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1d37d57ad971609cf3c53ba6a7e365e40660e3be0e5175fa9f2365a379d6095a", size = 767463, upload-time = "2025-09-25T21:32:06.152Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/6a/b627b4e0c1dd03718543519ffb2f1deea4a1e6d42fbab8021936a4d22589/pyyaml-6.0.3-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:37503bfbfc9d2c40b344d06b2199cf0e96e97957ab1c1b546fd4f87e53e5d3e4", size = 794986, upload-time = "2025-09-25T21:32:07.367Z" },
+    { url = "https://files.pythonhosted.org/packages/45/91/47a6e1c42d9ee337c4839208f30d9f09caa9f720ec7582917b264defc875/pyyaml-6.0.3-cp311-cp311-win32.whl", hash = "sha256:8098f252adfa6c80ab48096053f512f2321f0b998f98150cea9bd23d83e1467b", size = 142543, upload-time = "2025-09-25T21:32:08.95Z" },
+    { url = "https://files.pythonhosted.org/packages/da/e3/ea007450a105ae919a72393cb06f122f288ef60bba2dc64b26e2646fa315/pyyaml-6.0.3-cp311-cp311-win_amd64.whl", hash = "sha256:9f3bfb4965eb874431221a3ff3fdcddc7e74e3b07799e0e84ca4a0f867d449bf", size = 158763, upload-time = "2025-09-25T21:32:09.96Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
+name = "rpi5-iot-gw-host-tools"
+version = "0.1.0"
+source = { virtual = "." }
+dependencies = [
+    { name = "pyyaml" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "pyyaml", specifier = ">=6.0" }]
+
+[package.metadata.requires-dev]
+dev = [{ name = "pytest", specifier = ">=7.0" }]


### PR DESCRIPTION
## Summary

Replaces the bash FIT-signing wrappers with a Python tool (`scripts/sign_fit.py`) backed by a profile-based signer config, and adds first-class SoftHSM support so engineers without a YubiKey can sign and boot dev-trusted FIT images locally. Existing YubiKey flows keep working through compatibility shims.

Three FIT signing paths are now supported against the same dual-trust DTB:

- **file-key** — legacy build-time mkimage signing (unchanged behaviour)
- **YubiKey** — post-build HSM signing via PIV slot 9a (production path)
- **SoftHSM** — post-build software signing for YK-less developers (dev-only; the recipe gate is explicitly off by default and the docs warn against enabling it on production builds)

When more than one trust root is enabled, the kernel-fit recipe writes `/signature/required-mode = "any"` so a FIT signed by any one root verifies; with a single root the property is omitted and U-Boot's default verify semantics apply.

## Hardware validation

Verified end-to-end on RPi5 with all three trust roots in the DTB:

```
$ ls /sys/firmware/devicetree/base/signature/
key-iotgw-fit-dev   key-iotgw-fit-softhsm-dev   key-iotgw-fit-yk-2026
required-mode

$ cat /sys/firmware/devicetree/base/signature/required-mode
any
```

**SoftHSM path** — first-attempt verify success against the SoftHSM trust root:

```
[IOTGW] FIT loaded (fitImage-a)
   Verifying Hash Integrity ... sha256,rsa2048:iotgw-fit-softhsm-dev+ OK
   Verifying Hash Integrity ... sha256+ OK
```

**YubiKey path** — one `error!` fallthrough (U-Boot tried a non-matching DTB key first) followed by `+ OK` on the YubiKey trust root — exactly the `required-mode = "any"` semantics this PR adds:

```
[IOTGW] FIT loaded (fitImage-b)
   Verifying Hash Integrity ... sha256,rsa2048:iotgw-fit-yk-2026-  error!
sha256,rsa2048:iotgw-fit-yk-2026+ OK
   Verifying Hash Integrity ... sha256+ OK
   Booting using the fdt blob at 0x2eff9000
```

Both installs alternated A/B slots cleanly; RAUC marked each new slot good (`bootcount=1` on the boot that reached systemd).

The file-key path's behaviour is unchanged from PR #72 (recipe code path identical; this PR only adds a SoftHSM gate as a sibling and refactors the required-mode counting), so file-key hardware re-validation is treated as regression-only.

## mkimage workaround for SoftHSM URI

mkimage 2025.04's `-N pkcs11` path silently ignores `-G` and rewrites any `-k` URI that lacks `object=`. The Python tool always passes `-k pkcs11:object=<label>`; profile validation rejects URIs without `object=` early with a clear error.

## Test environment

Operator signing continues to work on system Python plus a distro-installed `python3-yaml`. Tests use a uv-managed venv (PyYAML + pytest pinned in `uv.lock`) so the suite is reproducible across hosts. The Makefile signing targets do NOT run through `uv run`; Yocto builds do NOT depend on uv.

```bash
make tools-venv             # uv sync (run once or after dep bumps)
make test-sign-fit          # 26 passed (SoftHSM env present)
SOFTHSM_AVAILABLE=0 make test-sign-fit   # 21 passed, 5 SoftHSM-tagged tests skipped
```

## Test plan

- [x] `make test-sign-fit` green (26 passed)
- [x] `SOFTHSM_AVAILABLE=0 make test-sign-fit` green (21 passed, 5 skipped)
- [x] Recipe parses cleanly with all three trust gates resolving (`bitbake -e linux-iotgw-mainline-fit`)
- [x] Build-time DTB inspection shows three `/signature/key-*` subnodes + `required-mode = "any"` (`fdtget -l`)
- [x] SoftHSM provisioning runbook in `docs/FIT_BOOT_SIGNING.md` exercised end-to-end (token + RSA-2048 keypair + self-signed cert under operator vault)
- [x] `make sign-bootfiles-fit-softhsm` produces a valid SoftHSM-signed inner FIT for both `conf-primary` and `conf-recovery`
- [x] `make sign-bootfiles-fit-yk` produces a valid YubiKey-signed inner FIT (PIN + touch interactive)
- [x] `make bundle-dev-full-fit-resign` reassembles the bundle without rebuilding kernel/rootfs
- [x] SoftHSM-signed bundle installs via RAUC and boots cleanly on target (U-Boot verify, slot switch, RAUC mark-good)
- [x] YubiKey-signed bundle installs via RAUC and boots cleanly on target
- [x] Bash compatibility shims preserve legacy CLI: `--key-label`, `--engine-conf`-only overrides, `--` separator