### PR TITLE
fix(rauc): clear FAT dirty bit on /boot after FIT install

### DIFF
--- a/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
@@ -136,7 +136,19 @@ cleanup() {
       umount "$BOOT_MP" || log_warn "failed to unmount $BOOT_MP during cleanup"
     fi
   elif [ "$boot_was_readonly" -eq 1 ]; then
-    mount -o remount,ro "$BOOT_MP" || log_warn "failed to remount $BOOT_MP read-only during cleanup"
+    # A plain `remount,ro` flips the mount flags but never releases the
+    # mount, so the FAT dirty bit set during the r/w write phase is never
+    # cleared — every subsequent boot then logs a spurious "Volume was not
+    # properly unmounted" warning. Only a real umount clears the bit. Fall
+    # back to remount,ro if something else still holds /boot open.
+    sync
+    if umount "$BOOT_MP" 2>/dev/null; then
+      mount -t vfat -o ro "$BOOT_DEV" "$BOOT_MP" \
+        || log_warn "failed to remount $BOOT_MP ro after sync cycle"
+    else
+      mount -o remount,ro "$BOOT_MP" \
+        || log_warn "failed to remount $BOOT_MP read-only during cleanup"
+    fi
   fi
   rm -rf "$tmpdir" || true
 }


### PR DESCRIPTION
## Symptom

After every successful RAUC OTA install on the RPi5, the next boot logs:

```
FAT-fs (mmcblk0p1): Volume was not properly unmounted. Some data may be corrupt. Please run fsck.
```

Cosmetic, not real corruption — `dosfsck -n /dev/mmcblk0p1` reports the filesystem clean. But the warning fires every install cycle, masking any genuine FAT issue that might appear later.

## Root cause

`bundle-hooks-fit.sh`'s `cleanup()` trap returned `/boot` to read-only via `mount -o remount,ro`. A remount transitions the mount flags but never releases the mount, so the FAT dirty bit set during the r/w write phase is never cleared. The bit only clears on a real `umount`.

In production `/boot` is mounted `ro` per `/etc/fstab`; the hook detects `boot_was_readonly=1`, remounts r/w, writes the boot files, then on cleanup took the `remount,ro` branch — leaving the dirty bit set.

## Fix

Replace the `remount,ro` branch with `sync` → `umount` → `ro-mount`, which actually clears the dirty bit. A plain `remount,ro` is kept as a fallback for the edge case where something else still holds `/boot` open.

Safe because `cleanup()` runs as the `EXIT` trap, after all hook writes to `/boot` complete. RAUC's later slot-marking and U-Boot env writes go via `fw_setenv` (separate env partition) and do not touch `/boot`.

## Testing

- `bash -n` — clean
- `shellcheck -S warning` — clean
- On-target acceptance (per issue): `dmesg | grep "not properly unmounted"` after install + reboot should be empty; existing M2/M3 install paths unchanged.

Closes #68