### PR TITLE
fix(uboot): one-cycle slot exhaustion + halt endpoint on FIT verify failure

### DIFF
--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0001-rpi-env-minimize-boot-scanning-for-iot-gateway.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0001-rpi-env-minimize-boot-scanning-for-iot-gateway.patch
@@ -15,7 +15,7 @@ index 30228285edd..a1b2c3d4e5f 100644
  stdout=serial,vidconsole
  stderr=serial,vidconsole
  
-@@ -74,4 +74,14 @@ pxefile_addr_r=0x02500000
+@@ -74,4 +74,15 @@ pxefile_addr_r=0x02500000
  fdt_addr_r=0x02600000
  ramdisk_addr_r=0x02700000
  
@@ -28,7 +28,8 @@ index 30228285edd..a1b2c3d4e5f 100644
 +iotgw_rauc_select=test -n "${BOOT_ORDER}" || setenv BOOT_ORDER A B; test -n "${BOOT_A_LEFT}" || setenv BOOT_A_LEFT 3; test -n "${BOOT_B_LEFT}" || setenv BOOT_B_LEFT 3; setenv rauc_slot; for BOOT_SLOT in ${BOOT_ORDER}; do if test x${BOOT_SLOT} = xA; then run iotgw_try_a; else run iotgw_try_b; fi; done
 +iotgw_set_bootargs=if part uuid mmc 0:${rootpartnum} rootpartuuid; then fdt addr ${fdt_addr}; fdt get value bootargs /chosen bootargs; setenv bootargs ${bootargs} root=PARTUUID=${rootpartuuid} rootwait rauc.slot=${rauc_slot}; if test -n "${EXTRA_KERNEL_ARGS}"; then setenv bootargs ${bootargs} ${EXTRA_KERNEL_ARGS}; fi; else echo [RAUC] part uuid failed; reset; fi
 +iotgw_load_boot=if test x${rauc_slot} = xA; then setenv _fitimg fitImage-a; else setenv _fitimg fitImage-b; fi; if fatload mmc 0:1 ${iotgw_fit_addr_r} ${_fitimg}; then echo [IOTGW] FIT loaded (${_fitimg}); elif fatload mmc 0:1 ${iotgw_fit_addr_r} fitImage; then echo [IOTGW] FIT loaded (fallback); else echo [IOTGW] FIT load failed; reset; fi
-+iotgw_exec_fit=test -n "${iotgw_fit_conf}" || setenv iotgw_fit_conf ${iotgw_fit_conf_default}; bootm ${iotgw_fit_addr_r}#${iotgw_fit_conf} - ${fdt_addr}; echo [IOTGW] bootm returned; reset
-+bootcmd=run iotgw_rauc_select; if test -z "${rauc_slot}"; then setenv BOOT_A_LEFT 3; setenv BOOT_B_LEFT 3; saveenv; reset; fi; run iotgw_set_bootargs; run iotgw_load_boot; saveenv; run iotgw_exec_fit
++iotgw_exec_fit=test -n "${iotgw_fit_conf}" || setenv iotgw_fit_conf ${iotgw_fit_conf_default}; bootm ${iotgw_fit_addr_r}#${iotgw_fit_conf} - ${fdt_addr}; echo [IOTGW] bootm returned for slot ${rauc_slot}: marking slot non-bootable; setenv BOOT_${rauc_slot}_LEFT 0; saveenv; reset
++iotgw_halt=echo [IOTGW][HALT] All RAUC slots exhausted (A_LEFT=${BOOT_A_LEFT} B_LEFT=${BOOT_B_LEFT}); echo [IOTGW][HALT] No bootable FIT image. Out-of-band recovery required (serial console or SD reflash); while itest 1 -eq 1; do sleep 60; echo [IOTGW][HALT] halted; done
++bootcmd=run iotgw_rauc_select; if test -z "${rauc_slot}"; then run iotgw_halt; fi; run iotgw_set_bootargs; run iotgw_load_boot; saveenv; run iotgw_exec_fit
 +boot_targets=mmc
  


### PR DESCRIPTION
## Summary

Two narrow edits to the U-Boot env-macro boot flow in
`0001-rpi-env-minimize-boot-scanning-for-iot-gateway.patch` so that a
non-verifying FIT no longer reboot-loops a release device with no A/B
rollback (#76).

- **`iotgw_exec_fit`** — on `bootm` return, mark the just-tried slot
  non-bootable in *one cycle* (`setenv BOOT_${rauc_slot}_LEFT 0; saveenv`)
  before `reset`. Previous behaviour relied on the natural per-cycle
  decrement in `iotgw_rauc_select` and took three reboots per bad slot,
  during which the device reboot-spun visibly.
- **`bootcmd` + new `iotgw_halt`** — replace the exhausted-slot
  counter-reset branch (which re-armed both `_LEFT=3` and `reset`ed,
  creating an infinite loop) with a loud halt that prints the state and
  enters a `while ... sleep 60; echo halted; done` loop. Operators with
  serial access can interrupt the halt loop with raw Ctrl-C, or use the
  autoboot stop-string (`igw`) before bootcmd runs.

Selection logic (`iotgw_rauc_select`, `iotgw_try_a/b`), `iotgw_load_boot`,
`iotgw_set_bootargs`, the prod env writeable-list, and `boot.cmd.in` are
unchanged.

Closes #76. Unblocks #73 (`feat-fit-release-trust-profile` was parked at
c48907d pending this fix; can now be rebased and the release-trust
negative test re-run).

## Validation — on-target (RPi5, dev image built from this branch)

Pre-patch validation already done at the U-Boot prompt via MCP serial:
`setenv BOOT_${rauc_slot}_LEFT 0` resolves dynamically, `saveenv` returns
OK, the new `iotgw_halt` `while/sleep/echo` loop runs correctly and raw
Ctrl-C interrupts cleanly.

Post-build validation: `strings u-boot.bin | grep` confirms both new
strings (`marking slot non-bootable`, `[IOTGW][HALT]`) are present and
the new `bootcmd` uses `run iotgw_halt`.

On-target acceptance run (full log:
`tio-session-logs/tio_ttyACM0_2026-05-25T16:50:45.log`):

### Item 1 — bad slot exhausts in one cycle, alternate boots
- L1439 `run iotgw_exec_fit` (with `iotgw_fit_addr_r=0x09000000` — no
  valid FIT at that address, so `bootm` returns).
- L1442 `[IOTGW] bootm returned for slot A: marking slot non-bootable`
- L1443 `Saving Environment to FAT... OK`
- L1444 `resetting ...`
- L1573 — single BL31 banner (one reset, no spin)
- L1589 `Failed to load 'fitImage-b'` — selector picked B because
  `BOOT_A_LEFT=0` from Edit 1.
- L1591 `[IOTGW] FIT loaded (fallback)` — plain `fitImage` fallback (no
  per-slot `fitImage-b` on a fresh-flashed SD — known, see deferred).
- Multi-root verify produces `sha256,rsa2048:iotgw-fit-dev+ OK`, kernel
  uncompresses, `Starting kernel ...`, `rauc.slot=B` in cmdline.

### Item 2 — halt endpoint when both slots exhausted
- `fw_setenv BOOT_A_LEFT 0 && fw_setenv BOOT_B_LEFT 0 && reboot`
- Serial:
  ```
  Autoboot in 2s - type 'igw' to stop
  [IOTGW][HALT] All RAUC slots exhausted (A_LEFT=0 B_LEFT=0)
  [IOTGW][HALT] No bootable FIT image. Out-of-band recovery required (serial console or SD reflash)
  [IOTGW][HALT] halted
  [IOTGW][HALT] halted
  [IOTGW][HALT] halted
  ```
- Single boot banner before the halt, no further reboots. Autoboot
  stop-string `igw` interrupts before bootcmd runs and drops to U-Boot
  prompt for operator recovery.

### Item 3 — positive regression
- After Item 1, in userspace on slot B: `rauc status` correctly reports
  `Booted from: rootfs.1 (B)`, `Activated: rootfs.1 (B)`, slot A
  `boot status: bad` (RAUC reads `BOOT_A_LEFT=0` set by Edit 1), slot B
  `boot status: good` (RAUC mark-good ran on boot, restored
  `BOOT_B_LEFT=3`).
- Earlier in the same session a clean post-restore boot on slot A also
  came up without hitting any failure path — Edit 1's success path
  (`bootm` does not return) is the normal flow.

## Test plan

- [x] `bitbake u-boot` succeeds with the patched env macros.
- [x] `strings build/tmp-glibc/deploy/images/raspberrypi5/u-boot.bin |
      grep -E 'marking slot non-bootable|IOTGW.*HALT'` returns both
      strings.
- [x] On target — Item 1 (one-cycle exhaustion + A/B fallback).
- [x] On target — Item 2 (halt endpoint, no reset spin).
- [x] On target — Item 3 (positive regression).
- [ ] After merge: rebase `feat-fit-release-trust-profile` (c48907d)
      onto `main`, re-run the full #73 acceptance matrix with the real
      release-trust DTB + file-key negative bundle
      (`iot-gw-image-prod-bundle-full-fit-filekey-negative.raucb`),
      close #73.

## Deferred (separate issues)

- **Shared control-FDT trust transition.** Enforce dual-trust transition
  image (#72 infra exists) so a release-trust install only proceeds when
  the alternate slot's FIT verifies under the new key set. New issue.
- **Recovery FIT (`conf-recovery`).** Referenced in `boot.cmd.in` but
  ITS template only emits `conf-primary`/`conf-secondary`. New issue.
- **Initial `/boot` population with per-slot fitImages.** On a fresh SD
  with no RAUC install behind it, neither `fitImage-a` nor `fitImage-b`
  exists — both slots resolve to plain `fitImage` via fallback. Means
  the first install cannot exhibit true A/B FIT-divergence until both
  slots have been installed at least once. Track separately.
- **`boot.cmd.in` alignment.** Not the active path; keep both forms in
  sync next time either is touched.
- **`iotgw_load_boot` `reset` on load-failure.** When neither per-slot
  nor fallback FIT loads, current behaviour `reset`s; the same
  `setenv BOOT_${rauc_slot}_LEFT 0; saveenv` pattern as Edit 1 would
  apply symmetrically. Follow-up.