### PR TITLE
feat(fit): release-trust profile (YK-only) + sign_fit context-aware hints (#73)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: help base dev prod desktop \
-        bundle-dev bundle-dev-full bundle-dev-full-fit sign-bootfiles-fit-yk sign-bootfiles-fit-softhsm bundle-dev-full-fit-resign bundle-base-full-fit-fast bundle-prod-full bundle-desktop-full bundle-desktop \
+        bundle-dev bundle-dev-full bundle-dev-full-fit sign-bootfiles-fit-yk sign-bootfiles-fit-softhsm bundle-dev-full-fit-resign bundle-base-full-fit-fast bundle-prod-full bundle-prod-full-fit bundle-prod-full-fit-resign bundle-desktop-full bundle-desktop \
         tools-venv test-sign-fit test-sign-fit-softhsm \
         layers parse clean-lock
 
@@ -7,6 +7,7 @@ KAS ?= kas
 RAUC ?= kas/rauc.yml
 LOCAL ?= kas/local.yml
 UBOOT_PROD_HARDENING_KAS ?= kas/uboot-prod-hardening.yml
+FIT_RELEASE_TRUST_KAS ?= kas/fit-release-trust.yml
 # Default to RAUC builds always; prefer local RAUC config if present
 BASE ?= $(if $(wildcard $(LOCAL)),$(LOCAL),$(RAUC))
 
@@ -37,6 +38,8 @@ help:
 	@echo "  make bundle-dev-full-fit-resign  # Re-assemble bundle with HSM-signed FIT (unattended)"
 	@echo "  make bundle-base-full-fit-fast # FIT bundle from base image (OTBR off, faster)"
 	@echo "  make bundle-prod-full     # Bundle from prod image"
+	@echo "  make bundle-prod-full-fit # FIT bundle from prod image (release trust)"
+	@echo "  make bundle-prod-full-fit-resign # Reassemble prod FIT bundle around YK-signed FIT"
 	@echo "  make bundle-desktop-full  # Bundle from desktop image"
 	@echo "  -- Bundles (rootfs-only) --"
 	@echo "  make bundle-dev           # Rootfs-only bundle from dev image"
@@ -62,6 +65,8 @@ base:
 dev:
 	$(call image_cmd,iot-gw-image-dev)
 
+PROD_KAS_OVERLAYS = $(BASE)$(if $(wildcard $(UBOOT_PROD_HARDENING_KAS)),:$(UBOOT_PROD_HARDENING_KAS))$(if $(wildcard $(FIT_RELEASE_TRUST_KAS)),:$(FIT_RELEASE_TRUST_KAS))
+
 prod:
 	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \
 			   IOTGW_ENABLE_OTBR=$(IOTGW_ENABLE_OTBR) \
@@ -69,7 +74,7 @@ prod:
 			   IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS=$(IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS) \
 			   IOTGW_ENABLE_OBSERVABILITY=$(IOTGW_ENABLE_OBSERVABILITY) \
 			   IOTGW_ENABLE_BTF_CORE_DEV=$(IOTGW_ENABLE_BTF_CORE_DEV) \
-			   bitbake iot-gw-image-prod' $(if $(wildcard $(UBOOT_PROD_HARDENING_KAS)),$(BASE):$(UBOOT_PROD_HARDENING_KAS),$(BASE))
+			   bitbake iot-gw-image-prod' $(PROD_KAS_OVERLAYS)
 
 desktop:
 	# Prefer dedicated desktop KAS config; include local.yml if present for keys
@@ -180,15 +185,35 @@ bundle-base-full-fit-fast:
 			   IOTGW_ENABLE_BTF_CORE_DEV=$(IOTGW_ENABLE_BTF_CORE_DEV) \
 			   bitbake iot-gw-bundle-full-fit' $(BASE)
 
+define prod_bundle_cmd
+  $(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \
+                   BUNDLE_IMAGE_NAME=iot-gw-image-prod \
+                   IOTGW_ENABLE_OTBR=$(IOTGW_ENABLE_OTBR) \
+                   IOTGW_ENABLE_CONTAINERS=$(IOTGW_ENABLE_CONTAINERS) \
+                   IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS=$(IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS) \
+                   IOTGW_ENABLE_OBSERVABILITY=$(IOTGW_ENABLE_OBSERVABILITY) \
+                   IOTGW_ENABLE_BTF_CORE_DEV=$(IOTGW_ENABLE_BTF_CORE_DEV) \
+                   bitbake $(1)' $(PROD_KAS_OVERLAYS)
+endef
+
+# Release bundles. PROD_KAS_OVERLAYS composes kas/fit-release-trust.yml,
+# so both build iot-gw-image-prod with the release FIT trust profile
+# (YubiKey-only DTB). bundle-prod-full-fit is the release FIT artifact —
+# the prod-image equivalent of bundle-dev-full-fit, and the bundle to
+# flash for issue #73 on-target validation.
 bundle-prod-full:
-	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \
-			   BUNDLE_IMAGE_NAME=iot-gw-image-prod \
-			   IOTGW_ENABLE_OTBR=$(IOTGW_ENABLE_OTBR) \
-			   IOTGW_ENABLE_CONTAINERS=$(IOTGW_ENABLE_CONTAINERS) \
-			   IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS=$(IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS) \
-			   IOTGW_ENABLE_OBSERVABILITY=$(IOTGW_ENABLE_OBSERVABILITY) \
-			   IOTGW_ENABLE_BTF_CORE_DEV=$(IOTGW_ENABLE_BTF_CORE_DEV) \
-			   bitbake iot-gw-bundle-full' $(if $(wildcard $(UBOOT_PROD_HARDENING_KAS)),$(BASE):$(UBOOT_PROD_HARDENING_KAS),$(BASE))
+	$(call prod_bundle_cmd,iot-gw-bundle-full)
+
+bundle-prod-full-fit:
+	$(call prod_bundle_cmd,iot-gw-bundle-full-fit)
+
+# Reassemble the release FIT bundle around an already YubiKey-signed
+# bootfiles-fit.tar.gz. Run after `make sign-bootfiles-fit-yk`; re-runs the
+# bundle recipe from do_configure so the .raucb picks up the HSM-signed FIT.
+# Prod equivalent of bundle-dev-full-fit-resign; keeps PROD_KAS_OVERLAYS so
+# kas/fit-release-trust.yml stays active.
+bundle-prod-full-fit-resign:
+	$(call prod_bundle_cmd,-C do_configure iot-gw-bundle-full-fit)
 
 bundle-desktop-full:
 	$(KAS) shell -c 'BB_ENV_PASSTHROUGH_ADDITIONS="$$BB_ENV_PASSTHROUGH_ADDITIONS BUNDLE_IMAGE_NAME IOTGW_ENABLE_OTBR IOTGW_ENABLE_CONTAINERS IOTGW_ENABLE_CONTAINERS_IMAGE_TOOLS IOTGW_ENABLE_OBSERVABILITY IOTGW_ENABLE_BTF_CORE_DEV" \

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -455,7 +455,7 @@ YubiKey:
 |-------|-----------------|-----------------|-------|
 | Legacy baseline | file key only | file key | Status quo before this rotation. |
 | **Rotation window** | **file key + YK pubkey** | file key (build) or YK (post-build, optional) | DTB carries both pubkeys with `/signature/required-mode = "any"`. A FIT signed by either root verifies. |
-| Production cutover | YK pubkey only | YK (post-build, mandatory) | File key retired. `IOTGW_FIT_TRUST_FILE_KEY = "0"` in `kas/local.yml`. |
+| Production cutover | YK pubkey only | YK (post-build, mandatory) | File key retired via the `kas/fit-release-trust.yml` release overlay (`IOTGW_FIT_TRUST_FILE_KEY:fitflow = "0"`; SoftHSM forced off too). |
 | Dev variant (optional) | adds SoftHSM dev pubkey alongside any of the above | YK (production) or SoftHSM (dev) | `IOTGW_FIT_TRUST_SOFTHSM_KEY = "1"`. **Dev hardware only — never ship.** |
 
 The rotation-window build is the only one that should ship while
@@ -586,15 +586,84 @@ Both paths must boot cleanly on the same device before promoting the
 rotation-window build to fleet rollout, and before scoping the
 production cutover.
 
-### Production cutover (separate change)
+### Production cutover
 
-The cutover build drops `IOTGW_FIT_TRUST_FILE_KEY = "0"` in
-`kas/local.yml`. The recipe then injects only the YK pubkey, and with
-a single trust root the recipe omits `required-mode` so U-Boot's
-default single-required-key verification applies. The bundle FIT MUST
-be HSM-signed before release; a file-key-signed FIT would be rejected
-by every fielded device. The cutover is scoped to a separate change
-once the rotation-window build is validated on hardware.
+The cutover build sets `IOTGW_FIT_TRUST_FILE_KEY:fitflow = "0"` and
+`IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "0"` via the committed
+`kas/fit-release-trust.yml` overlay (see the next section). The recipe
+then injects only the YK pubkey, and with a single trust root
+`required-mode` is left unset — U-Boot's default single-required-key
+verification applies (no recipe change; same behaviour as PR #74). The
+bundle FIT MUST be HSM-signed before release; a file-key-signed FIT
+would be rejected by every fielded device. On-target validation of the
+cutover build is still pending.
+
+## Release vs dev KAS trust profiles
+
+Two profiles govern which trust roots land in the U-Boot control FDT.
+
+| Profile | `IOTGW_FIT_TRUST_FILE_KEY` | DTB trust roots | `required-mode` |
+|---------|---------------------------|-----------------|-----------------|
+| **Dev** (default) | `1` | file key + YubiKey/SoftHSM pubkey(s) | `any` (multi-root) |
+| **Release** | `0` | YubiKey pubkey only | unset (single root) |
+
+The release profile also forces `IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "0"`,
+so a developer's `kas/local.yml` with all three trust roots enabled cannot
+leak the SoftHSM dev key into a release DTB.
+
+### Dev profile
+
+The default. `IOTGW_FIT_TRUST_FILE_KEY` defaults to `"1"` in the
+recipe, so no kas overlay change is needed for dev builds. The dev
+profile is the multi-root rotation-window configuration where a FIT
+signed by any enabled trust root verifies at boot.
+
+### Release profile
+
+`kas/fit-release-trust.yml` is a committed overlay that sets
+`IOTGW_FIT_TRUST_FILE_KEY:fitflow = "0"` and
+`IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "0"` — the file key and the
+dev-only SoftHSM key are both dropped, leaving the YubiKey pubkey as the
+sole trust root. Forcing SoftHSM off matters because a developer's
+`kas/local.yml` may enable all three roots; without it a release build
+composed on that config would carry the SoftHSM dev key in the DTB. The
+`:fitflow` override qualifier is required: `kas/local.yml` scopes every
+FIT trust gate to that override, and a bare assignment would be shadowed
+by it. The overlay is composed automatically with `prod`,
+`bundle-prod-full`, and `bundle-prod-full-fit` by the `Makefile` whenever
+the file exists (the same pattern as `kas/uboot-prod-hardening.yml`), and
+after `kas/local.yml` so the override-tier assignments win. A release
+build therefore picks up the release trust profile without any manual
+`kas/local.yml` change.
+
+Safety gate: with `IOTGW_FIT_TRUST_FILE_KEY:fitflow = "0"`, if
+`IOTGW_FIT_TRUST_YK_KEY` is also not `"1"`, the recipe `bbfatal`s at
+`do_deploy` time. `iotgw-uboot-prod-key-guard.bbclass` enforces the same
+invariant earlier and independently: it fails any prod build
+(`iot-gw-image-prod` / `appliance_lockdown`) whose trust gates are not
+the release set — file and SoftHSM off, YubiKey on — before
+`do_configure`. Release builds require a YubiKey trust root. Ensure
+`kas/local.yml` (or another composed overlay) sets:
+
+```yaml
+local_conf_header:
+  fit_dtb_yk_pubkey_trust: |
+    IOTGW_FIT_TRUST_YK_KEY:fitflow = "1"
+    IOTGW_FIT_YK_KEYDIR:fitflow = "${IOTGW_RAUC_KEY_DIR}/rauc-ca/fit"
+    IOTGW_FIT_YK_KEYNAME:fitflow = "iotgw-fit-yk-2026"
+```
+
+Verifying the release DTB output:
+
+```bash
+DTB=build/tmp-glibc/deploy/images/raspberrypi5/bcm2712-rpi-5-b.dtb
+fdtget -l "$DTB" /signature       # exactly one subnode: key-iotgw-fit-yk-2026
+fdtget -p "$DTB" /signature       # property list must NOT include required-mode
+```
+
+With a single trust root the recipe leaves `required-mode` unset, so
+`fdtget "$DTB" /signature required-mode` errors with "not found" — that
+absence is the expected result, not a failure.
 
 ## Signing FIT against a PKCS#11 token (YubiKey)
 

--- a/kas/fit-release-trust.yml
+++ b/kas/fit-release-trust.yml
@@ -1,0 +1,47 @@
+header:
+  version: 18
+
+local_conf_header:
+  fit_release_trust: |
+    # Release FIT trust profile: trust ONLY the YubiKey-resident pubkey.
+    #
+    #   IOTGW_FIT_TRUST_FILE_KEY:fitflow    = "0"  drops the build-time file key
+    #   IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "0"  drops the dev-only SoftHSM key
+    #
+    # from the U-Boot control FDT. The deployed DTB then carries exactly one
+    # /signature/key-* node — key-iotgw-fit-yk-2026. With a single trust root
+    # the recipe leaves /signature/required-mode unset; U-Boot's default
+    # single-required-key verification applies (same behaviour as PR #74 —
+    # this overlay deliberately makes no recipe change).
+    #
+    # BOTH non-YubiKey gates are forced off here, not just the file key. A
+    # developer's kas/local.yml may enable all three trust roots (file +
+    # YubiKey + SoftHSM) for the dev rotation profile; forcing SoftHSM off in
+    # this overlay stops that local dev config from leaking the SoftHSM dev
+    # key into a release image. A release DTB must carry exactly one key.
+    #
+    # Effect: a release image boots ONLY YubiKey-signed FITs. A FIT signed
+    # with the file key or the SoftHSM dev key fails U-Boot signature
+    # verification and triggers RAUC/bootchooser A/B rollback to the
+    # previous known-good slot.
+    #
+    # The :fitflow override qualifier is REQUIRED, not optional. kas/local.yml
+    # sets every FIT trust gate as ":fitflow" (the FIT boot flow runs under
+    # that override). A bare assignment here would be shadowed by local.yml's
+    # ":fitflow" assignment whenever the override is active — an
+    # override-qualified assignment always beats a bare one regardless of
+    # parse order. This overlay must be composed AFTER local.yml (the
+    # Makefile's PROD_KAS_OVERLAYS does so) so these :fitflow assignments win
+    # at the same override tier.
+    #
+    # SAFETY: this overlay disables the file-key and SoftHSM trust roots. If
+    # IOTGW_FIT_TRUST_YK_KEY is also not "1" in kas/local.yml (or another
+    # composed overlay), the recipe bbfatals at do_deploy time with "all
+    # three trust gates off … would brick the device". That is intentional —
+    # a release build MUST have the YubiKey trust root configured. Before
+    # composing this overlay, ensure kas/local.yml sets:
+    #   IOTGW_FIT_TRUST_YK_KEY:fitflow  = "1"
+    #   IOTGW_FIT_YK_KEYDIR:fitflow     = "<dir holding iotgw-fit-yk-2026.crt>"
+    #   IOTGW_FIT_YK_KEYNAME:fitflow    = "iotgw-fit-yk-2026"
+    IOTGW_FIT_TRUST_FILE_KEY:fitflow = "0"
+    IOTGW_FIT_TRUST_SOFTHSM_KEY:fitflow = "0"

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -105,7 +105,12 @@ local_conf_header:
     # are HSM-signed.
     #
     # Production cutover (IOTGW_FIT_TRUST_FILE_KEY=0, only YK trusted):
-    # the recipe injects only the YK pubkey and omits required-mode.
+    # the recipe injects only the YK pubkey and leaves required-mode
+    # unset (single trust root — U-Boot's default verify semantics).
+    # Use the kas/fit-release-trust.yml overlay (composed automatically
+    # by make prod / bundle-prod-full / bundle-prod-full-fit) rather than
+    # setting this gate in local.yml; that overlay also force-disables the
+    # SoftHSM gate so a dev local.yml cannot leak it into a release.
     # Operator pre-flight: export slot 9a public cert with
     # `ykman piv certificates export 9a ${IOTGW_FIT_YK_KEYDIR}/${IOTGW_FIT_YK_KEYNAME}.crt`.
     #

--- a/meta-iot-gateway/classes/iotgw-uboot-prod-key-guard.bbclass
+++ b/meta-iot-gateway/classes/iotgw-uboot-prod-key-guard.bbclass
@@ -1,8 +1,16 @@
-# ── Production FIT signing key guard ─────────────────────────────────────────
-# Prevents iot-gw-image-prod from being built with a development signing key.
+# ── Production FIT trust-profile guard ───────────────────────────────────────
+# Ensures iot-gw-image-prod is built with the release FIT trust profile: the
+# deployed U-Boot control FDT must trust ONLY the YubiKey-resident pubkey.
+#
+# This guard deliberately does NOT inspect UBOOT_SIGN_KEYNAME. Under the
+# detached-signing model (PRs #70-#74), the build-time file key signs only a
+# Stage-1 placeholder FIT that is re-signed against the YubiKey post-build; it
+# is never a trust root in a release DTB (IOTGW_FIT_TRUST_FILE_KEY=0). The
+# build-time key name is therefore irrelevant to release security — what
+# matters is the trust-gate set baked into the control FDT.
 
 python do_iotgw_uboot_key_guard() {
-    # No-op when FIT signing is disabled entirely
+    # No-op when FIT signing is disabled entirely.
     fit_signing = d.getVar('IOTGW_FIT_SIGNING') or '0'
     if fit_signing != '1':
         bb.debug(1, 'iotgw-uboot-prod-key-guard: IOTGW_FIT_SIGNING != 1, skipping.')
@@ -21,20 +29,35 @@ python do_iotgw_uboot_key_guard() {
         bb.debug(1, 'iotgw-uboot-prod-key-guard: not prod-intent (%s, %s), skipping.' % (pn, ' '.join(features)))
         return
 
-    # Enforce: prod image must not reference a dev-named key
-    keyname = d.getVar('UBOOT_SIGN_KEYNAME') or ''
-    if 'dev' in keyname.lower():
+    # Enforce the release FIT trust profile: the production control FDT must
+    # trust ONLY the YubiKey root — the dev file key and the dev SoftHSM key
+    # must both be off so they are not injected as /signature/key-* nodes.
+    trust_yk      = d.getVar('IOTGW_FIT_TRUST_YK_KEY') or '0'
+    trust_file    = d.getVar('IOTGW_FIT_TRUST_FILE_KEY') or '0'
+    trust_softhsm = d.getVar('IOTGW_FIT_TRUST_SOFTHSM_KEY') or '0'
+
+    bad = []
+    if trust_yk != '1':
+        bad.append('IOTGW_FIT_TRUST_YK_KEY must be "1" (the production trust root) but is "%s"' % trust_yk)
+    if trust_file == '1':
+        bad.append('IOTGW_FIT_TRUST_FILE_KEY must be "0" but is "1" — the dev file key would be a release trust root')
+    if trust_softhsm == '1':
+        bad.append('IOTGW_FIT_TRUST_SOFTHSM_KEY must be "0" but is "1" — the dev SoftHSM key would be a release trust root')
+
+    if bad:
         bb.fatal(
             '\n'
-            'iot-gw-image-prod cannot be built with a development FIT signing key.\n'
-            'UBOOT_SIGN_KEYNAME is "%s" which matches the dev key pattern.\n'
-            'Production builds require a key named "iotgw-fit-prod" or similar,\n'
-            'generated and stored per docs/KEY_CEREMONY.md.\n'
-            'To proceed: set UBOOT_SIGN_KEYNAME to a non-dev key in kas/local.yml '
-            'under the fit_signing_prod block.' % keyname
+            'iot-gw-image-prod must be built with the release FIT trust profile —\n'
+            'the deployed U-Boot control FDT must trust ONLY the YubiKey root:\n\n'
+            '  - ' + '\n  - '.join(bad) + '\n\n'
+            'Fix: build via a prod target (make prod / bundle-prod-full /\n'
+            'bundle-prod-full-fit) so the Makefile composes kas/fit-release-trust.yml,\n'
+            'and ensure kas/local.yml enables the YubiKey trust root\n'
+            '(IOTGW_FIT_TRUST_YK_KEY:fitflow = "1" plus IOTGW_FIT_YK_KEYDIR / KEYNAME).\n'
+            'See docs/FIT_BOOT_SIGNING.md, section "Release vs dev KAS trust profiles".'
         )
 
-    bb.debug(1, 'iotgw-uboot-prod-key-guard: key "%s" passes prod check.' % keyname)
+    bb.debug(1, 'iotgw-uboot-prod-key-guard: release trust profile active (YubiKey-only), passes.')
 }
 
 addtask iotgw_uboot_key_guard before do_configure after do_patch

--- a/scripts/sign_fit.py
+++ b/scripts/sign_fit.py
@@ -510,6 +510,43 @@ def _sha256(p: pathlib.Path) -> str:
     return h.hexdigest()
 
 
+def _detect_trust_profile_from_dtb(dtb_path: pathlib.Path) -> Optional[str]:
+    """Return 'release-trust' or 'dev' by inspecting /signature in the DTB.
+
+    Release-trust = exactly one ``key-*`` subnode and no ``required-mode``
+    property. Anything else (multiple keys, or required-mode set) is treated
+    as dev / dual-trust. Returns None on any introspection failure so the
+    caller can fall back to a profile-agnostic hint.
+    """
+    fdtget = shutil.which("fdtget")
+    if not fdtget or not dtb_path.is_file():
+        return None
+    try:
+        subnodes = subprocess.run(
+            [fdtget, "-l", str(dtb_path), "/signature"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if subnodes.returncode != 0:
+            return None
+        key_subnodes = [s for s in subnodes.stdout.split() if s.startswith("key-")]
+        props = subprocess.run(
+            [fdtget, "-p", str(dtb_path), "/signature"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if props.returncode != 0:
+            return None
+        has_required_mode = "required-mode" in props.stdout.split()
+        if len(key_subnodes) == 1 and not has_required_mode:
+            return "release-trust"
+        return "dev"
+    except (OSError, subprocess.SubprocessError):
+        return None
+
+
 def _peek_inner_fit_algo_status(
     archive: pathlib.Path, expected_algo: str
 ) -> tuple[int, int]:
@@ -611,6 +648,15 @@ def sign_bootfiles_archive(
         if not extracted_fit.is_file():
             raise SignFitError(f"fitImage not found in archive (looked at {extracted_fit})")
 
+        # Detect kas trust profile from the control DTB so the "next step"
+        # hint can point at the right resign target. Non-fatal: the operator
+        # ran sign-bootfiles-fit-yk on whatever bootfiles tarball is in
+        # DEPLOY_DIR_IMAGE; if the alternate kas profile's resign target is
+        # used the bundle assembly picks up the wrong sstate and overwrites
+        # the just-signed tarball (see issue #73 validation 2026-05-25).
+        dtbs = list(pathlib.Path(tmpdir).glob("*.dtb"))
+        trust_profile = _detect_trust_profile_from_dtb(dtbs[0]) if dtbs else None
+
         log.info("invoking signing on extracted fitImage")
         mutated = True
         sign_fit_file(
@@ -642,6 +688,7 @@ def sign_bootfiles_archive(
             "post_sha": post_sha,
             "inner_fit_algo": expected_algo,
             "mode": "signed",
+            "trust_profile": trust_profile,
         }
     except Exception:
         if mutated and backup.is_file():
@@ -750,10 +797,24 @@ def cmd_sign_bootfiles(args: argparse.Namespace) -> int:
     )
     _print_summary("sign-bootfiles summary", summary)
     if "post_sha" in summary and summary["post_sha"] != summary["pre_sha"]:
+        trust = summary.get("trust_profile")
+        if trust == "release-trust":
+            target_block = "  make bundle-prod-full-fit-resign\n"
+        elif trust == "dev":
+            target_block = "  make bundle-dev-full-fit-resign\n"
+        else:
+            # Detection failed (no DTB found, fdtget missing, etc.). Print
+            # both so the operator can pick — running the wrong one will
+            # re-stage from sstate and stomp the just-signed tarball.
+            target_block = (
+                "  make bundle-prod-full-fit-resign   # release-trust build "
+                "(kas/fit-release-trust.yml active)\n"
+                "  make bundle-dev-full-fit-resign    # dev / dual-trust build\n"
+            )
         sys.stdout.write(
             "\nNext step: re-drive the bundle recipe so it picks up the new\n"
             "tarball. With this project's KAS+make wrapper, that is:\n"
-            "  make bundle-dev-full-fit-resign\n"
+            + target_block
         )
     return 0
 


### PR DESCRIPTION
## Summary

Closes #73 — retire dual-trust file-key root from release/prod images. Adds a `kas/fit-release-trust.yml` overlay that, when composed onto `bundle-prod-full-fit*` targets, builds a single-trust-root FIT pipeline anchored on the YubiKey key (`iotgw-fit-yk-2026`). File-key signing remains the default for dev images; nothing changes for `bundle-dev-full-fit*`.

Two commits:

- **5171ca6** — kas profile split + Makefile wiring + `iotgw-uboot-prod-key-guard.bbclass` enforcement so prod always pulls the release-trust DTB.
- **f0fe672** — `scripts/sign_fit.py` detects the active trust profile from the bundled DTB after YK-resign and prints the matching `bundle-{dev,prod}-full-fit-resign` hint. Motivated by a real session trap where the unconditional dev hint led to the wrong bitbake context and stomped the YK-signed tarball.

Both commits ship together because the sign-tool hint depends on profile-detection logic that only exists once the release-trust profile is checked in.

## Validation

### Positive half — YK-signed FIT under release-trust DTB (direct, on hardware)

`build/tmp-glibc/deploy/images/raspberrypi5/iot-gw-image-prod-bundle-full-fit.raucb` built with release-trust kas overlay, YK-signed via `make sign-bootfiles-fit-yk`, reassembled via `make bundle-prod-full-fit-resign`, installed on RPi5 dev target, rebooted into slot A.

`tio-session-logs/tio_ttyACM0_2026-05-26T08:34:56.log` lines 384–411:

```
[IOTGW] FIT loaded (fitImage-a)
## Loading kernel (any) from FIT Image at 08000000 ...
   Using 'conf-primary' configuration
   Verifying Hash Integrity ... sha256,rsa2048:iotgw-fit-yk-2026+ OK
   Trying 'kernel-1' kernel subimage
   ...
   Verifying Hash Integrity ... sha256+ OK
Starting kernel ...
[    0.000000] Kernel command line: ... rauc.slot=A
```

Note **single signature attempt** — release-trust DTB has only the YK key, so no error fall-through. `rauc status` after boot shows `rootfs.0 (A) booted, boot status: good`.

### DTB trust set — exactly one key, no `required-mode`

```
$ fdtget -l /boot/bcm2712-rpi-5-b.dtb /signature
key-iotgw-fit-yk-2026
```

(Compare with dev-trust DTB which carries both `key-iotgw-fit-yk-2026` and `key-iotgw-fit-dev` plus `/signature/required-mode = "any"`.)

### Sign-tool — `_detect_trust_profile_from_dtb`

`scripts/sign_fit.py` gains a detector that reads `/signature` subnodes and `required-mode` from the DTB after extracting the inner-FIT tarball, and uses the result to pick the correct resign-target hint.

- 26/26 existing tests pass (`make test-sign-fit`)
- Live smoke against the deployed release-trust DTB returns `release-trust`
- The dev hint path is unchanged when the detector returns `dev`

### Negative half — direct on-target demonstration **NOT** captured

The negative half (file-key-signed FIT loaded into slot B, verify-fail against release-trust DTB, `[IOTGW] bootm returned for slot B: marking slot non-bootable` → fallback to slot A) was attempted but blocked by a separate prod-U-Boot env-import behaviour on this hardware. The FIT-trust mismatch verify code path is the same one PR #74 already validates with dev-trust + file-key/YK rejection; #73 only narrows the trust set from two roots to one.

Two follow-up issues filed alongside this PR, both with on-target reproduction data:

1. **Stale boot-flow env macros after `/boot/u-boot.bin` update via OTA** — RAUC bundle install replaces the U-Boot binary but does not migrate persisted env macros. `CONFIG_ENV_WRITEABLE_LIST` (correctly) rejects external import of vars not on the writeable list, so post-#77 macro fixes never reach already-deployed prod devices.
2. **Prod U-Boot drops listed-writeable RAUC env vars on import** (#81) — `BOOT_ORDER:sw`, `BOOT_A_LEFT:dw`, `BOOT_B_LEFT:dw` are in `CONFIG_ENV_FLAGS_LIST_STATIC` with the `w` access flag and *should* be importable from saved env, but observed behaviour shows Linux writes do not survive across reboot on prod-locked U-Boot. Needs an instrumented build or dev-image repro to root-cause.

Neither blocks this PR's scope (trust profile split + sign-tool ergonomics); both are pre-existing and surface independently of the release-trust profile.

## Documentation

- `docs/FIT_BOOT_SIGNING.md` updated with the release-trust profile section, build/sign/resign command sequence, and the file-key→YK transition notes.
- `kas/local.yml.example` documents the local-only override hook.

## Test plan

- [ ] `make bundle-prod-full-fit` (release-trust kas overlay auto-composed) → DTB carries only `key-iotgw-fit-yk-2026`, no `required-mode`
- [ ] `make sign-bootfiles-fit-yk && make bundle-prod-full-fit-resign` → inner FIT carries `iotgw-fit-yk-2026` signature, `python3 scripts/sign_fit.py verify` returns PASS
- [ ] `make test-sign-fit` → 26/26
- [ ] Install resulting bundle on RPi5, reboot → slot boots cleanly under release-trust DTB with single signature attempt
- [ ] `make bundle-dev-full-fit` path unchanged — dev-trust DTB still carries both keys with `required-mode = "any"`