### PR TITLE
fix(uboot): inject prod env-flags static list via source patch (#81)

### DIFF
--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0005-rpi-iotgw-prod-env-flags-list-static.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0005-rpi-iotgw-prod-env-flags-list-static.patch
@@ -1,0 +1,27 @@
+--- a/include/configs/rpi.h
++++ b/include/configs/rpi.h
+@@ -34 +34,24 @@
++/*
++ * IoT Gateway production env-flag policy.
++ *
++ * CFG_ENV_FLAGS_LIST_STATIC is a C preprocessor override consumed by
++ * include/env_flags.h -- it is NOT a Kconfig symbol and cannot be set
++ * from a defconfig fragment. Define it here so the prod build's
++ * CONFIG_ENV_WRITEABLE_LIST=y policy actually grants writeable/read-only
++ * access to the variables it expects.
++ *
++ * Flag grammar: <name>:<type><access>
++ *   types:  s=string, d=decimal
++ *   access: w=writeable, r=read-only
++ * The 'w' access bit is only meaningful when CONFIG_ENV_WRITEABLE_LIST=y.
++ */
++#ifdef CONFIG_ENV_WRITEABLE_LIST
++#ifndef CFG_ENV_FLAGS_LIST_STATIC
++#define CFG_ENV_FLAGS_LIST_STATIC \
++	"BOOT_ORDER:sw,BOOT_A_LEFT:dw,BOOT_B_LEFT:dw," \
++	"bootcount:dw,upgrade_available:dw," \
++	"iotgw_appliance:sr,iotgw_enable_netboot:sr,iotgw_diag:sr," \
++	"iotgw_bootstage:sr,EXTRA_KERNEL_ARGS:sr"
++#endif
++#endif
+ #endif

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot-prod.cfg
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/iotgw-uboot-prod.cfg
@@ -33,7 +33,13 @@ CONFIG_ENV_WRITEABLE_LIST=y
 # to this entry: U-Boot will reject any fw_setenv attempt, so the
 # `if test -n "${EXTRA_KERNEL_ARGS}"` clause in iotgw_set_bootargs never
 # triggers.
-CONFIG_ENV_FLAGS_LIST_STATIC="BOOT_ORDER:sw,BOOT_A_LEFT:dw,BOOT_B_LEFT:dw,bootcount:dw,upgrade_available:dw,iotgw_appliance:sr,iotgw_enable_netboot:sr,iotgw_diag:sr,iotgw_bootstage:sr,EXTRA_KERNEL_ARGS:sr"
+#
+# The actual list of writeable/read-only variables lives in
+# files/0005-rpi-iotgw-prod-env-flags-list-static.patch -- CFG_ENV_FLAGS_LIST_STATIC
+# is a C preprocessor macro (see include/env_flags.h), not a Kconfig symbol,
+# so it cannot be set from this defconfig fragment (merge_config silently
+# drops unknown CONFIG_* lines, which is how this was missed historically --
+# see issue #81).
 
 # Prevent the -f (force) flag from bypassing variable access controls.
 CONFIG_ENV_ACCESS_IGNORE_FORCE=y

--- a/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
+++ b/meta-iot-gateway/recipes-bsp/u-boot/u-boot_%.bbappend
@@ -20,6 +20,12 @@ SRC_URI:append = "${@' file://iotgw-uboot-fit-enforce.cfg' \
 # appliance_lockdown: production prompt/env lockdown
 SRC_URI:append = "${@' file://iotgw-uboot-prod.cfg' \
     if 'appliance_lockdown' in (d.getVar('IOTGW_UBOOT_FEATURES') or '') else ''}"
+# CFG_ENV_FLAGS_LIST_STATIC is a C macro (not Kconfig) so the prod
+# writeable-list policy must be injected via a source patch -- see
+# 0005-rpi-iotgw-prod-env-flags-list-static.patch and the comment in
+# iotgw-uboot-prod.cfg next to CONFIG_ENV_WRITEABLE_LIST.
+SRC_URI:append = "${@' file://0005-rpi-iotgw-prod-env-flags-list-static.patch' \
+    if 'appliance_lockdown' in (d.getVar('IOTGW_UBOOT_FEATURES') or '') else ''}"
 
 # ── Production key guard ─────────────────────────────────────────────────────
 inherit iotgw-uboot-prod-key-guard


### PR DESCRIPTION
## Summary
- Replace dead `CONFIG_ENV_FLAGS_LIST_STATIC=...` cfg-fragment line with a source patch that defines the actual `CFG_ENV_FLAGS_LIST_STATIC` C macro in `include/configs/rpi.h`.
- Wire the new patch into `u-boot_%.bbappend` under the existing `appliance_lockdown` feature gate (prod-only).
- Annotate the prod cfg fragment so the next reader doesn't repeat the Kconfig-vs-CPP-macro confusion.

Refs #81 (not `Fixes`: on-target acceptance test still pending — see Test plan below). Root-cause walkthrough: https://github.com/umair-as/rpi5-iot-gateway/issues/81#issuecomment-4542644495

## What was wrong

`iotgw-uboot-prod.cfg` carried `CONFIG_ENV_FLAGS_LIST_STATIC="BOOT_ORDER:sw,..."`, but there is no such Kconfig symbol in `env/Kconfig` -- `merge_config.sh` silently drops unknown `CONFIG_*` lines, so the line was dead. The real override is the C macro `CFG_ENV_FLAGS_LIST_STATIC` (`include/env_flags.h:40-42`, `#ifndef`-guarded default `""`), concatenated into `ENV_FLAGS_LIST_STATIC` at lines 87-92.

`CONFIG_ENV_WRITEABLE_LIST=y` *is* a real Kconfig symbol (selects `ENV_APPEND`), and it was being applied -- so prod ended up with the writeable-only policy active against an empty user static list. Every external import of `BOOT_ORDER`/`BOOT_A_LEFT`/`BOOT_B_LEFT` was silently rejected by `env_flags_validate` (`env/flags.c`), which is why RAUC's `fw_setenv` persisted to disk but never reached U-Boot.

## Test plan
- [x] `bitbake u-boot` under `kas/local.yml:kas/uboot-prod-hardening.yml:kas/fit-release-trust.yml` succeeds
- [x] Prod `.config` has `CONFIG_ENV_WRITEABLE_LIST=y` and `CONFIG_ENV_APPEND=y` (auto-selected); absence of `CONFIG_ENV_FLAGS_LIST_STATIC` is expected (not a Kconfig symbol)
- [x] Prod `u-boot.bin` strings contain the full list -- `BOOT_ORDER:sw,BOOT_A_LEFT:dw,BOOT_B_LEFT:dw,bootcount:dw,upgrade_available:dw,iotgw_appliance:sr,iotgw_enable_netboot:sr,iotgw_diag:sr,iotgw_bootstage:sr,EXTRA_KERNEL_ARGS:sr`
- [x] `bitbake u-boot` under `kas/local.yml` only (dev) succeeds
- [x] Dev `.config` has `CONFIG_ENV_WRITEABLE_LIST` not set, `CONFIG_BOOTDELAY=2`, `CONFIG_CMD_EDITENV=y`
- [x] Dev `u-boot.bin` strings show only the upstream default static-list segment (`eth\d*addr:mo,ipaddr:i,...serial#:so,`); no `BOOT_*:sw`/`:dw` tokens
- [ ] **On-target import test (acceptance for #81)**: from Linux, `fw_setenv BOOT_ORDER "B A"; fw_setenv BOOT_B_LEFT 3`, reboot. Post-#77 expectation: one B cycle hits FIT verify failure, `iotgw_exec_fit` marks `BOOT_B_LEFT=0` (one-cycle slot exhaustion) and `saveenv`/reset; the next cycle picks A from `BOOT_ORDER` and boots. The pre-#77 "3x B-cycles then A" pattern from the original #81 repro no longer applies on a current prod image. Deferred -- target currently in awkward post-#77 state per session notes; needs SD reflash to a fresh prod image first. **#81 stays open until this passes.**

## Scope
Narrow fix, no behaviour changes beyond making the prod env-flag policy actually take effect. Standalone -- not stacked on any other open work. Does not touch overlay reconciliation, shared-boot env migration, or anything else from the #80 design space.
