### PR TITLE
fix(ota-user): deterministic ota + iotgwtpm identity on first boot

### DIFF
--- a/meta-iot-gateway/classes/iotgw-rootfs.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rootfs.bbclass
@@ -221,3 +221,72 @@ iotgw_rootfs_seed_bashrc() {
     fi
 }
 do_rootfs[postfuncs] += "iotgw_rootfs_seed_bashrc"
+
+# -----------------------------------------------------------------------------
+# Supplementary group membership reconciliation
+# -----------------------------------------------------------------------------
+# Why: USERADD_PARAM's `--groups <X>` is racy when <X> is created by another
+# recipe -- failure is atomic and silently loses the entire useradd. This
+# block mutates /etc/group at ROOTFS_POSTPROCESS time, after all package
+# useradd/groupadd processing has completed. Race-free, deterministic, and
+# does not depend on run-postinsts.service (absent from prod images).
+#
+# Set IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS from distro/feature config, gated on
+# the relevant toggles. Space-separated <user>:<group> pairs. Names must
+# match ^[A-Za-z_][A-Za-z0-9_-]*\$?$ (POSIX form); validated at parse time.
+# A pair that names a missing user or group is fatal -- if a feature gate
+# asked for the membership but either side is absent, the image is
+# internally inconsistent and we want to fail loudly.
+IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS ??= ""
+
+python () {
+    import re
+    NAME_RE = re.compile(r'^[A-Za-z_][A-Za-z0-9_-]*\$?$')
+    spec = (d.getVar('IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS') or '').split()
+    for pair in spec:
+        if ':' not in pair:
+            bb.fatal("IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS: '%s' is not <user>:<group>" % pair)
+        user, group = pair.split(':', 1)
+        if not NAME_RE.match(user):
+            bb.fatal("IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS: invalid user name '%s'" % user)
+        if not NAME_RE.match(group):
+            bb.fatal("IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS: invalid group name '%s'" % group)
+}
+
+iotgw_rootfs_supplementary_groups() {
+    local group_file="${IMAGE_ROOTFS}${sysconfdir}/group"
+    local passwd_file="${IMAGE_ROOTFS}${sysconfdir}/passwd"
+    local pair user group tmp
+
+    [ -z "${IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS}" ] && return 0
+
+    for pair in ${IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS}; do
+        user="${pair%%:*}"
+        group="${pair##*:}"
+
+        if ! grep -q "^${user}:" "${passwd_file}"; then
+            bbfatal "iotgw-supplementary-group: user '${user}' missing from rootfs ${passwd_file#${IMAGE_ROOTFS}}"
+        fi
+        if ! grep -q "^${group}:" "${group_file}"; then
+            bbfatal "iotgw-supplementary-group: group '${group}' missing from rootfs ${group_file#${IMAGE_ROOTFS}}"
+        fi
+
+        tmp="${group_file}.iotgw-supp-tmp"
+        awk -F: -v g="${group}" -v u="${user}" '
+        BEGIN { OFS=":" }
+        $1 == g {
+            n = split($4, members, ",")
+            found = 0
+            for (i = 1; i <= n; i++) if (members[i] == u) { found = 1; break }
+            if (!found) {
+                if ($4 == "") $4 = u
+                else          $4 = $4 "," u
+            }
+        }
+        { print }
+        ' "${group_file}" > "${tmp}"
+        mv "${tmp}" "${group_file}"
+        bbnote "iotgw-supplementary-group: applied '${user}' -> '${group}'"
+    done
+}
+ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_supplementary_groups;"

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -286,6 +286,15 @@ IOTGW_RAUC_STREAMING_KEY_MODE_EFFECTIVE ?= "${@'file' if ((d.getVar('IOTGW_RAUC_
 # Internal helper gate used by OTA/RAUC recipes for TPM-only behavior.
 IOTGW_RAUC_PKCS11_USES_TPM2 ?= "${@'1' if ((d.getVar('IOTGW_RAUC_STREAMING_KEY_MODE') or 'file') == 'pkcs11' and (d.getVar('IOTGW_RAUC_PKCS11_BACKEND') or 'tpm2').lower() == 'tpm2' and (d.getVar('IOTGW_ENABLE_TPM_SLB9672') or '0') == '1') else '0'}"
 
+# Cross-recipe supplementary group membership applied at rootfs-postprocess.
+# See meta-iot-gateway/classes/iotgw-rootfs.bbclass for the mechanism. The
+# 'ota:iotgwtpm' pair is gated on the same conditions as the iotgw-tpm-policy
+# RDEPENDS in iotgw-ota-user (which is what causes iotgwtpm to exist in
+# /etc/group at all). Both must fire together; the duplicate-condition
+# pattern is tracked by the parked gating refactor.
+IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS ??= ""
+IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS += "${@'ota:iotgwtpm' if ((d.getVar('IOTGW_ENABLE_OTA_TPM_MTLS_EFFECTIVE') or '0') == '1' or (d.getVar('IOTGW_RAUC_PKCS11_USES_TPM2') or '0') == '1') else ''}"
+
 # Optional encrypted RAUC bundle support (disabled by default):
 # - build side: create `crypt` bundles and encrypt to recipient cert set
 # - target side: populate /etc/rauc/system.conf [encryption] for decrypt key

--- a/meta-iot-gateway/recipes-ota/ota-user/iotgw-ota-user_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-user/iotgw-ota-user_1.0.0.bb
@@ -37,34 +37,11 @@ USERADD_PARAM:${PN} = " \
     ota \
 "
 
+# When TPM/PKCS#11 is gated on, iotgw-tpm-policy is RDEPENDS-pulled so
+# /etc/group contains the iotgwtpm group. The 'ota -> iotgwtpm' supplementary
+# membership itself is added by ROOTFS_POSTPROCESS in iotgw-rootfs.bbclass
+# (see IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS in iotgw-common.inc) -- race-free,
+# does not depend on run-postinsts.service.
 RDEPENDS:${PN} = " \
     ${@'iotgw-tpm-policy' if ((d.getVar('IOTGW_ENABLE_OTA_TPM_MTLS_EFFECTIVE') or '0') == '1' or (d.getVar('IOTGW_RAUC_PKCS11_USES_TPM2') or '0') == '1') else ''} \
 "
-
-pkg_postinst:${PN}() {
-if [ -n "$D" ]; then
-    exit 0
-fi
-
-# Keep upgrades deterministic: existing devices may already have the ota user.
-if ! id ota >/dev/null 2>&1; then
-    echo "iotgw-ota-user: postinst skip - user 'ota' does not exist"
-    exit 0
-fi
-
-if ! getent group iotgwtpm >/dev/null 2>&1; then
-    echo "iotgw-ota-user: postinst skip - group 'iotgwtpm' does not exist"
-    exit 0
-fi
-
-if id -nG ota | tr ' ' '\n' | grep -Fxq iotgwtpm; then
-    echo "iotgw-ota-user: postinst ok - user 'ota' already in group 'iotgwtpm'"
-    exit 0
-fi
-
-if usermod -a -G iotgwtpm ota; then
-    echo "iotgw-ota-user: postinst ok - added user 'ota' to group 'iotgwtpm'"
-else
-    echo "iotgw-ota-user: postinst warning - failed to add user 'ota' to group 'iotgwtpm'" >&2
-fi
-}

--- a/meta-iot-gateway/recipes-ota/ota-user/iotgw-ota-user_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-user/iotgw-ota-user_1.0.0.bb
@@ -21,12 +21,17 @@ RPROVIDES:${PN} += "ota-user"
 
 USERADD_PACKAGES = "${PN}"
 GROUPADD_PARAM:${PN} = "-r ota"
+# Supplementary group 'iotgwtpm' (when TPM/PKCS#11 is enabled) is intentionally
+# NOT listed via --groups here: the group is provided by iotgw-tpm-policy and
+# may not yet exist in /etc/group when this useradd runs during rootfs
+# assembly. A baked-in --groups iotgwtpm fails the whole useradd in that case,
+# leaving no 'ota' user or group at all. The pkg_postinst below adds the
+# supplementary group after both packages are installed.
 USERADD_PARAM:${PN} = " \
     --system \
     --home /nonexistent \
     --no-create-home \
     --shell /bin/false \
-    ${@'--groups iotgwtpm' if ((d.getVar('IOTGW_ENABLE_OTA_TPM_MTLS_EFFECTIVE') or '0') == '1' or (d.getVar('IOTGW_RAUC_PKCS11_USES_TPM2') or '0') == '1') else ''} \
     --gid ota \
     --comment 'OTA Update Daemon' \
     ota \


### PR DESCRIPTION
## Summary

- Drop racy `--groups iotgwtpm` from `iotgw-ota-user`'s `USERADD_PARAM`. The supplementary group is created by a separate recipe (`iotgw-tpm-policy`), and rootfs assembly doesn't guarantee that recipe's `groupadd` runs before this `useradd`. When the ordering loses the race, `useradd ota --groups iotgwtpm` fails atomically — the entire useradd is lost and neither the `ota` user nor its primary group end up in the rootfs.
- Move the supplementary membership add to a new image-scope reconciler in `iotgw-rootfs.bbclass` (`IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS`). Mutates `/etc/group` at `ROOTFS_POSTPROCESS_COMMAND` time via `awk`, race-free because `/etc/group` is fully populated at that stage. Sits alongside the existing image-level finalizers in that bbclass (sudoers, sysctl, audit rules, NM masking, etc.).
- Drop the now-dead `pkg_postinst:${PN}() { if [ -n "\$D" ]; then exit 0; fi … }` from `iotgw-ota-user_1.0.0.bb`. This pattern marks the postinst "succeeded" during rootfs build and is never queued for first boot; the prod image set also doesn't ship `run-postinsts.service`, so any deferral via that mechanism would silently fail.

## Why this matters

Symptom observed on prod hardware: `ota-certs-provision.service` failed at boot with `Required group 'ota' is missing`, leaving `/etc/ota` empty and causing `rauc install` to fail with `failed to load cert file '/etc/ota/device.crt'`. Root cause was the build-time race above. After the two commits in this PR, the supplementary membership is set in `/etc/group` from `do_rootfs` onward — deterministic, no first-boot machinery required.

## Implementation notes

- New variable `IOTGW_ROOTFS_SUPPLEMENTARY_GROUPS` holds space-separated `<user>:<group>` pairs.
- Parse-time validation of names against a POSIX-ish regex (`^[A-Za-z_][A-Za-z0-9_-]*\$?\$`) so layer config can't shell-inject into the reconciler.
- The `awk` rewrite correctly handles all three `/etc/group` member-field shapes (`empty`, `existing`, `existing,user`) and is idempotent.
- `bbfatal` if any declared user or group is absent from the staged rootfs — if a feature gate asked for the membership but either side wasn't pulled in, the image is internally inconsistent and a loud build failure is preferable to a silent skip.
- `iotgw-common.inc` gates the `ota:iotgwtpm` pair on the same TPM/PKCS#11 toggles that already gate the `RDEPENDS` on `iotgw-tpm-policy` (which stays — it's what causes `iotgwtpm` to land in `/etc/group` at all).

## Test plan

- [x] `make bundle-dev-full-fit` succeeds on this branch.
- [x] Staged rootfs check: `grep '^iotgwtpm:' .../iot-gw-image-dev/.../rootfs/etc/group` → `iotgwtpm:x:NNN:ota` (member set at build time, before image packaging).
- [x] Install bundle on target via `rauc install`, reboot into new slot.
- [x] `id ota` on first boot shows `groups=NNN(ota),NNN(iotgwtpm)` with no manual intervention.
- [x] `systemctl status ota-certs-provision` reaches `active (exited)` on first boot.
- [x] `rauc status` shows new slot `status=ok`.