### PR TITLE
fix(fit): guard release-trust WIC misuse (issue #83)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ export IOTGW_ENABLE_BTF_CORE_DEV
 help:
 	@echo "Targets (RAUC-enabled by default):"
 	@echo "  make dev                  # Build developer image"
-	@echo "  make prod                 # Build production image"
+	@echo "  make prod                 # Build production image (WIC is intermediate under release-trust; see bundle-prod-full-fit-resign)"
 	@echo "  make base                 # Build base image"
 	@echo "  make desktop              # Build desktop image (Wayland/Weston)"
 	@echo "  -- Bundles (rootfs + kernel/DTBs) --"
@@ -39,7 +39,7 @@ help:
 	@echo "  make bundle-base-full-fit-fast # FIT bundle from base image (OTBR off, faster)"
 	@echo "  make bundle-prod-full     # Bundle from prod image"
 	@echo "  make bundle-prod-full-fit # FIT bundle from prod image (release trust)"
-	@echo "  make bundle-prod-full-fit-resign # Reassemble prod FIT bundle around YK-signed FIT"
+	@echo "  make bundle-prod-full-fit-resign # Reassemble prod FIT bundle around YK-signed FIT [FINAL RELEASE ARTIFACT]"
 	@echo "  make bundle-desktop-full  # Bundle from desktop image"
 	@echo "  -- Bundles (rootfs-only) --"
 	@echo "  make bundle-dev           # Rootfs-only bundle from dev image"

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -697,12 +697,16 @@ into release-trust). Signed production initial-flash SD images are not
 currently part of the supported flow; the field path is dev/dual-trust
 SD → OTA to release-trust bundle.
 
-The `iotgw-rauc-image.bbclass` carries a build-time guard
-(`iotgw_release_trust_wic_guard`, prefuncs on `do_image_wic`) that emits
-a `bb.warn` whenever a WIC is produced under release-trust, naming the
-unbootable artifact and pointing at this workflow. The warning is
-loud-by-design; if you have suppressed it locally, you've also taken on
-responsibility for not flashing the resulting `.wic.bz2`.
+The `iotgw-rauc-image.bbclass` carries a parse-time anonymous Python
+guard that emits a `bb.warn` whenever a WIC-producing image recipe is
+parsed under release-trust (i.e. `IMAGE_FSTYPES` contains a `wic`
+variant, `IOTGW_FIT_TRUST_FILE_KEY="0"`, and `IOTGW_FIT_TRUST_YK_KEY="1"`).
+The check runs at every `bitbake` invocation against an affected image
+recipe — including sstate-covered rebuilds where task prefuncs would be
+bypassed. The warning names the unbootable artifact and points at this
+workflow; it is loud-by-design. If you have suppressed it locally,
+you've also taken on responsibility for not flashing the resulting
+`.wic.bz2`.
 
 ## Signing FIT against a PKCS#11 token (YubiKey)
 

--- a/docs/FIT_BOOT_SIGNING.md
+++ b/docs/FIT_BOOT_SIGNING.md
@@ -665,6 +665,45 @@ With a single trust root the recipe leaves `required-mode` unset, so
 `fdtget "$DTB" /signature required-mode` errors with "not found" — that
 absence is the expected result, not a failure.
 
+### Supported release artifacts under the release profile
+
+Under the release profile, `make prod` does **not** produce a final
+flashable SD image. The `.wic.bz2` it deposits in `${DEPLOY_DIR_IMAGE}`
+contains a `/boot/fitImage` that is still **file-key signed** by the
+kernel recipe at build time — the DTB on the same image only trusts the
+YubiKey root, so flashing that WIC fails U-Boot FIT verification on the
+first boot cycle and exhausts both RAUC slots. This is the failure class
+tracked as **issue #83**.
+
+The detached HSM signing flow (`make sign-bootfiles-fit-yk`) finalizes
+bootfiles for **RAUC bundle delivery only**. It re-signs the FIT inside
+`bootfiles-fit.tar.gz` so the bundle's OTA install hook
+(`bundle-hooks-fit.sh`) writes a YubiKey-signed `/boot/fitImage-{a,b}`
+to the target's existing boot partition. It does **not** touch the
+WIC's `/boot/fitImage` baked into the SD image.
+
+The supported release artifact is therefore the **resigned RAUC bundle**:
+
+```bash
+make bundle-prod-full-fit            # build with file-key FIT
+make sign-bootfiles-fit-yk           # YK + PIN + touch; re-signs bootfiles tarball
+make bundle-prod-full-fit-resign     # reassembles .raucb around the re-signed tarball
+```
+
+The output `iot-gw-image-prod-bundle-full-fit.raucb` is the deliverable
+for field rollout — install it on a device that was previously
+provisioned (initial flash via a dev or dual-trust SD image, then OTA'd
+into release-trust). Signed production initial-flash SD images are not
+currently part of the supported flow; the field path is dev/dual-trust
+SD → OTA to release-trust bundle.
+
+The `iotgw-rauc-image.bbclass` carries a build-time guard
+(`iotgw_release_trust_wic_guard`, prefuncs on `do_image_wic`) that emits
+a `bb.warn` whenever a WIC is produced under release-trust, naming the
+unbootable artifact and pointing at this workflow. The warning is
+loud-by-design; if you have suppressed it locally, you've also taken on
+responsibility for not flashing the resulting `.wic.bz2`.
+
 ## Signing FIT against a PKCS#11 token (YubiKey)
 
 The default flow above signs the FIT inside bitbake against a file-based

--- a/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rauc-image.bbclass
@@ -135,3 +135,51 @@ python do_iotgw_validate_wic_alignment() {
 }
 
 addtask iotgw_validate_wic_alignment after do_image_wic before do_image_complete
+
+# -----------------------------------------------------------------------------
+# Release-trust WIC misuse guard (issue #83)
+# -----------------------------------------------------------------------------
+# Under kas/fit-release-trust.yml, the U-Boot control DTB embeds only the
+# YubiKey pubkey. The kernel recipe still signs the fitImage with the file
+# key at build time (linux-iotgw-mainline-fit_6.18.bb do_deploy:append), and
+# the WIC bootimg-partition plugin copies that file-key-signed fitImage to
+# /boot/fitImage via IMAGE_BOOT_FILES. Flashing the produced .wic.bz2 fails
+# U-Boot FIT verification on first boot (see issue #83).
+#
+# Detached signing model: the final release artifact is the resigned RAUC
+# bundle from `make bundle-prod-full-fit-resign`, NOT the WIC. Signed
+# production initial-flash SD images are not part of the supported flow.
+# This guard surfaces the misconfiguration; it does not attempt a second
+# WIC signing pipeline. bbwarn (not bbfatal) is used so the bundle workflow
+# under release-trust (which transitively depends on do_image_wic via
+# do_image_complete) is not broken.
+#
+# Anonymous python at parse time (not a do_image_wic prefunc) so the warning
+# fires on every bitbake invocation against an affected image recipe,
+# including sstate-covered rebuilds where prefuncs would be bypassed.
+python () {
+    fstypes = (d.getVar('IMAGE_FSTYPES') or '').split()
+    if not any('wic' in f for f in fstypes):
+        return
+    file_key = (d.getVar('IOTGW_FIT_TRUST_FILE_KEY') or '1') == '1'
+    yk_key   = (d.getVar('IOTGW_FIT_TRUST_YK_KEY')   or '0') == '1'
+    if (not file_key) and yk_key:
+        bb.warn(
+            "Release-trust FIT profile is active (IOTGW_FIT_TRUST_FILE_KEY=0, "
+            "IOTGW_FIT_TRUST_YK_KEY=1) but the kernel's fitImage on this WIC "
+            "is still file-key signed. The produced .wic.bz2 is NOT a final "
+            "release artifact and is known-unbootable for initial SD flash "
+            "(U-Boot FIT verify will reject the file-key signature -- see "
+            "issue #83).\n"
+            "\n"
+            "The release artifact under the detached signing model is the "
+            "resigned RAUC bundle. Use:\n"
+            "    make bundle-prod-full-fit\n"
+            "    make sign-bootfiles-fit-yk\n"
+            "    make bundle-prod-full-fit-resign\n"
+            "\n"
+            "If you need a flashable SD for development, drop "
+            "kas/fit-release-trust.yml from the kas composition -- the dev "
+            "or dual-trust profile signs the FIT with a key the DTB trusts."
+        )
+}


### PR DESCRIPTION
## Summary

- Adds a parse-time guard in `meta-iot-gateway/classes/iotgw-rauc-image.bbclass` that emits a `bb.warn` whenever a WIC-producing image recipe is parsed under the release-trust profile (`IOTGW_FIT_TRUST_FILE_KEY=0`, `IOTGW_FIT_TRUST_YK_KEY=1`). Named cause, identified consequence (unbootable `.wic.bz2`), actionable workflow pointer.
- Documents the architectural posture in `docs/FIT_BOOT_SIGNING.md`: under release-trust, `make prod` does **not** produce a final flashable SD image; the detached HSM signing flow finalizes bootfiles for RAUC bundle delivery only; the supported release artifact is the resigned RAUC bundle.
- Makefile help-text clarifies that `make prod`'s WIC is intermediate under release-trust and tags `bundle-prod-full-fit-resign` as the final release artifact.

## Why

Closes issue #83. The kernel recipe signs `fitImage` with the file key at build time (`linux-iotgw-mainline-fit_6.18.bb:188-192`). The WIC `bootimg-partition` plugin copies that file-key-signed `fitImage` to `/boot/fitImage` via `IMAGE_BOOT_FILES`. Under release-trust the DTB only trusts the YubiKey root, so flashing the produced `.wic.bz2` fails U-Boot FIT verification on the first boot cycle and exhausts both RAUC slots → halt.

The detached HSM signing model already addresses this for the **OTA delivery path** — `sign-bootfiles-fit-yk` re-signs the FIT inside `bootfiles-fit.tar.gz`, the bundle wraps the re-signed tarball, and the bundle's `bundle-hooks-fit.sh` post-install hook writes a YubiKey-signed `/boot/fitImage-{a,b}` to the target's existing boot partition on RAUC install. That path is correct and unchanged here.

The WIC path is not addressed by detached signing and is not intended to be: signed production initial-flash SD images are not currently part of the supported flow. The field path is dev/dual-trust SD → OTA to release-trust bundle. This PR makes that posture explicit at build time (loud warning) and in the docs (release-flow section).

## Why bbwarn, not bbfatal

`bbfatal` at `do_image_wic` (or any task that gates WIC production) would break `make bundle-prod-full-fit` under release-trust, because the bundle's task graph transitively depends on `do_image_complete` (which depends on `do_image_wic`). Operators must be able to run the existing 3-step release flow:
```
make bundle-prod-full-fit
make sign-bootfiles-fit-yk
make bundle-prod-full-fit-resign
```
`bbwarn` surfaces the issue loudly without breaking that intermediate workflow. The unbootable `.wic.bz2` is still produced; the warning is the operator's signal not to flash it; the docs reinforce this.

## Implementation note

Implemented as an anonymous `python ()` block rather than a `do_image_wic[prefuncs]` hook, so the warning fires on every bitbake invocation against an affected image recipe — including sstate-covered rebuilds where prefuncs would be bypassed. The check looks at `IMAGE_FSTYPES` to ensure it only triggers when a WIC will actually be produced.

## Test plan

- [x] `bitbake -e iot-gw-image-prod` under `kas/local.yml:kas/uboot-prod-hardening.yml:kas/fit-release-trust.yml` resolves `IOTGW_FIT_TRUST_FILE_KEY=0`, `IOTGW_FIT_TRUST_YK_KEY=1` — guard condition true.
- [x] `bitbake -p iot-gw-image-prod` under release-trust composition emits the warning at parse time, once per WIC-producing image recipe.
- [x] `bitbake -p iot-gw-image-dev` under `kas/local.yml` alone is silent on this guard. Dev resolves `FILE_KEY=1, YK_KEY=1` (dual-trust posture, intentionally not flagged).
- [x] Optional follow-on: `make bundle-prod-full-fit` under release-trust completes (warning emitted once during parse, but build proceeds). Existing bundle workflow unaffected.