### PR TITLE
fix(uboot): make crash-debug cmdline policy single-source

### DIFF
--- a/docs/KERNEL.md
+++ b/docs/KERNEL.md
@@ -230,10 +230,10 @@ deployments**.
 - `iotgw-crash-debug-sysctl` drops `/etc/sysctl.d/95-iotgw-crash-debug.conf`:
   `kernel.panic = ${IOTGW_CRASH_PANIC_TIMEOUT}`,
   `kernel.panic_on_oops = 1`, `kernel.sysrq = 1`.
-- `rpi-cmdline.bbappend` appends to the kernel command line:
+- `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` sets the U-Boot runtime cmdline policy:
   `panic=${IOTGW_CRASH_PANIC_TIMEOUT} oops=panic sysrq_always_enabled=1`
-  (the cmdline value governs the kernel-phase panic timeout before
-  `sysctl.d` applies; both are driven by the same variable).
+  (the cmdline value governs the kernel phase before `sysctl.d` applies;
+  both are driven by the same variable).
 
 **Layer gates:**
 - `IOTGW_ENABLE_CRASH_DEBUG_DEV` (default `"0"`) — opt-in.
@@ -250,7 +250,7 @@ deployments**.
 | `iotgw-pstore-persist` (`.mount` + tmpfiles + prune) | ✓ | ✓ |
 | `CONFIG_DYNAMIC_DEBUG`, `MAGIC_SYSRQ`, `DETECT_HUNG_TASK`, `SOFTLOCKUP_DETECTOR`, `PSTORE_FTRACE` | ✗ | ✓ |
 | `iotgw-crash-debug-sysctl` (panic/oops/sysrq sysctls) | ✗ | ✓ |
-| Cmdline `panic= oops=panic sysrq_always_enabled=1` | ✗ | ✓ |
+| U-Boot cmdline policy `panic= oops=panic sysrq_always_enabled=1` | ✗ | ✓ |
 
 ---
 

--- a/docs/UBOOT_HARDENING.md
+++ b/docs/UBOOT_HARDENING.md
@@ -199,10 +199,8 @@ policy override; in prod it's blocked, in dev it's an intentional
 operator escape hatch.
 
 If a deployed prod fleet ever needs cmdline tuning, use a signed-image path:
-1. Build a new image with the desired arg in `cmdline.txt` via
-   `rpi-cmdline.bbappend`'s `CMDLINE:append`, and/or
-2. Set build-time policy variable `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` in the
-   image build inputs.
+set build-time policy variable `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` in the image
+build inputs.
 
 `IOTGW_UBOOT_EXTRA_KERNEL_ARGS` is consumed by provisioning policy wiring:
 `iotgw-provision.sh` applies it to U-Boot env only where runtime env writes are

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -178,8 +178,8 @@ IOTGW_ENABLE_PSTORE_PERSIST_EFFECTIVE = "${@'1' if (d.getVar('IOTGW_ENABLE_CRASH
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_PSTORE_PERSIST_EFFECTIVE', '1', ' igw_pstore_persist', '', d)}"
 IOTGW_KERNEL_FEATURES:append = "${@bb.utils.contains('IOTGW_ENABLE_CRASH_DEBUG_DEV', '1', ' igw_crash_debug_dev', '', d)}"
 
-# Crash-debug panic timeout (seconds). Drives the lab sysctl + cmdline
-# drop-ins for fast post-mortem turnaround. The kernel-baked default
+# Crash-debug panic timeout (seconds). Drives the lab sysctl + U-Boot
+# cmdline policy for fast post-mortem turnaround. The kernel-baked default
 # (CONFIG_PANIC_TIMEOUT=30 in panic-recovery.cfg, always applied) is the
 # floor that covers early-boot/pre-sysctl panics. Lab sysctl overrides
 # this downward to 5s once userspace is up.
@@ -197,8 +197,9 @@ IOTGW_ENABLE_PANIC_ON_OOPS ?= "1"
 # via fw_setenv. Honoured by iotgw_set_bootargs in U-Boot, which appends
 # the value to bootargs after `root=PARTUUID` and `rauc.slot=`.
 #
-# Default empty — no runtime cmdline injection. Lab/dev profiles that
-# want panic/oops/sysrq handling for crash-debug workflows append below.
+# Default empty — no runtime cmdline injection. The crash-debug lab profile
+# owns its panic/oops/sysrq cmdline through this policy so firmware
+# cmdline.txt stays a stable Raspberry Pi baseline.
 #
 # Production images with `appliance_lockdown` reject EXTRA_KERNEL_ARGS
 # writes via the env writeable-list, so this policy is dev-only at

--- a/meta-iot-gateway/recipes-bsp/bootfiles/rpi-cmdline.bbappend
+++ b/meta-iot-gateway/recipes-bsp/bootfiles/rpi-cmdline.bbappend
@@ -5,10 +5,3 @@ CMDLINE_SERIAL = "console=ttyAMA10,115200"
 # Avoid embedding a static root= token from firmware cmdline.
 # RAUC/U-Boot chooses the active slot and injects root=PARTUUID dynamically.
 CMDLINE_ROOTFS = ""
-
-# Crash-debug lab profile (opt-in via IOTGW_ENABLE_CRASH_DEBUG_DEV=1):
-# - reserved-memory/ramoops is provided by a kernel DT patch
-# - panic= here governs the kernel-phase panic timeout (before /etc/sysctl.d
-#   applies); the same value is used post-userspace via 95-iotgw-crash-debug.conf
-#   so behavior is consistent across boot phases.
-CMDLINE:append = "${@bb.utils.contains('IOTGW_ENABLE_CRASH_DEBUG_DEV', '1', ' panic=%s oops=panic sysrq_always_enabled=1' % (d.getVar('IOTGW_CRASH_PANIC_TIMEOUT') or '5'), '', d)}"

--- a/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
@@ -242,8 +242,11 @@ case "${RAUC_SLOT_NAME:-}" in
 esac
 log_info "FIT destination: ${FIT_DEST_NAME} (slot=${RAUC_SLOT_NAME:-unknown})"
 
-# FIT variant: fitImage handled separately above; keep Image/kernel_2712 for compatibility.
-FILES=(boot.scr u-boot.bin splash.bmp Image kernel_2712.img bcm2712-rpi-5-b.dtb)
+# FIT variant: fitImage handled separately above; keep Image/kernel_2712 for
+# compatibility. cmdline.txt is image-owned firmware baseline; the
+# post-install pass below strips any stale root=/rauc.slot= tokens when
+# U-Boot is in charge.
+FILES=(boot.scr u-boot.bin cmdline.txt splash.bmp Image kernel_2712.img bcm2712-rpi-5-b.dtb)
 for f in "${FILES[@]}"; do
   if [ -f "$tmpdir/$f" ]; then
     label="$f"

--- a/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks.sh
+++ b/meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks.sh
@@ -221,8 +221,10 @@ install_if_changed() {
   return 0
 }
 
-# Files we may replace in /boot
-FILES=(boot.scr u-boot.bin splash.bmp Image kernel_2712.img bcm2712-rpi-5-b.dtb)
+# Files we may replace in /boot. cmdline.txt is image-owned firmware
+# baseline; the post-install pass below strips any stale root=/rauc.slot=
+# tokens when U-Boot is in charge.
+FILES=(boot.scr u-boot.bin cmdline.txt splash.bmp Image kernel_2712.img bcm2712-rpi-5-b.dtb)
 for f in "${FILES[@]}"; do
   if [ -f "$tmpdir/$f" ]; then
     label="$f"


### PR DESCRIPTION
## Summary
- move crash-debug kernel args ownership out of Raspberry Pi firmware cmdline and into U-Boot EXTRA_KERNEL_ARGS policy
- include cmdline.txt in FIT RAUC bootfile hook updates so OTA installs refresh the firmware baseline
- update kernel/U-Boot docs to describe U-Boot cmdline policy as the crash-debug source of truth

## Validation
- bash -n meta-iot-gateway/recipes-ota/rauc/files/bundle-hooks-fit.sh
- git diff --check
- make bundle-dev-full-fit
- RAUC install on RPi5 target: FIT hook reported bootfiles update and install succeeded
- full SD flash from generated WIC image
- target verification after reboot:
  - /boot/cmdline.txt contains only firmware baseline args
  - /proc/cmdline contains panic=5 oops=panic sysrq_always_enabled=1 exactly once
  - fw_printenv EXTRA_KERNEL_ARGS contains the crash-debug lab policy
  - /data partition is present and mounted after fresh flash

## Notes
- Existing U-Boot hardening remains intact; this follows the deferred direction from PR #57 to use U-Boot policy as the single source for runtime cmdline tuning.
