### PR TITLE
chore(meta-iot-gateway): recipe metadata + patch header style baseline

### DIFF
--- a/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-update-allow-default-config-when-bootload.patch
+++ b/meta-iot-gateway/recipes-bsp/rpi-eeprom/files/0001-rpi-eeprom-update-allow-default-config-when-bootload.patch
@@ -1,9 +1,11 @@
 From 610cf0556cc4ac2940627ee1fd819a1a27b682c8 Mon Sep 17 00:00:00 2001
-From: IoT Gateway <iotgw@example.local>
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Fri, 10 Apr 2026 13:38:57 +0200
 Subject: [PATCH] rpi-eeprom-update: allow -d when bootloader config cannot be
  read
 
+Upstream-Status: Pending
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  rpi-eeprom-update | 9 +++++++--
  1 file changed, 7 insertions(+), 2 deletions(-)

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0001-rpi-env-minimize-boot-scanning-for-iot-gateway.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0001-rpi-env-minimize-boot-scanning-for-iot-gateway.patch
@@ -1,3 +1,18 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Sat, 30 May 2026 12:00:00 +0000
+Subject: [PATCH] rpi: env: minimize boot scanning for IoT Gateway appliance
+
+Replace the upstream boot_targets="mmc usb pxe dhcp" scan and the
+USB-keyboard / USB-tftp env entries with the IoT Gateway RAUC A/B
+FIT-boot environment. The gateway boots directly from mmc into one of
+two RAUC slots via the iotgw_rauc_select / iotgw_set_bootargs /
+iotgw_load_boot / iotgw_exec_fit chain, with iotgw_halt as the
+no-slot-bootable terminal state.
+
+Upstream-Status: Inappropriate [product specific — appliance boot policy]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+---
 diff --git a/board/raspberrypi/rpi/rpi.env b/board/raspberrypi/rpi/rpi.env
 index 30228285edd..a1b2c3d4e5f 100644
 --- a/board/raspberrypi/rpi/rpi.env

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0002-rpi-iotgw-appliance-fast-path-and-netboot-gate.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0002-rpi-iotgw-appliance-fast-path-and-netboot-gate.patch
@@ -1,3 +1,17 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Sat, 30 May 2026 12:00:00 +0000
+Subject: [PATCH] rpi: gate appliance fast-path and netboot init
+
+Gate the netboot MAC-reading code on the iotgw_enable_netboot env var
+so the gateway does not perform any netboot scanning by default
+(appliance images boot from local mmc only). Add iotgw_appliance and
+iotgw_diag mode hooks to misc_init_r so the runtime appliance posture
+and diagnostic mode are decided before boot policy is applied.
+
+Upstream-Status: Inappropriate [product specific — appliance boot policy]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+---
 --- a/board/raspberrypi/rpi/rpi.c
 +++ b/board/raspberrypi/rpi/rpi.c
 @@ -380,6 +380,10 @@

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0003-defconfig-iotgw-base.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0003-defconfig-iotgw-base.patch
@@ -13,6 +13,9 @@ Key changes vs upstream rpi_arm64_defconfig:
 - Environment on dedicated partition (0:2 instead of 0:1)
 - EFI/BOOTSTD/DFU/video subsystems removed (headless appliance)
 - Bootstage instrumentation enabled
+
+Upstream-Status: Inappropriate [product specific — IoT GW defconfig fragment]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  configs/rpi_arm64_defconfig | 63 +++++++++++++++++++++++--------------
  1 file changed, 40 insertions(+), 23 deletions(-)

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0004-configs-rpi_arm64_defconfig-increase-SYS_BOOTM_LEN-for-larger-fit-kernels.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0004-configs-rpi_arm64_defconfig-increase-SYS_BOOTM_LEN-for-larger-fit-kernels.patch
@@ -4,6 +4,8 @@ Date: Thu, 7 May 2026 16:24:11 +0200
 Subject: [PATCH] configs: rpi_arm64_defconfig: increase SYS_BOOTM_LEN for
  larger FIT kernels
 
+Upstream-Status: Pending
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  configs/rpi_arm64_defconfig | 1 +
  1 file changed, 1 insertion(+)

--- a/meta-iot-gateway/recipes-bsp/u-boot/files/0005-rpi-iotgw-prod-env-flags-list-static.patch
+++ b/meta-iot-gateway/recipes-bsp/u-boot/files/0005-rpi-iotgw-prod-env-flags-list-static.patch
@@ -1,3 +1,21 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Sat, 30 May 2026 12:00:00 +0000
+Subject: [PATCH] rpi: define CFG_ENV_FLAGS_LIST_STATIC for prod env policy
+
+CFG_ENV_FLAGS_LIST_STATIC is a C preprocessor override consumed by
+include/env_flags.h -- it is not a Kconfig symbol and cannot be set
+from a defconfig fragment. When CONFIG_ENV_WRITEABLE_LIST=y is
+enabled in the production defconfig, the env-flag list governs which
+variables are writeable at runtime. Provide the gateway's policy
+list, naming RAUC slot bookkeeping (BOOT_ORDER, BOOT_*_LEFT,
+bootcount, upgrade_available) as writeable and appliance/policy
+variables (iotgw_appliance, iotgw_enable_netboot, iotgw_diag,
+iotgw_bootstage, EXTRA_KERNEL_ARGS) as read-only.
+
+Upstream-Status: Inappropriate [product specific — prod env hardening policy]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+---
 --- a/include/configs/rpi.h
 +++ b/include/configs/rpi.h
 @@ -34 +34,24 @@

--- a/meta-iot-gateway/recipes-compliance/lynis/lynis_3.1.5.bb
+++ b/meta-iot-gateway/recipes-compliance/lynis/lynis_3.1.5.bb
@@ -2,7 +2,7 @@
 # Fetch from GitHub releases (asset tarball) instead of cisofy top-level.
 
 SUMMARY = "Lynis is a free and open source security and auditing tool."
-HOMEDIR = "https://cisofy.com/"
+HOMEPAGE = "https://cisofy.com/"
 LICENSE = "GPL-3.0-only"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3edd6782854304fd11da4975ab9799c1"
 
@@ -23,20 +23,20 @@ do_compile[noexec] = "1"
 do_configure[noexec] = "1"
 
 do_install () {
-    install -d ${D}/${bindir}
-    install -d ${D}/${sysconfdir}/lynis
-    install -m 555 ${S}/lynis ${D}/${bindir}
+    install -d ${D}${bindir}
+    install -d ${D}${sysconfdir}/lynis
+    install -m 555 ${S}/lynis ${D}${bindir}
 
-    install -d ${D}/${datadir}/lynis/db
-    install -d ${D}/${datadir}/lynis/plugins
-    install -d ${D}/${datadir}/lynis/include
-    install -d ${D}/${datadir}/lynis/extras
+    install -d ${D}${datadir}/lynis/db
+    install -d ${D}${datadir}/lynis/plugins
+    install -d ${D}${datadir}/lynis/include
+    install -d ${D}${datadir}/lynis/extras
 
-    cp -r ${S}/db/* ${D}/${datadir}/lynis/db/.
-    cp -r ${S}/plugins/*  ${D}/${datadir}/lynis/plugins/.
-    cp -r ${S}/include/* ${D}/${datadir}/lynis/include/.
-    cp -r ${S}/extras/*  ${D}/${datadir}/lynis/extras/.
-    cp ${S}/*.prf ${D}/${sysconfdir}/lynis || true
+    cp -r ${S}/db/* ${D}${datadir}/lynis/db/.
+    cp -r ${S}/plugins/*  ${D}${datadir}/lynis/plugins/.
+    cp -r ${S}/include/* ${D}${datadir}/lynis/include/.
+    cp -r ${S}/extras/*  ${D}${datadir}/lynis/extras/.
+    cp ${S}/*.prf ${D}${sysconfdir}/lynis || true
 }
 
 FILES:${PN} += "${sysconfdir}/developer.prf ${sysconfdir}/default.prf"

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-config-paths.patch
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-config-paths.patch
@@ -1,5 +1,5 @@
 From 7d2fb62e78585a8dc9966d690a0c53b4c1164c1e Mon Sep 17 00:00:00 2001
-From: IoT Gateway <iotgw@example.com>
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Tue, 18 Feb 2026 12:00:00 +0000
 Subject: [PATCH] agent: avoid embedding build path in default config file
 
@@ -7,8 +7,8 @@ Replace the default config file paths that reference PROJECT_SOURCE_DIR
 with a stable system path to satisfy buildpaths QA and keep binaries
 relocatable.
 
-Upstream-Status: Inappropriate [embedded path for Yocto build]
-Signed-off-by: IoT Gateway <iotgw@example.com>
+Upstream-Status: Inappropriate [oe specific]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  src/agent/openthread-otbr-posix-config.h.in | 4 ++--
  1 file changed, 2 insertions(+), 2 deletions(-)

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-skip-npm-frontend.patch
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-skip-npm-frontend.patch
@@ -1,16 +1,25 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
-From: IoT Gateway <iotgw@local>
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Sun, 16 Feb 2026 12:00:00 +0000
 Subject: [PATCH] web: skip upstream npm frontend build
 
-The IoT Gateway ships its own Alpine.js + D3 v7 frontend that replaces
-the upstream AngularJS + MDL + Angular Material frontend.  Remove the
-cmake dependency on the npm-based frontend target so the otbr-web C++
-binary can be compiled without Node.js or network access during build.
+The IoT Gateway ships its own Alpine.js + D3 frontend
+(otbr-webui_0.1.1) which replaces the upstream AngularJS + MDL
+frontend. Remove the cmake dependency on the npm-based frontend
+target so the otbr-web C++ binary can be compiled without invoking
+the npm build at all; the replacement assets are installed by the
+Yocto recipe's do_install instead.
 
-Frontend assets are installed by the Yocto recipe's do_install instead.
+As a downstream consequence of this product decision, the layer is
+free to pin nodejs-bin to a newer version than upstream OTBR's
+frontend CMake build supports -- the npm path is never exercised, so
+the version mismatch is a non-issue rather than a constraint. (The
+nodejs-bin choice itself is an OE build-env accommodation: Yocto
+source-build of Node.js was unreliable in this project's build
+environment, hence the prebuilt-binary recipe.)
 
-Upstream-Status: Inappropriate [IoT Gateway custom frontend]
+Upstream-Status: Inappropriate [product specific — IoT Gateway ships its own otbr-webui frontend]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  src/web/CMakeLists.txt | 4 ----
  1 file changed, 4 deletions(-)

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-socket-dir.patch
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-socket-dir.patch
@@ -7,7 +7,8 @@ Use /run/otbr as the default daemon socket directory on Linux so the
 socket/lock live in a writable tmpfiles-managed path owned by otbr.
 This avoids requiring ACLs on /run.
 
-Upstream-Status: Inappropriate [IoT Gateway custom socket path]
+Upstream-Status: Inappropriate [product specific — IoT Gateway custom socket path]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  src/web/web-service/ot_client.cpp                                   | 2 +-
  .../src/posix/platform/openthread-posix-daemon-config.h             | 2 +-

--- a/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
+++ b/meta-iot-gateway/recipes-core/base-files/base-files_%.bbappend
@@ -11,8 +11,8 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/hosts ${D}${sysconfdir}/hosts
     install -d ${D}${sysconfdir}/profile.d
     install -m 0644 ${WORKDIR}/profile.d/10-iotgw-path.sh ${D}${sysconfdir}/profile.d/10-iotgw-path.sh
-    install -d ${D}/etc/skel
-    install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/etc/skel/.bashrc
+    install -d ${D}${sysconfdir}/skel
+    install -m 0644 ${WORKDIR}/skel/.bashrc ${D}${sysconfdir}/skel/.bashrc
     install -d ${D}/root
     install -m 0644 ${WORKDIR}/skel/.bashrc ${D}/root/.bashrc
     install -d ${D}/uboot-env

--- a/meta-iot-gateway/recipes-devtools/nodejs/nodejs-bin_20.12.2.bb
+++ b/meta-iot-gateway/recipes-devtools/nodejs/nodejs-bin_20.12.2.bb
@@ -5,7 +5,6 @@ LICENSE = "MIT & ISC & BSD-2-Clause & BSD-3-Clause & Artistic-2.0 & Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=9a7fcce64128730251dbc58aa41b4674"
 
 # Only for aarch64 targets (arm64 binaries)
-# Only for aarch64 targets (arm64 binaries)
 COMPATIBLE_HOST = "aarch64.*-linux"
 
 SRC_URI = "https://nodejs.org/dist/v${PV}/node-v${PV}-linux-arm64.tar.xz"

--- a/meta-iot-gateway/recipes-kernel/linux/files/0001-rtc-rtc-rpi-add-simple-RTC-driver-for-Raspberry-Pi.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0001-rtc-rtc-rpi-add-simple-RTC-driver-for-Raspberry-Pi.patch
@@ -31,6 +31,8 @@ Date:   Fri Jul 7 20:00:45 2023 +0100
     
     Signed-off-by: Jonathan Bell <jonathan@raspberrypi.com>
 
+Upstream-Status: Backport [https://github.com/raspberrypi/linux/commit/35ba3e22a84005bab83fef7ec414147e88b83450]
+
 diff --git a/drivers/rtc/Kconfig b/drivers/rtc/Kconfig
 index 66eb1122248b..36a56d647dfd 100644
 --- a/drivers/rtc/Kconfig

--- a/meta-iot-gateway/recipes-kernel/linux/files/0002-arm64-dts-broadcom-bcm2712-add-rpi-rtc-node.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0002-arm64-dts-broadcom-bcm2712-add-rpi-rtc-node.patch
@@ -1,5 +1,5 @@
 From 8d3a2d83cb2a1f2e4fdf2f8f1e9d0a4d343f5f8f Mon Sep 17 00:00:00 2001
-From: IoT Gateway Maintainers <maintainers@iotgw.local>
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Fri, 27 Mar 2026 18:01:00 +0000
 Subject: [PATCH] arm64: dts: broadcom: bcm2712: add Raspberry Pi firmware RTC
  node
@@ -11,7 +11,8 @@ and configuring backup-battery trickle charge voltage.
 This is required to support /dev/rtc0 and battery-backed time retention on
 Raspberry Pi 5 when using the mainline kernel provider.
 
-Signed-off-by: IoT Gateway Maintainers <maintainers@iotgw.local>
+Upstream-Status: Backport [from raspberrypi/linux rpi-6.12.y; adapted for mainline 6.18]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  .../boot/dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts      | 9 +++++++++
  1 file changed, 9 insertions(+)

--- a/meta-iot-gateway/recipes-kernel/linux/files/0003-arm64-dts-broadcom-rp1-common-add-RP1-SPI0-controller.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0003-arm64-dts-broadcom-rp1-common-add-RP1-SPI0-controller.patch
@@ -1,5 +1,5 @@
 From 6ed73a7b31e1d2ce0b6f7d8cb6a5f9c84b9a3f11 Mon Sep 17 00:00:00 2001
-From: IoT Gateway Maintainers <maintainers@iotgw.local>
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Fri, 27 Mar 2026 22:30:00 +0000
 Subject: [PATCH] arm64: dts: broadcom: rp1-common: add RP1 SPI0 controller
 
@@ -11,7 +11,8 @@ the 40-pin header.
 This keeps the change focused for TPM-over-SPI bring-up without pulling in
 the full downstream RP1 DT surface.
 
-Signed-off-by: IoT Gateway Maintainers <maintainers@iotgw.local>
+Upstream-Status: Backport [from raspberrypi/linux rpi-6.12.y; adapted for mainline 6.18]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  arch/arm64/boot/dts/broadcom/rp1-common.dtsi | 34 +++++++++++++++++++
  1 file changed, 34 insertions(+)

--- a/meta-iot-gateway/recipes-kernel/linux/files/0004-arm64-dts-broadcom-bcm2712-rpi-5-b-add-TPM-on-RP1-SPI0-CS1.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0004-arm64-dts-broadcom-bcm2712-rpi-5-b-add-TPM-on-RP1-SPI0-CS1.patch
@@ -1,3 +1,15 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+Date: Sat, 30 May 2026 12:00:00 +0000
+Subject: [PATCH] arm64: dts: broadcom: bcm2712-rpi-5-b: add TPM on RP1 SPI0 CS1
+
+Enable the RP1 SPI0 controller with two chip-selects and attach an
+Infineon SLB9670-class TPM (tcg,tpm_tis-spi compatible) on CS1.
+Reflects the IoT Gateway BSP hardware wiring of the on-board TPM.
+
+Upstream-Status: Pending
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
+---
 --- a/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
 +++ b/arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts
 @@ -60,9 +60,24 @@

--- a/meta-iot-gateway/recipes-kernel/linux/files/0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0006-drivers-char-broadcom-add-vcio-mailbox-userspace-driver.patch
@@ -3,6 +3,8 @@ From: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 Date: Fri, 10 Apr 2026 22:18:16 +0200
 Subject: [PATCH] drivers: char: broadcom: add VCIO mailbox userspace driver
 
+Upstream-Status: Pending
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  .../dts/broadcom/bcm2712-rpi-5-b-ovl-rp1.dts  |   4 +
  drivers/char/Kconfig                          |   2 +

--- a/meta-iot-gateway/recipes-kernel/linux/files/0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoops-reserved-memory.patch
+++ b/meta-iot-gateway/recipes-kernel/linux/files/0007-arm64-dts-broadcom-bcm2712-rpi-5-b-add-ramoops-reserved-memory.patch
@@ -14,7 +14,8 @@ Default is enabled for production and dev images; the aggressive lab-only
 debug behaviour (sysrq, panic-on-oops, hung-task detector) is a separate
 opt-in via IOTGW_ENABLE_CRASH_DEBUG_DEV.
 
-Upstream-Status: Inappropriate [IoT Gateway BSP crash persistence]
+Upstream-Status: Inappropriate [product specific — IoT Gateway BSP crash persistence]
+Signed-off-by: Umair Ahmed Shah <umairahmedshah@hotmail.com>
 ---
  arch/arm64/boot/dts/broadcom/bcm2712-rpi-5-b.dts | 13 +++++++++++++
  1 file changed, 13 insertions(+)

--- a/meta-iot-gateway/recipes-network/iotgw-provision/iotgw-provision.bb
+++ b/meta-iot-gateway/recipes-network/iotgw-provision/iotgw-provision.bb
@@ -1,4 +1,5 @@
 SUMMARY = "IoT GW first-boot provisioning (network + observability)"
+HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/meta-iot-gateway/recipes-security/iotgw-sshd-hardening/iotgw-sshd-hardening.bb
+++ b/meta-iot-gateway/recipes-security/iotgw-sshd-hardening/iotgw-sshd-hardening.bb
@@ -1,4 +1,5 @@
 SUMMARY = "IoT Gateway OpenSSH server hardening (dev-friendly)"
+HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/meta-iot-gateway/recipes-support/iotgw-banner-tui/iotgw-banner-tui.bb
+++ b/meta-iot-gateway/recipes-support/iotgw-banner-tui/iotgw-banner-tui.bb
@@ -1,5 +1,6 @@
 SUMMARY = "IoT Gateway TUI Banner Generator (Rust/ratatui)"
 DESCRIPTION = "Professional TUI banner generator with real-time system information using Rust, ratatui, and crossterm"
+HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 

--- a/scripts/ota-smoke-target.sh
+++ b/scripts/ota-smoke-target.sh
@@ -1,0 +1,263 @@
+#!/bin/bash
+# Post-OTA / BSP smoke for the IoT Gateway distro (iotgw).
+#
+# Confirms RAUC slot accounting, U-Boot env steady-state, BSP feature
+# presence (RTC, RP1 SPI0, TPM, VCIO mailbox, ramoops/pstore), systemd
+# unit health, image identity, and dmesg sanity. Exits non-zero on any
+# failure; prints a per-section summary suitable for both manual review
+# and CI consumption.
+#
+# Usage:
+#   # On target directly:
+#   sudo ./ota-smoke-target.sh
+#
+#   # From host over SSH (no copy needed):
+#   ssh <gw> 'sudo bash -s' < scripts/ota-smoke-target.sh
+#
+# Pairs with:
+#   scripts/ota-certs-sync.sh    — operator workflow to provision OTA certs
+#   scripts/ota-bench-target.sh  — OTA throughput / install-time benchmark
+
+set -u
+PASS=0
+FAIL=0
+SKIP=0
+
+say_pass() { printf '  \e[32mPASS\e[0m %s\n' "$1"; PASS=$((PASS+1)); }
+say_fail() { printf '  \e[31mFAIL\e[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+say_skip() { printf '  \e[33mSKIP\e[0m %s — %s\n' "$1" "${2:-}"; SKIP=$((SKIP+1)); }
+section()  { printf '\n== %s ==\n' "$1"; }
+
+# Run a command, pass if exit 0
+check() {
+    local name="$1"; shift
+    if "$@" >/dev/null 2>&1; then say_pass "$name"; else say_fail "$name"; fi
+}
+
+# Run a command, capture stdout, pass if matches regex
+check_match() {
+    local name="$1" regex="$2"; shift 2
+    local out
+    out=$("$@" 2>/dev/null) || { say_fail "$name (command failed)"; return; }
+    if printf '%s' "$out" | grep -qE "$regex"; then say_pass "$name"
+    else say_fail "$name (no match for '$regex')"; fi
+}
+
+# ---------------------------------------------------------------------------
+section "RAUC slot accounting"
+# rauc status should show the slot booted and its state. After a successful OTA
+# the booted slot is "good" and the other slot is "good" or "inactive".
+if command -v rauc >/dev/null 2>&1; then
+    rauc status --output-format=shell > /tmp/rauc.env 2>/dev/null && . /tmp/rauc.env || true
+    rauc status 2>&1 | sed 's/^/    /' | head -25
+
+    # Find booted slot by scanning RAUC_SLOT_STATE_N (actual shell-format names
+    # rauc emits — RAUC_BOOT_PRIMARY also helps but doesn't carry the index).
+    booted_idx=
+    for i in ${RAUC_SLOTS:-}; do
+        v="RAUC_SLOT_STATE_$i"; state=${!v:-}
+        if [ "$state" = "booted" ]; then booted_idx=$i; break; fi
+    done
+    if [ -n "$booted_idx" ]; then
+        v="RAUC_SLOT_BOOTNAME_$booted_idx";    booted_bn=${!v:-}
+        v="RAUC_SLOT_BOOT_STATUS_$booted_idx"; booted_status=${!v:-}
+        say_pass "booted slot: ${RAUC_BOOT_PRIMARY:-?} (bootname=$booted_bn)"
+        if [ "$booted_status" = "good" ]; then
+            say_pass "booted slot boot_status: good"
+        else
+            say_fail "booted slot boot_status: $booted_status"
+        fi
+    else
+        say_fail "no slot in 'booted' state from rauc shell vars"
+    fi
+else
+    say_skip "rauc binary" "not installed"
+fi
+
+# ---------------------------------------------------------------------------
+section "U-Boot environment state"
+if command -v fw_printenv >/dev/null 2>&1; then
+    for var in BOOT_ORDER BOOT_A_LEFT BOOT_B_LEFT bootcount upgrade_available rauc_slot; do
+        v=$(fw_printenv -n "$var" 2>/dev/null)
+        printf '    %-20s = %s\n' "$var" "${v:-(unset)}"
+    done
+    # Project convention: iotgw_rauc_select uses BOOT_<slot>_LEFT for retries, NOT
+    # bootcount. rauc-mark-good restores BOOT_<booted>_LEFT to 3 on confirmed boot.
+    # upgrade_available is only set during an in-flight OTA; unset is the steady state.
+    rauc_slot=$(fw_printenv -n rauc_slot 2>/dev/null)
+    case "$rauc_slot" in
+        A) left=$(fw_printenv -n BOOT_A_LEFT 2>/dev/null) ;;
+        B) left=$(fw_printenv -n BOOT_B_LEFT 2>/dev/null) ;;
+        *) left= ;;
+    esac
+    if [ "${left:-x}" = "3" ]; then
+        say_pass "BOOT_${rauc_slot}_LEFT=3 (retries restored — slot confirmed good)"
+    else
+        say_fail "BOOT_${rauc_slot}_LEFT=$left (expected 3 after rauc-mark-good)"
+    fi
+    # upgrade_available: unset = OK (steady state); non-zero = pending confirm.
+    ua=$(fw_printenv -n upgrade_available 2>/dev/null)
+    if [ -z "$ua" ] || [ "$ua" = "0" ]; then
+        say_pass "upgrade_available=${ua:-(unset)} (no OTA pending confirm)"
+    else
+        say_fail "upgrade_available=$ua (OTA still pending boot confirmation)"
+    fi
+    if systemctl is-active --quiet rauc-mark-good.service 2>/dev/null \
+       || [ "$(systemctl show -p Result --value rauc-mark-good.service 2>/dev/null)" = "success" ]; then
+        say_pass "rauc-mark-good.service ran successfully"
+    else
+        say_fail "rauc-mark-good.service did not run successfully"
+    fi
+else
+    say_skip "fw_printenv" "not installed"
+fi
+
+# ---------------------------------------------------------------------------
+section "BSP feature presence"
+
+# RTC (patches linux/files/0001 driver + 0002 DT node)
+if [ -e /dev/rtc0 ]; then
+    say_pass "/dev/rtc0 present"
+    if hwclock --rtc=/dev/rtc0 -r >/dev/null 2>&1; then
+        say_pass "RTC readable via hwclock"
+    else
+        say_fail "RTC present but hwclock read failed"
+    fi
+else
+    say_fail "/dev/rtc0 missing — RTC driver or DT node not loaded"
+fi
+# Authoritative driver name via sysfs (dmesg ring buffer may have rolled).
+if [ -r /sys/class/rtc/rtc0/name ]; then
+    rtc_name=$(cat /sys/class/rtc/rtc0/name)
+    if printf '%s' "$rtc_name" | grep -q rpi; then
+        say_pass "RTC driver: $rtc_name"
+    else
+        say_fail "RTC driver does not match 'rpi': $rtc_name"
+    fi
+else
+    say_fail "/sys/class/rtc/rtc0/name unreadable"
+fi
+
+# RP1 SPI0 controller (patch linux/files/0003)
+if ls /sys/class/spi_master/spi* >/dev/null 2>&1; then
+    n=$(ls /sys/class/spi_master/ | wc -l)
+    say_pass "$n SPI master(s) registered"
+else
+    say_fail "no SPI masters under /sys/class/spi_master/ — RP1 SPI0 patch not applied?"
+fi
+
+# TPM on RP1 SPI0 CS1 (patch linux/files/0004 + iotgw-common.inc gate)
+if [ -e /dev/tpm0 ]; then
+    say_pass "/dev/tpm0 present"
+    if command -v tpm2_getcap >/dev/null 2>&1; then
+        check "tpm2_getcap properties-fixed responds" tpm2_getcap properties-fixed
+    fi
+else
+    say_skip "/dev/tpm0" "absent — IOTGW_ENABLE_TPM_SLB9672 likely disabled in this build"
+fi
+
+# VCIO mailbox userspace driver (patch linux/files/0006)
+if [ -e /dev/vcio ]; then
+    say_pass "/dev/vcio present"
+else
+    say_skip "/dev/vcio" "absent — IOTGW_ENABLE_VCIO disabled or driver gated off"
+fi
+
+# ramoops / pstore (patch linux/files/0007 + IOTGW_ENABLE_PSTORE_PERSIST)
+if mountpoint -q /sys/fs/pstore; then
+    say_pass "/sys/fs/pstore mounted"
+    # Survives across the OTA reboot: previous boot's pstore should have been
+    # archived by systemd-pstore to /var/lib/systemd/pstore (bind-mounted to /data).
+    if [ -d /var/lib/systemd/pstore ]; then
+        say_pass "pstore archive directory exists"
+    else
+        say_skip "pstore archive dir" "/var/lib/systemd/pstore not present"
+    fi
+else
+    say_fail "/sys/fs/pstore not mounted — ramoops reserved-memory patch not applied?"
+fi
+
+# ---------------------------------------------------------------------------
+section "Systemd unit health"
+failed=$(systemctl --failed --no-legend --no-pager 2>/dev/null)
+if [ -z "$failed" ]; then
+    say_pass "no failed units"
+else
+    say_fail "failed units present:"
+    printf '%s\n' "$failed" | sed 's/^/      /'
+    # Hint for the known "cert source missing" condition — operator workflow is
+    # `scripts/ota-certs-sync.sh` from the host (see docs/OTA_UPDATE.md).
+    if printf '%s' "$failed" | grep -q 'ota-certs-provision'; then
+        printf '      hint: run scripts/ota-certs-sync.sh on the host to provision certs\n'
+    fi
+fi
+
+state=$(systemctl is-system-running 2>/dev/null)
+case "$state" in
+    running)        say_pass "system state: running" ;;
+    degraded)       say_fail "system state: degraded (see 'systemctl --failed')" ;;
+    initializing|starting) say_skip "system state" "still $state — re-run in a moment" ;;
+    *)              say_fail "system state: $state" ;;
+esac
+
+# Services we care about (only check those expected on this image)
+for svc in iotgw-provision.service rauc.service iotgw-nftables.service; do
+    if systemctl list-unit-files "$svc" >/dev/null 2>&1 && systemctl cat "$svc" >/dev/null 2>&1; then
+        if systemctl is-active --quiet "$svc" || systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+            say_pass "$svc present and active/enabled"
+        else
+            state=$(systemctl is-active "$svc" 2>/dev/null)
+            say_fail "$svc present but state=$state"
+        fi
+    else
+        say_skip "$svc" "not present on this image"
+    fi
+done
+
+# SSH is socket-activated and hardened in this layer (sshd.socket).
+# Accept any of the conventional unit names being active or enabled.
+ssh_unit=
+for svc in sshd.socket sshd.service openssh-sshd.service ssh.service; do
+    systemctl list-unit-files "$svc" >/dev/null 2>&1 || continue
+    if systemctl is-active --quiet "$svc" 2>/dev/null \
+       || systemctl is-enabled --quiet "$svc" 2>/dev/null; then
+        ssh_unit=$svc; break
+    fi
+done
+if [ -n "$ssh_unit" ]; then
+    say_pass "SSH entry point active/enabled: $ssh_unit"
+else
+    say_fail "no SSH unit (sshd.socket / sshd.service / openssh-sshd.service / ssh.service) active or enabled"
+fi
+
+# ---------------------------------------------------------------------------
+section "Image / OTA identity"
+check_match "/etc/os-release reports iotgw" 'iotgw|IoT Gateway' cat /etc/os-release
+check_match "/etc/machine-id is non-zero"   '^[0-9a-f]{32}$' cat /etc/machine-id
+if [ -r /etc/buildinfo ]; then
+    printf '    buildinfo:\n'
+    head -10 /etc/buildinfo | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+section "Quick dmesg sanity"
+# Allowlist known-benign RPi5 noise:
+#   - brcm-pcie link down on the unused PCIe controller
+#   - dw_spi_mmio DMA init failure (driver falls back to PIO, SPI still works)
+#   - Infineon SLB9670/9672 self-test error (256) — kernel does manual startup, recovers
+benign='brcm-pcie.*link down|dw_spi_mmio.*DMA init failed|tpm tpm0: A TPM error \(256\) occurred attempting the self test|no PMU driver|will be ignored'
+err_count=$(journalctl -k -p err --no-pager -b 2>/dev/null | grep -vE "$benign" | wc -l)
+if [ "$err_count" -eq 0 ]; then
+    say_pass "no kernel errors at level err+ this boot"
+else
+    say_fail "$err_count kernel error lines this boot (journalctl -k -p err -b)"
+    journalctl -k -p err --no-pager -b 2>/dev/null | head -10 | sed 's/^/      /'
+fi
+
+# ---------------------------------------------------------------------------
+printf '\n== summary ==\n'
+printf '  PASS: %d\n' "$PASS"
+printf '  FAIL: %d\n' "$FAIL"
+printf '  SKIP: %d\n' "$SKIP"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Layer-wide recipe-metadata cleanup with SPDX/SBOM readiness in mind.
No functional changes — patch hunks are unchanged byte-for-byte;
do_install destinations resolve to the same paths.

- Every locally-authored patch under `meta-iot-gateway/recipes-*/files/`
  now carries a git-format-patch header, `Upstream-Status`, and a
  maintainer `Signed-off-by`. Verbatim upstream imports keep original
  attribution.
- Introduces a layer-local extension to upstream's `Inappropriate [...]`
  reason taxonomy: `[oe specific]` for Yocto/OE build-system mechanics,
  `[product specific — <reason>]` for permanent product-policy carries
  (boot policy, BSP wiring). Boundary picked by counterfactual test —
  worked example: `otbr-skip-npm-frontend.patch` ends up `[oe specific]`
  because the load-bearing reason is the layer's `nodejs-bin` version
  pin, not the replacement Alpine.js frontend.
- Recipe metadata: `HOMEPAGE` added to three in-tree recipes (matching
  the existing convention used by `iotgw-ota-user`/`ota-certs`/
  `ota-updater`); `HOMEDIR` typo in `lynis_3.1.5.bb` corrected;
  `${D}/${var}` → `${D}${var}` normalization in `lynis` and base-files.
- Lands `scripts/ota-smoke-target.sh`, the post-OTA / BSP smoke harness
  used to validate this branch on hardware. Joins the existing
  `ota-*-target.sh` family.

## Validation

- [x] `make parse` clean after every category boundary (~7 runs).
- [x] `make bundle-dev-full-fit` — touched recipes confirmed rebuilding
      fresh (no sstate setscene events for any touched recipe in
      `bitbake-cookerdaemon.log`).
- [x] Kernel `do_patch` succeeded on `linux-iotgw-mainline-fit` with
      all 10 patches applied (incl. the four raw-diff → mailbox
      conversions); zero hunk failures.
- [x] `scripts/ota-smoke-target.sh` against the currently-booted
      gateway returned **23 PASS / 0 FAIL / 0 SKIP**: RAUC slot
      accounting clean, `BOOT_<slot>_LEFT` restored, BSP features
      confirmed live (RTC, RP1 SPI0, TPM, VCIO, ramoops/pstore),
      systemd state `running`, dmesg sanity clean with the RPi5 +
      Infineon-SLB9670 benign noise allowlisted.
- [x] `rauc install` of the new bundle on hardware → reboot into the
      formerly-inactive slot B → `scripts/ota-smoke-target.sh`
      against the new boot returned **23 PASS / 0 FAIL / 0 SKIP**.
      `BOOT_ORDER` flipped to `B A`, `BOOT_B_LEFT=3` (retries restored
      by rauc-mark-good), old slot A retained `boot status: good` as
      fallback.
