### PR TITLE
overlayfs-setup: narrow /var persistence and restore volatile semantics

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ Use these docs to customize the gateway image and runtime behavior:
 
 - [Operations](docs/OPERATIONS.md) for host build workflow, provisioning, and OTA runtime operations
 - [Partition Layouts](docs/PARTITIONS.md) for storage sizing and WKS selection
+- [Persistent State Architecture](docs/PERSISTENT_STATE.md) for writable/persistent state and what survives updates
 
 Subsystem deep dives:
 
@@ -178,6 +179,7 @@ Detailed documentation is available in the `docs/` directory:
 - **[SELinux](docs/SELINUX.md)** — Active MAC: concept primer, local wiring, refpolicy-mcs, and bring-up-to-enforcing roadmap
 - **[Kernel Configuration](docs/KERNEL.md)** — Feature sets, fragments, runtime parameters
 - **[Partition Layouts](docs/PARTITIONS.md)** — RAUC A/B partitions, WKS variants, sizing
+- **[Persistent State Architecture](docs/PERSISTENT_STATE.md)** — volatile `/var`, `/data`-backed persistent state, and what survives A/B updates
 - **[OpenThread Border Router](docs/OTBR.md)** — OTBR setup, configuration, commissioning
 - **[OTA Updates](docs/OTA_UPDATE.md)** — RAUC workflow, bundles, rollback
 - **[RAUC Update Runbook](docs/RAUC_UPDATE.md)** — Slot validation and adaptive update checks

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -90,6 +90,13 @@ flowchart TD
 | InfluxDB 1 | 1.x     | `recipes-observability/influxdb/influxdb_%.bbappend` |
 | InfluxDB 3 | 3.0.0   | `recipes-observability/influxdb3-bin/influxdb3-bin_3.0.0.bb` (experimental, see [Upgrading to InfluxDB 3](#upgrading-to-influxdb-3-native)) |
 
+**Persistence.** Mosquitto (in all image variants) keeps retained
+messages/sessions at `/data/mosquitto` (`persistence_location`), so they survive
+reboot and RAUC A/B updates. When the optional InfluxDB 3 recipe is installed,
+its data directory persists at `/data/influxdb3` (`INFLUXDB3_DATA_DIR`). The
+larger Telegraf/InfluxDB stack remains opt-in and is not in any image variant.
+See [Persistent State Architecture](PERSISTENT_STATE.md).
+
 There is no meta-package; reinstatement is done by adding the desired
 components directly to `IMAGE_INSTALL`. The previous
 `iotgw-observability-stack` meta-recipe was retired together with the

--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -374,6 +374,27 @@ For provisioning/OTA debugging, prefer the serial console or the
 persistent target tmux session (Section 9) to minimize namespace
 confusion.
 
+## 11) Persistent State
+
+`/var` is volatile; only an explicit set of paths persists on `/data`. The full
+layout — what is volatile, what persists, and what survives A/B updates — is in
+[Persistent State Architecture](PERSISTENT_STATE.md). During OTA validation,
+confirm the narrowed shape from PID1's view (per Section 10):
+
+```bash
+stat -f -c %T /proc/1/root/var/volatile                    # tmpfs
+findmnt -no SOURCE --target /var/volatile/log/journal      # /dev/...p5[/log/journal]
+findmnt -no SOURCE --target /var/volatile/log/audit        # /dev/...p5[/log/audit]
+systemctl --failed
+```
+
+The on-target smoke check includes a `/var narrowing & /data persistence`
+section:
+
+```bash
+scripts/run-target-checks.sh <device-ip> ota-smoke
+```
+
 ## Related
 
 - [RAUC Update Runbook](RAUC_UPDATE.md) - install semantics and troubleshooting

--- a/docs/OTBR.md
+++ b/docs/OTBR.md
@@ -110,6 +110,14 @@ When enabled, the following are included:
 
 **Note:** Ensure `igw_networking_iot` kernel features are enabled for nftables/NAT support.
 
+### Operational Dataset Persistence
+
+The OpenThread operational dataset (network key, PAN ID, channel) remains visible
+at `/var/lib/thread`, but that path is a bind mount from `/data/lib/thread`. The
+dataset therefore survives reboot and RAUC A/B updates, and the border router does
+not need re-commissioning after an update. See
+[Persistent State Architecture](PERSISTENT_STATE.md).
+
 ### Thread Version
 
 Default Thread version is **1.4**. Override in `kas/local.yml` if needed:

--- a/docs/PARTITIONS.md
+++ b/docs/PARTITIONS.md
@@ -125,13 +125,17 @@ space on first boot by `rauc-grow-data-partition`.
 **Mount Options:** `noatime,nodiratime,commit=60`
 
 **Purpose:**
-- Persistent application data
-- Logs (if not using journald volatile)
-- Configuration files that survive updates
-- Container volumes
-- User data
+- Persistent application data and user data
+- Persistent runtime state re-homed off the read-only rootfs (journald and audit
+  logs, SSH host keys, TPM2 PKCS#11 token DB, provisioning stamps, and more)
+- Writable OverlayFS uppers for `/etc`, `/home`, `/root` (under `overlays/`)
+- Container storage
 
-**Note:** Journald persistent storage is under `/var/log/journal` on the overlay-backed `/var` (stored on `/data`).
+**Note:** `/var` is **not** overlay-backed. Journald and audit logs persist on
+`/data` (`/data/log/{journal,audit}`) via dedicated bind mounts, not an overlay.
+The full writable/persistent-state layout — what is volatile, what persists, and
+what survives A/B updates — is documented in
+[Persistent State Architecture](PERSISTENT_STATE.md).
 
 **Survives OTA Updates:** This partition is not touched by RAUC updates.
 

--- a/docs/PERSISTENT_STATE.md
+++ b/docs/PERSISTENT_STATE.md
@@ -1,0 +1,187 @@
+# Persistent State Architecture
+
+Canonical description of writable and persistent state on the gateway. This is
+the source of truth; other documents summarize and link here rather than
+maintaining their own state maps.
+
+## Objective
+
+The device boots from an A/B pair of **read-only** root filesystems that RAUC
+replaces wholesale during an update. Nothing written to a root slot survives an
+update. All writable state therefore has to live outside the slots, on the
+shared **`/data`** partition (ext4, GPT partition `p5`, label `data`), which:
+
+- survives reboot,
+- survives a RAUC A/B slot switch and rollback (it is not a slot), and
+- is re-created empty only by a full flash/reprovision.
+
+Writable trees on the read-only rootfs are provided in one of three ways:
+persistent OverlayFS uppers on `/data` (for `/etc`, `/home`, `/root`), dedicated
+`/data`-backed bind mounts (for the small set of must-persist runtime state), or
+the stock OpenEmbedded volatile model (RAM-backed, cleared each boot).
+
+`/var` is intentionally **not** an OverlayFS mount. A blanket overlay over the
+whole `/var` captured `/var/volatile` (so the tmpfs was shadowed and "volatile"
+data persisted), persisted all of `/var` when only a small subset needs to
+survive reboot, and prevented the stock `volatile-binds` from taking effect.
+Removing the `/var` overlay restores true-volatile semantics and confines
+persistence to an explicit, bounded set of `/data`-backed paths.
+
+## The `/var` model
+
+- `/var/volatile` is a **tmpfs** (from `base-files`' fstab) and is cleared at
+  every boot.
+- `/var/log` and `/var/tmp` are the standard OE symlinks into `/var/volatile`
+  (`/var/log -> volatile/log`, `/var/tmp -> volatile/tmp`), so logs and temp
+  files are RAM-backed by default.
+- The stock OE `volatile-binds` units supply writable-but-volatile `/var/lib`,
+  `/var/cache`, `/var/spool`, and `/srv` on the read-only rootfs. These trees
+  are writable at runtime but are **not** persistent; their rootfs content is
+  visible through the copybind lower, and runtime writes are discarded at reboot.
+- `/etc`, `/home`, and `/root` keep persistent OverlayFS uppers under
+  `/data/overlays/<name>/{upper,work}`. `/var` does not. The `/etc` upper has its
+  own drift-control model across updates — see
+  [Overlay Reconciliation](OVERLAY_RECONCILIATION.md).
+
+The must-persist runtime state that would otherwise be lost is re-homed onto
+`/data` (see the map below).
+
+## Persistent-state map
+
+Persistence classes:
+
+- **Volatile** — RAM-backed, cleared at boot.
+- **Persistent** — survives reboot on `/data`.
+- **Persistent across A/B** — survives reboot *and* RAUC slot switch/rollback,
+  because `/data` is outside the root slots. All `/data`-backed rows below are in
+  this class; it follows that this state is **shared** between slots, not
+  slot-scoped.
+
+| State | Runtime path | Persistent backing | Mechanism | Notes |
+|---|---|---|---|---|
+| journald | `/var/volatile/log/journal` (via `/var/log/journal`) | `/data/log/journal` | bind mount (`var-volatile-log-journal.mount`) | `Storage=persistent`; retention below |
+| auditd | `/var/volatile/log/audit` (via `/var/log/audit`) | `/data/log/audit` | bind mount (`var-volatile-log-audit.mount`) | retention below |
+| pstore/crash | `/var/lib/systemd/pstore` | `/data/crash/pstore` | bind mount (`var-lib-systemd-pstore.mount`) | pre-existing; gated by `IOTGW_ENABLE_PSTORE_PERSIST` |
+| SSH host identity | `/data/ssh` | `/data/ssh` | direct `HostKey` paths in the read-only-rootfs sshd config | keys generated once |
+| Mosquitto retained state | `/data/mosquitto` | `/data/mosquitto` | `persistence_location` in `mosquitto.conf` | retained messages/sessions |
+| TPM2 PKCS#11 token DB | `/data/tpm2_pkcs11` | `/data/tpm2_pkcs11` | `IOTGW_TPM2_PKCS11_STORE` (provider/provisioning config) | OTA mTLS device identity |
+| OTA cert provisioning state | `/data/ota-certs-provision.state`, `/data/ota-certs-provision.done` | same | direct script paths | provision id/replay + completion stamp |
+| First-boot provisioning stamp | `/data/iotgw-provision.done` | same | direct script path | prevents re-running provisioning |
+| OpenThread dataset | `/var/lib/thread` | `/data/lib/thread` | bind mount (`var-lib-thread.mount`) | present only with OTBR builds |
+| Bluetooth adapter identity + pairings | `/var/lib/bluetooth` | `/data/lib/bluetooth` | bind mount (`var-lib-bluetooth.mount`) | gated on the `bluetooth` distro feature |
+| InfluxDB 3 data | `/data/influxdb3` | `/data/influxdb3` | `INFLUXDB3_DATA_DIR` service config | only when the optional InfluxDB 3 recipe is installed |
+| Container storage | `/var/lib/containers` (stub) | `/data/containers/storage` | `graphroot` in `storage.conf` | only with the container stack |
+| `/etc`, `/home`, `/root` | same | `/data/overlays/<name>/{upper,work}` | OverlayFS | writable-rootfs uppers |
+
+Everything else under `/var` is volatile. Notably, `/var/lib/systemd/random-seed`
+and `/var/lib/systemd/timesync/clock` are not persisted; the RTC provides a clock
+floor and systemd reseeds entropy.
+
+## Boot and mount ordering
+
+The journal and audit binds cannot rely on the normal `systemd-tmpfiles-setup`
+pass. `systemd-journal-flush.service` is ordered *before* that pass and pulls
+`/var/log/journal`, so the backing directory and mountpoint must exist earlier.
+`iotgw-log-persist-prep.service` runs early (before journal flush and auditd) and
+creates `/data/log/{journal,audit}` and the `/var/volatile/log/{journal,audit}`
+mountpoints. The bind units then depend on that oneshot rather than on the
+tmpfiles pass, which also avoids an ordering cycle with journal flush.
+
+The bind units themselves carry no install target; they are pulled and ordered
+by `Wants=`/`After=` drop-ins on their consumers — `systemd-journal-flush` for
+the journal bind and `auditd` for the audit bind — referencing the mounts by
+unit name. A `RequiresMountsFor=` on the symlinked `/var/log/...` path orders the
+consumer but does not reliably activate the bind, so the pull is wired
+explicitly.
+
+The `/var/lib` binds (Thread, Bluetooth) target real (non-symlink) paths and
+their consumers start late, so they order after `data.mount`, the stock
+`/var/lib` volatile bind (`var-volatile-lib.service`), and
+`systemd-tmpfiles-setup.service`, and are pulled by a `RequiresMountsFor=`
+drop-in on the owning service.
+
+Because `/var/lib` is now writable only after `var-volatile-lib.service` lands,
+`systemd-timesyncd` (which creates `StateDirectory=systemd/timesync`) is ordered
+after that unit via a drop-in; without it, timesyncd fails
+`238/STATE_DIRECTORY` early in boot and only recovers once the bind is up.
+
+## Retention and failure behavior
+
+**journald** — configured in `meta-iot-gateway/recipes-support/iotgw-journald`:
+`Storage=persistent`, `SystemMaxUse=64M`, `RuntimeMaxUse=32M`,
+`MaxRetentionSec=2week`, `MaxFileSec=1week`, `Compress=yes`, `Seal=yes`,
+`ForwardToSyslog=no`. The persistent journal is bounded to 64 MiB on `/data`.
+
+**auditd** — the shipped `auditd.conf` (`meta-iot-gateway/recipes-security/iotgw-audit`,
+deployed at rootfs post-processing since `auditd` owns `/etc/audit`) sets
+`max_log_file=16` MiB and `num_logs=5` (an ~80 MiB nominal rotated-file budget)
+with `max_log_file_action=ROTATE`. Disk-pressure actions are deliberately
+**non-fatal** for an unattended gateway: `disk_full_action=ROTATE`,
+`disk_error_action=SYSLOG`, and `admin_space_left_action=SYSLOG` (rather than the
+package defaults of `SUSPEND`), so a full or failing `/data` cannot wedge
+auditing. Audit-rule immutability (`-e`) is controlled separately by
+`IOTGW_AUDIT_RULE_IMMUTABLE`.
+
+These budgets bound normal growth; they do not guarantee that state can never be
+lost. A `/data` filesystem fault is not transparent — persistent state depends on
+`/data` being healthy and mounted.
+
+## Security boundaries
+
+`/data` is persistent but currently **plaintext ext4**. State placed on `/data`
+is durable but is not confidential merely by virtue of being outside the root
+slots — persistence and confidentiality are separate properties.
+
+Any future encrypted-`/data` work (for example a LUKS-backed store) must either
+preserve the same runtime-path contract described in the map above, or migrate
+the backing paths deliberately, so that services continue to find their state at
+the documented runtime paths.
+
+SELinux is enabled in **permissive** mode on this branch, and the narrowing was
+validated in that mode. The new `/data`-backed persistent paths do not yet carry
+dedicated SELinux file contexts; correct persistent-path labeling and policy are
+prerequisites for enforcing mode and are follow-up work. See
+[SELinux](SELINUX.md).
+
+## Operations and verification
+
+Read mounts from PID1's view — an interactive SSH session can sit in a
+service-hardening mount namespace that misreports mounts (see
+[Operations §10](OPERATIONS.md#10-ssh-sessions-and-mount-namespaces)).
+
+```sh
+# /var/volatile is a true tmpfs (not overlayfs)
+stat -f -c %T /proc/1/root/var/volatile            # -> tmpfs
+
+# /var has no overlay upper
+grep -q 'upperdir=[^ ,]*/overlays/var/' /proc/1/mountinfo && echo overlaid || echo clean
+
+# stock volatile-bind units are active
+systemctl is-active var-volatile-lib.service var-volatile-cache.service var-volatile-spool.service
+
+# journal/audit mount sources resolve to /data
+findmnt -no SOURCE --target /var/volatile/log/journal   # -> /dev/...p5[/log/journal]
+findmnt -no SOURCE --target /var/volatile/log/audit     # -> /dev/...p5[/log/audit]
+
+# Thread / Bluetooth binds when their features are present
+grep -E '/var/lib/(thread|bluetooth)' /proc/1/mountinfo
+```
+
+Reboot survival — write a marker, reboot, and confirm it is still readable
+(journald under the previous boot; audit in the `/data`-backed log):
+
+```sh
+MARK="persist-check-$(date +%s)"
+logger -t persist-check "$MARK"; auditctl -m "$MARK"; journalctl --rotate; sync
+reboot
+# after reboot:
+journalctl -b -1 | grep "$MARK"                 # journal marker, previous boot
+grep "$MARK" /var/log/audit/audit.log           # audit marker on /data
+```
+
+The project on-target smoke check includes a `/var narrowing & /data
+persistence` section:
+
+```sh
+scripts/run-target-checks.sh <device-ip> ota-smoke
+```

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -141,6 +141,15 @@ Rules are staged under `/usr/share/iotgw-audit/iotgw.rules` and deployed into
 `/etc/audit/rules.d/iotgw.rules` during rootfs post-processing to avoid package
 ownership conflicts with `auditd`.
 
+**Persistence and retention:** the package also ships an explicit `auditd.conf`
+(deployed the same way). Audit logs persist on `/data` — `/var/log/audit` is a
+bind mount from `/data/log/audit` — and rotate at `max_log_file=16` MiB with
+`num_logs=5` (~80 MiB nominal budget). Disk-pressure actions are deliberately
+non-fatal for an unattended gateway (`disk_full_action=ROTATE`,
+`disk_error_action=SYSLOG`, `admin_space_left_action=SYSLOG`), so a full or
+failing `/data` cannot wedge auditing. The full persistent-state layout is in
+[Persistent State Architecture](PERSISTENT_STATE.md).
+
 **What's Audited:**
 - File integrity (critical system files)
 - User/group modifications

--- a/kas/local.yml.example
+++ b/kas/local.yml.example
@@ -211,8 +211,8 @@ local_conf_header:
     # IOTGW_RAUC_PKCS11_BACKEND = "tpm2"
     # TPM2 preset (defaults in layer):
     # IOTGW_RAUC_PKCS11_TLS_KEY_TPM2 = "pkcs11:token=iotgw;object=rauc-client-key;type=private;pin-source=file:/etc/ota/pkcs11-pin"
-    # TPM2 PKCS#11 DB location for RAUC sandbox-helper:
-    # IOTGW_TPM2_PKCS11_STORE = "/var/lib/tpm2_pkcs11"
+    # TPM2 PKCS#11 DB location for RAUC sandbox-helper (persistent /data):
+    # IOTGW_TPM2_PKCS11_STORE = "/data/tpm2_pkcs11"
     # Custom backend example:
     # IOTGW_RAUC_PKCS11_TLS_KEY_CUSTOM = "pkcs11:token=<token>;object=<key>;type=private"
     # IOTGW_RAUC_PKCS11_MODULE_CUSTOM = "/usr/lib/pkcs11/<provider>.so"

--- a/meta-iot-gateway/classes/iotgw-rootfs.bbclass
+++ b/meta-iot-gateway/classes/iotgw-rootfs.bbclass
@@ -69,6 +69,13 @@ iotgw_rootfs_audit_rules() {
         sed -i -E "s/^-e[[:space:]]+[0-9]+$/-e ${audit_lock_mode}/" \
             ${IMAGE_ROOTFS}${sysconfdir}/audit/rules.d/iotgw.rules
     fi
+
+    # Override the auditd package-default auditd.conf with our retention/disk
+    # policy (non-fatal disk actions; logs persist on /data via iotgw-log-persist).
+    if [ -e ${IMAGE_ROOTFS}${datadir}/iotgw-audit/auditd.conf ]; then
+        install -m 0640 ${IMAGE_ROOTFS}${datadir}/iotgw-audit/auditd.conf \
+            ${IMAGE_ROOTFS}${sysconfdir}/audit/auditd.conf
+    fi
 }
 ROOTFS_POSTPROCESS_COMMAND += " iotgw_rootfs_audit_rules;"
 

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -332,7 +332,9 @@ IOTGW_RAUC_PKCS11_TLS_KEY_TPM2 ?= "pkcs11:token=iotgw;object=rauc-client-key;typ
 IOTGW_RAUC_PKCS11_MODULE_TPM2 ?= "/usr/lib/pkcs11/libtpm2_pkcs11.so"
 IOTGW_RAUC_PKCS11_PROVIDER_PACKAGES_TPM2 ?= "tpm2-pkcs11"
 # TPM2 PKCS#11 token DB location used by sandboxed RAUC streaming helper.
-IOTGW_TPM2_PKCS11_STORE ?= "/var/lib/tpm2_pkcs11"
+# On persistent /data (not volatile /var/lib) so the device OTA identity
+# survives reboot and A/B updates.
+IOTGW_TPM2_PKCS11_STORE ?= "/data/tpm2_pkcs11"
 
 # Custom profile preset: override these in kas/local.yml for other backends.
 IOTGW_RAUC_PKCS11_TLS_KEY_CUSTOM ?= ""

--- a/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/10-iotgw-bluetooth-persist.conf
+++ b/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/10-iotgw-bluetooth-persist.conf
@@ -8,3 +8,9 @@ RequiresMountsFor=/var/lib/bluetooth
 # StateDirectory management — clear the upstream StateDirectory=bluetooth so the
 # two do not fight over /var/lib/bluetooth.
 StateDirectory=
+# bluetooth.service runs ProtectSystem=strict, which remounts the tree read-only
+# inside the service namespace and only re-opens ReadWritePaths= as writable —
+# even over an already-mounted host bind. StateDirectory used to be that
+# exception; now that it is cleared, name the path explicitly so bluetoothd can
+# write adapter identity and pairings to the /data-backed bind.
+ReadWritePaths=/var/lib/bluetooth

--- a/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/10-iotgw-bluetooth-persist.conf
+++ b/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/10-iotgw-bluetooth-persist.conf
@@ -1,0 +1,10 @@
+[Unit]
+# Pull the /data-backed Bluetooth state bind before bluetoothd starts, so the
+# adapter identity and device pairings survive reboot on the volatile /var/lib.
+RequiresMountsFor=/var/lib/bluetooth
+
+[Service]
+# The persistent dir is provided by var-lib-bluetooth.mount, not systemd's
+# StateDirectory management — clear the upstream StateDirectory=bluetooth so the
+# two do not fight over /var/lib/bluetooth.
+StateDirectory=

--- a/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/iotgw-bluetooth-persist.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/iotgw-bluetooth-persist.tmpfiles.conf
@@ -1,0 +1,4 @@
+# Persistent backing on /data for Bluetooth adapter identity + device pairings
+# (bound over the volatile /var/lib/bluetooth by var-lib-bluetooth.mount).
+d /data/lib 0755 root root -
+d /data/lib/bluetooth 0700 root root -

--- a/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/var-lib-bluetooth.mount
+++ b/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/files/var-lib-bluetooth.mount
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bind /data-backed Bluetooth state over /var/lib/bluetooth
+DefaultDependencies=no
+After=data.mount var-volatile-lib.service systemd-tmpfiles-setup.service
+Wants=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+ConditionPathIsDirectory=/data/lib/bluetooth
+Before=bluetooth.service umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/data/lib/bluetooth
+Where=/var/lib/bluetooth
+Type=none
+Options=bind,nodev,nosuid,noexec
+DirectoryMode=0700
+TimeoutSec=10s

--- a/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/iotgw-bluetooth-persist_1.0.0.bb
+++ b/meta-iot-gateway/recipes-connectivity/iotgw-bluetooth-persist/iotgw-bluetooth-persist_1.0.0.bb
@@ -1,0 +1,37 @@
+SUMMARY = "Persist Bluetooth adapter identity and pairings on /data"
+DESCRIPTION = "Bind-mounts /data/lib/bluetooth onto /var/lib/bluetooth so BlueZ adapter identity and \
+device pairings survive reboot once /var is no longer overlaid (volatile /var/lib)."
+HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://var-lib-bluetooth.mount \
+    file://10-iotgw-bluetooth-persist.conf \
+    file://iotgw-bluetooth-persist.tmpfiles.conf \
+"
+
+S = "${UNPACKDIR}"
+
+# The .mount carries no [Install]; it is pulled on demand by the RequiresMountsFor
+# drop-in on bluetooth.service.
+do_install() {
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/var-lib-bluetooth.mount ${D}${systemd_system_unitdir}/var-lib-bluetooth.mount
+
+    install -d ${D}${systemd_system_unitdir}/bluetooth.service.d
+    install -m 0644 ${UNPACKDIR}/10-iotgw-bluetooth-persist.conf \
+        ${D}${systemd_system_unitdir}/bluetooth.service.d/10-iotgw-bluetooth-persist.conf
+
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${UNPACKDIR}/iotgw-bluetooth-persist.tmpfiles.conf \
+        ${D}${sysconfdir}/tmpfiles.d/iotgw-bluetooth-persist.conf
+}
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/var-lib-bluetooth.mount \
+    ${systemd_system_unitdir}/bluetooth.service.d/10-iotgw-bluetooth-persist.conf \
+    ${sysconfdir}/tmpfiles.d/iotgw-bluetooth-persist.conf \
+"
+
+RDEPENDS:${PN} += "util-linux systemd"

--- a/meta-iot-gateway/recipes-connectivity/mosquitto/files/iotgw-mosquitto-persist.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-connectivity/mosquitto/files/iotgw-mosquitto-persist.tmpfiles.conf
@@ -1,0 +1,3 @@
+# Persistent mosquitto state (retained messages/sessions) on /data.
+# persistence_location points here; the broker does not create it itself.
+d /data/mosquitto 0700 mosquitto mosquitto -

--- a/meta-iot-gateway/recipes-connectivity/mosquitto/files/mosquitto.conf
+++ b/meta-iot-gateway/recipes-connectivity/mosquitto/files/mosquitto.conf
@@ -1,8 +1,9 @@
 # Mosquitto MQTT Broker Configuration for IoT Gateway
 
-# Persist retained messages/sessions in writable state dir.
+# Persist retained messages/sessions on the persistent /data partition so they
+# survive reboot and A/B updates (/var/lib is volatile tmpfs on this image).
 persistence true
-persistence_location /var/lib/mosquitto/
+persistence_location /data/mosquitto/
 autosave_interval 180
 
 # Keep logs useful but not overly verbose by default.

--- a/meta-iot-gateway/recipes-connectivity/mosquitto/mosquitto_%.bbappend
+++ b/meta-iot-gateway/recipes-connectivity/mosquitto/mosquitto_%.bbappend
@@ -5,6 +5,7 @@ SRC_URI += " \
     file://20-security.conf \
     file://acl \
     file://passwd \
+    file://iotgw-mosquitto-persist.tmpfiles.conf \
 "
 
 do_install:append() {
@@ -16,4 +17,11 @@ do_install:append() {
     # Provisioning/RAUC reconciliation enforce mosquitto:mosquitto ownership at runtime.
     install -m 0600 ${UNPACKDIR}/acl ${D}${sysconfdir}/mosquitto/acl
     install -m 0600 ${UNPACKDIR}/passwd ${D}${sysconfdir}/mosquitto/passwd
+
+    # Create the persistent /data-backed state dir (persistence_location).
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${UNPACKDIR}/iotgw-mosquitto-persist.tmpfiles.conf \
+        ${D}${sysconfdir}/tmpfiles.d/iotgw-mosquitto-persist.conf
 }
+
+FILES:${PN} += "${sysconfdir}/tmpfiles.d/iotgw-mosquitto-persist.conf"

--- a/meta-iot-gateway/recipes-connectivity/openssh/files/openssh-hostkeys.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-connectivity/openssh/files/openssh-hostkeys.tmpfiles.conf
@@ -1,1 +1,1 @@
-d /var/lib/ssh 0700 root root -
+d /data/ssh 0700 root root -

--- a/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
@@ -3,24 +3,21 @@ FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 SRC_URI:append = " file://openssh-hostkeys.tmpfiles.conf"
 
 do_install:append() {
-    # For read-only-rootfs profile, OE-Core points sshd_config_readonly HostKey
-    # to /var/run/ssh (volatile), forcing key regeneration every boot.
-    # Move host keys to /var/lib/ssh so sshdgenkeys is one-time.
+    # Host keys live on the persistent /data partition, so the host identity is
+    # stable across reboots and A/B updates and sshdgenkeys runs once. /var/lib
+    # is volatile (tmpfs) on this image and OE-Core's read-only-rootfs config
+    # points HostKey at volatile /var/run/ssh, either of which would regenerate
+    # keys every boot. sshd_check_keys derives the key paths from the HostKey
+    # directives of the -f config (sshd_config_readonly, via SSHD_OPTS), so
+    # rewriting these lines is sufficient — SYSCONFDIR in /etc/default/ssh is only
+    # a runtime scratch dir and does not affect where host keys are generated.
     if [ -f ${D}${sysconfdir}/ssh/sshd_config_readonly ]; then
         sed -i '/^HostKey /d' ${D}${sysconfdir}/ssh/sshd_config_readonly
         {
-            echo "HostKey /var/lib/ssh/ssh_host_rsa_key"
-            echo "HostKey /var/lib/ssh/ssh_host_ecdsa_key"
-            echo "HostKey /var/lib/ssh/ssh_host_ed25519_key"
+            echo "HostKey /data/ssh/ssh_host_rsa_key"
+            echo "HostKey /data/ssh/ssh_host_ecdsa_key"
+            echo "HostKey /data/ssh/ssh_host_ed25519_key"
         } >> ${D}${sysconfdir}/ssh/sshd_config_readonly
-    fi
-
-    # Keep sshd_check_keys target directory aligned with readonly sshd config.
-    if [ -f ${D}${sysconfdir}/default/ssh ]; then
-        # Upstream default points to volatile /var/run/ssh on RO rootfs setups.
-        # Rewrite to persistent /var/lib/ssh so key generation is one-time.
-        sed -i -e 's#/var/run/ssh#/var/lib/ssh#g' -e 's#/run/ssh#/var/lib/ssh#g' \
-            ${D}${sysconfdir}/default/ssh
     fi
 
     # Ensure persistent host key directory exists with strict permissions.

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5.bb
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5.bb
@@ -17,6 +17,8 @@ SRC_URI += " \
     file://otbr-rcp.rules \
     file://dbus-wrapper-otbr.sh \
     file://otbr-config-paths.patch \
+    file://var-lib-thread.mount \
+    file://otbr-agent-thread-persist.conf \
 "
 
 # Ship systemd units
@@ -117,6 +119,12 @@ SYSTEMD_SERVICE:${PN} = "otbr-agent.service"
 do_install:append() {
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/otbr-agent.service ${D}${systemd_system_unitdir}/
+
+    # Persist the Thread dataset on /data (bind over volatile /var/lib/thread).
+    install -m 0644 ${UNPACKDIR}/var-lib-thread.mount ${D}${systemd_system_unitdir}/var-lib-thread.mount
+    install -d ${D}${systemd_system_unitdir}/otbr-agent.service.d
+    install -m 0644 ${UNPACKDIR}/otbr-agent-thread-persist.conf \
+        ${D}${systemd_system_unitdir}/otbr-agent.service.d/10-iotgw-thread-persist.conf
 
     # Provide default env for agent
     install -d ${D}${sysconfdir}/default

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent-thread-persist.conf
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent-thread-persist.conf
@@ -1,0 +1,5 @@
+[Unit]
+# Pull the /data-backed Thread dataset bind before otbr-agent starts, so the
+# OpenThread operational dataset (network key, PAN ID, channel) survives reboot
+# on the volatile /var/lib.
+RequiresMountsFor=/var/lib/thread

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent.service
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-agent.service
@@ -50,8 +50,10 @@ RestrictSUIDSGID=true
 LockPersonality=true
 MemoryDenyWriteExecute=false
 
-# Persistent state for OpenThread settings
-StateDirectory=thread
+# Persistent state for OpenThread settings. /var/lib is volatile on this image;
+# the Thread dataset is re-homed onto a /data-backed bind (var-lib-thread.mount,
+# pulled via the RequiresMountsFor drop-in), so StateDirectory= is intentionally
+# not used here.
 ReadWritePaths=/var/lib/thread
 ReadWritePaths=/run
 

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-tmpfiles.conf
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/otbr-tmpfiles.conf
@@ -1,2 +1,7 @@
 # Dedicated runtime dir for OTBR sockets/lock files
 d /run/otbr 0750 otbr otbr -
+
+# Persistent backing on /data for the Thread dataset (bound over /var/lib/thread
+# by var-lib-thread.mount, since /var/lib is volatile on this image).
+d /data/lib 0755 root root -
+d /data/lib/thread 0700 otbr otbr -

--- a/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/var-lib-thread.mount
+++ b/meta-iot-gateway/recipes-connectivity/otbr/otbr-rpi5/var-lib-thread.mount
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bind /data-backed Thread dataset over /var/lib/thread
+DefaultDependencies=no
+After=data.mount var-volatile-lib.service systemd-tmpfiles-setup.service
+Wants=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+ConditionPathIsDirectory=/data/lib/thread
+Before=otbr-agent.service umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/data/lib/thread
+Where=/var/lib/thread
+Type=none
+Options=bind,nodev,nosuid,noexec
+DirectoryMode=0700
+TimeoutSec=10s

--- a/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
+++ b/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
@@ -47,6 +47,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     iotgw-sysctl \
     iotgw-journald \
     iotgw-log-persist \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'bluetooth', 'iotgw-bluetooth-persist', '', d)} \
     iotgw-firewall \
     iotgw-systemd-presets \
     iotgw-provision \

--- a/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
+++ b/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
@@ -46,6 +46,7 @@ CORE_IMAGE_EXTRA_INSTALL += " \
     iotgw-network-units \
     iotgw-sysctl \
     iotgw-journald \
+    iotgw-log-persist \
     iotgw-firewall \
     iotgw-systemd-presets \
     iotgw-provision \

--- a/meta-iot-gateway/recipes-observability/influxdb3-bin/influxdb3-bin_3.0.0.bb
+++ b/meta-iot-gateway/recipes-observability/influxdb3-bin/influxdb3-bin_3.0.0.bb
@@ -34,7 +34,7 @@ do_install() {
     install -d ${D}${sysconfdir}/default
     cat > ${D}${sysconfdir}/default/influxdb3 <<'EOF'
 INFLUXDB3_HTTP_ADDR=127.0.0.1:8181
-INFLUXDB3_DATA_DIR=/var/lib/influxdb3
+INFLUXDB3_DATA_DIR=/data/influxdb3
 EOF
 
     install -d ${D}${systemd_system_unitdir}

--- a/meta-iot-gateway/recipes-observability/influxdb3-bin/influxdb3-bin_3.0.0.bb
+++ b/meta-iot-gateway/recipes-observability/influxdb3-bin/influxdb3-bin_3.0.0.bb
@@ -48,6 +48,7 @@ StartLimitIntervalSec=0
 [Service]
 Type=simple
 EnvironmentFile=-/etc/default/influxdb3
+ExecStartPre=/bin/mkdir -p ${INFLUXDB3_DATA_DIR}
 ExecStart=/usr/bin/influxdb3 serve --node-id iotgw --object-store file --data-dir ${INFLUXDB3_DATA_DIR} --http-bind ${INFLUXDB3_HTTP_ADDR}
 Restart=on-failure
 RestartSec=10

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.service
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.service
@@ -30,7 +30,7 @@ RestrictNamespaces=true
 RestrictRealtime=true
 RestrictSUIDSGID=true
 LockPersonality=true
-ReadWritePaths=/etc/ota /data /var/lib /boot
+ReadWritePaths=/etc/ota /data /boot
 
 [Install]
 WantedBy=multi-user.target

--- a/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
+++ b/meta-iot-gateway/recipes-ota/ota-certs/files/ota-certs-provision.sh
@@ -15,12 +15,15 @@ readonly CERT_DIR="/etc/ota"
 readonly BOOT_SRC="/boot/iotgw/ota"
 readonly BOOT_META="${BOOT_SRC}/meta.json"
 readonly DATA_SRC="/data/ota/certs"
-readonly STATE_FILE="/var/lib/ota-certs-provision.state"
+# State + stamp on persistent /data (/var/lib is volatile on this image): keeps
+# the provision_id replay/stale-material history and avoids re-provisioning every
+# boot.
+readonly STATE_FILE="/data/ota-certs-provision.state"
 readonly ALLOW_KEYLESS_DEVICE_CERTS="${OTA_CERTS_ALLOW_KEYLESS_DEVICE_CERTS:-0}"
 readonly REQUIRE_PKCS11_PIN="${OTA_CERTS_REQUIRE_PKCS11_PIN:-0}"
 readonly PKCS11_PIN_FILE="${CERT_DIR}/pkcs11-pin"
 readonly PKCS11_MODULE="${OTA_CERTS_PKCS11_MODULE:-/usr/lib/pkcs11/libtpm2_pkcs11.so}"
-readonly PKCS11_STORE="${OTA_CERTS_PKCS11_STORE:-/var/lib/tpm2_pkcs11}"
+readonly PKCS11_STORE="${OTA_CERTS_PKCS11_STORE:-/data/tpm2_pkcs11}"
 readonly PKCS11_TOKEN_LABEL="${OTA_CERTS_PKCS11_TOKEN_LABEL:-iotgw}"
 readonly PKCS11_KEY_LABEL="${OTA_CERTS_PKCS11_KEY_LABEL:-rauc-client-key}"
 
@@ -48,7 +51,7 @@ get_device_id() {
     printf 'unknown'
     return 0
 }
-readonly STAMP="/var/lib/ota-certs-provision.done"
+readonly STAMP="/data/ota-certs-provision.done"
 
 log_info()  { echo "[$(date -Iseconds)] [INFO]  $*"; }
 log_warn()  { echo "[$(date -Iseconds)] [WARN]  $*" >&2; }

--- a/meta-iot-gateway/recipes-ota/ota-certs/ota-certs_1.0.0.bb
+++ b/meta-iot-gateway/recipes-ota/ota-certs/ota-certs_1.0.0.bb
@@ -29,7 +29,7 @@ PACKAGES =+ "${PN}-devca"
 RAUC_OTA_CA_DIR ?= ""
 IOTGW_NEED_TPM_POLICY ?= "0"
 IOTGW_RAUC_PKCS11_USES_TPM2 ?= "0"
-IOTGW_TPM2_PKCS11_STORE ?= "/var/lib/tpm2_pkcs11"
+IOTGW_TPM2_PKCS11_STORE ?= "/data/tpm2_pkcs11"
 
 SYSTEMD_PACKAGES = "${PN}"
 SYSTEMD_SERVICE:${PN} = "ota-certs-provision.service"

--- a/meta-iot-gateway/recipes-security/iotgw-audit/files/auditd.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-audit/files/auditd.conf
@@ -1,0 +1,52 @@
+#
+# IoT Gateway audit daemon configuration.
+#
+# Based on the auditd package default, with retention and disk-full behaviour
+# tuned for an unattended gateway whose audit trail persists on /data (re-homed
+# via iotgw-log-persist). Deltas from the package default:
+#   - max_log_file 8 -> 16 (MiB per file; 16 x num_logs=5 = 80 MiB budget)
+#   - verify_email yes -> no (no MTA on the gateway)
+#   - admin_space_left_action SUSPEND -> SYSLOG   (never wedge auditing)
+#   - disk_full_action        SUSPEND -> ROTATE   (keep running, recycle logs)
+#   - disk_error_action       SUSPEND -> SYSLOG
+# Audit-rule immutability (-e 1/2) is handled separately via
+# IOTGW_AUDIT_RULE_IMMUTABLE in iotgw-rootfs.bbclass.
+#
+
+local_events = yes
+write_logs = yes
+log_file = /var/log/audit/audit.log
+log_group = root
+log_format = ENRICHED
+flush = INCREMENTAL_ASYNC
+freq = 50
+max_log_file = 16
+num_logs = 5
+priority_boost = 4
+name_format = NONE
+##name = mydomain
+max_log_file_action = ROTATE
+space_left = 75
+space_left_action = SYSLOG
+verify_email = no
+action_mail_acct = root
+admin_space_left = 50
+admin_space_left_action = SYSLOG
+disk_full_action = ROTATE
+disk_error_action = SYSLOG
+report_interval = 0
+use_libwrap = yes
+##tcp_listen_port = 60
+tcp_listen_queue = 5
+tcp_max_per_addr = 1
+##tcp_client_ports = 1024-65535
+tcp_client_max_idle = 0
+transport = TCP
+krb5_principal = auditd
+##krb5_key_file = /etc/audit/audit.key
+distribute_network = no
+q_depth = 2000
+overflow_action = SYSLOG
+max_restarts = 10
+plugin_dir = /etc/audit/plugins.d
+end_of_event_timeout = 2

--- a/meta-iot-gateway/recipes-security/iotgw-audit/iotgw-audit.bb
+++ b/meta-iot-gateway/recipes-security/iotgw-audit/iotgw-audit.bb
@@ -4,7 +4,7 @@ HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://audit.rules"
+SRC_URI = "file://audit.rules file://auditd.conf"
 
 # Ensure auditd is present and owns /etc/audit; avoid packaging that directory here
 RDEPENDS:${PN} = "auditd"
@@ -14,9 +14,10 @@ S = "${UNPACKDIR}"
 do_install() {
     # Stage under datadir — auditd owns /etc/audit and /etc/audit/rules.d, so we
     # cannot package into those directories directly. iotgw-rootfs.bbclass deploys
-    # the rules into the image rootfs via ROOTFS_POSTPROCESS_COMMAND.
+    # the rules and auditd.conf into the image rootfs via ROOTFS_POSTPROCESS_COMMAND.
     install -d ${D}${datadir}/iotgw-audit
     install -m 0640 ${UNPACKDIR}/audit.rules ${D}${datadir}/iotgw-audit/iotgw.rules
+    install -m 0640 ${UNPACKDIR}/auditd.conf ${D}${datadir}/iotgw-audit/auditd.conf
 }
 
-FILES:${PN} = "${datadir}/iotgw-audit/iotgw.rules"
+FILES:${PN} = "${datadir}/iotgw-audit/iotgw.rules ${datadir}/iotgw-audit/auditd.conf"

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/10-iotgw-auditd.conf
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/10-iotgw-auditd.conf
@@ -1,0 +1,7 @@
+[Unit]
+# Pull and order the /data-backed audit bind before auditd opens its log, so the
+# audit trail persists on /data instead of the volatile /var/log tmpfs. Wire it
+# explicitly by unit name (RequiresMountsFor= via the /var/log symlink orders but
+# does not reliably activate the bind at boot).
+Wants=var-volatile-log-audit.mount
+After=var-volatile-log-audit.mount

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/10-iotgw-journal-flush.conf
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/10-iotgw-journal-flush.conf
@@ -1,0 +1,7 @@
+[Unit]
+# Pull and order the /data-backed journal bind so persistent journals land on
+# /data instead of the volatile /var/log tmpfs. RequiresMountsFor= resolved via
+# the /var/log symlink orders but does not reliably activate the bind at boot,
+# so wire it explicitly by unit name.
+Wants=var-volatile-log-journal.mount
+After=var-volatile-log-journal.mount

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/iotgw-log-persist-prep.service
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/iotgw-log-persist-prep.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=Prepare /data-backed log dirs and mountpoints before journald/auditd
+DefaultDependencies=no
+After=data.mount var-volatile.mount
+Wants=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+# Must complete before the binds and their early consumers so the persistent
+# journal/audit storage exists at flush time (journal-flush is Before= the
+# normal tmpfiles pass).
+Before=var-volatile-log-journal.mount var-volatile-log-audit.mount
+Before=systemd-journal-flush.service auditd.service sysinit.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/sbin/iotgw-log-persist-prep
+
+[Install]
+WantedBy=sysinit.target

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/iotgw-log-persist-prep.sh
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/iotgw-log-persist-prep.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+# Prepare the /data-backed log backing dirs and their volatile mountpoints
+# BEFORE systemd-journal-flush / auditd run.
+#
+# systemd-journal-flush.service is ordered Before=systemd-tmpfiles-setup.service
+# and RequiresMountsFor=/var/log/journal, so the journal bind (and therefore its
+# backing dir + mountpoint) must be ready earlier than the normal tmpfiles pass.
+# Ordering a .mount After=systemd-tmpfiles-setup.service would create a cycle
+# (flush -> mount -> tmpfiles -> flush); this oneshot creates the directories
+# early instead, so the mounts only depend on it.
+set -e
+
+# Persistent backing on /data.
+install -d -m 0755 -o root -g root /data/log
+install -d -m 2755 -o root -g systemd-journal /data/log/journal
+install -d -m 0700 -o root -g root /data/log/audit
+
+# Mountpoints on the volatile /var/volatile/log tmpfs (/var/log -> volatile/log).
+install -d -m 0755 -o root -g root /var/volatile/log
+install -d -m 2755 -o root -g systemd-journal /var/volatile/log/journal
+install -d -m 0700 -o root -g root /var/volatile/log/audit

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/var-volatile-log-audit.mount
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/var-volatile-log-audit.mount
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bind /data-backed audit log storage over /var/volatile/log/audit
+Documentation=man:auditd(8)
+DefaultDependencies=no
+After=data.mount var-volatile.mount iotgw-log-persist-prep.service
+Requires=iotgw-log-persist-prep.service
+Wants=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+ConditionPathIsDirectory=/data/log/audit
+Before=auditd.service umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/data/log/audit
+Where=/var/volatile/log/audit
+Type=none
+Options=bind,nodev,nosuid,noexec
+DirectoryMode=0700
+TimeoutSec=10s

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/files/var-volatile-log-journal.mount
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/files/var-volatile-log-journal.mount
@@ -1,0 +1,20 @@
+[Unit]
+Description=Bind /data-backed journal storage over /var/volatile/log/journal
+Documentation=man:systemd-journald.service(8)
+DefaultDependencies=no
+After=data.mount var-volatile.mount iotgw-log-persist-prep.service
+Requires=iotgw-log-persist-prep.service
+Wants=data.mount
+RequiresMountsFor=/data
+ConditionPathIsMountPoint=/data
+ConditionPathIsDirectory=/data/log/journal
+Before=systemd-journal-flush.service umount.target
+Conflicts=umount.target
+
+[Mount]
+What=/data/log/journal
+Where=/var/volatile/log/journal
+Type=none
+Options=bind,nodev,nosuid,noexec
+DirectoryMode=2755
+TimeoutSec=10s

--- a/meta-iot-gateway/recipes-support/iotgw-log-persist/iotgw-log-persist_1.0.0.bb
+++ b/meta-iot-gateway/recipes-support/iotgw-log-persist/iotgw-log-persist_1.0.0.bb
@@ -1,0 +1,58 @@
+SUMMARY = "Persist journald and audit logs on /data for read-only rootfs deployments"
+DESCRIPTION = "Bind-mounts /data/log/{journal,audit} onto the volatile /var/volatile/log/{journal,audit} \
+via systemd .mount units so the must-persist logs survive reboot once /var is no longer overlaid. \
+An early oneshot prepares the backing dirs and mountpoints before journald flush; the binds are \
+pulled by Wants= drop-ins on systemd-journal-flush and auditd."
+HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+SRC_URI = " \
+    file://iotgw-log-persist-prep.sh \
+    file://iotgw-log-persist-prep.service \
+    file://var-volatile-log-journal.mount \
+    file://var-volatile-log-audit.mount \
+    file://10-iotgw-journal-flush.conf \
+    file://10-iotgw-auditd.conf \
+"
+
+inherit systemd
+
+S = "${UNPACKDIR}"
+
+# The prep oneshot runs early (WantedBy=sysinit.target) to create the backing
+# dirs + mountpoints before the binds. The .mount units carry no [Install]: they
+# are pulled + ordered by Wants=/After= drop-ins on their consumers
+# (systemd-journal-flush and auditd) — RequiresMountsFor= via the /var/log
+# symlink orders but does not reliably activate the bind at boot.
+SYSTEMD_SERVICE:${PN} = "iotgw-log-persist-prep.service"
+SYSTEMD_AUTO_ENABLE = "enable"
+
+do_install() {
+    install -d ${D}${sbindir}
+    install -m 0755 ${UNPACKDIR}/iotgw-log-persist-prep.sh ${D}${sbindir}/iotgw-log-persist-prep
+
+    install -d ${D}${systemd_system_unitdir}
+    install -m 0644 ${UNPACKDIR}/iotgw-log-persist-prep.service ${D}${systemd_system_unitdir}/iotgw-log-persist-prep.service
+    install -m 0644 ${UNPACKDIR}/var-volatile-log-journal.mount ${D}${systemd_system_unitdir}/var-volatile-log-journal.mount
+    install -m 0644 ${UNPACKDIR}/var-volatile-log-audit.mount ${D}${systemd_system_unitdir}/var-volatile-log-audit.mount
+
+    install -d ${D}${systemd_system_unitdir}/systemd-journal-flush.service.d
+    install -m 0644 ${UNPACKDIR}/10-iotgw-journal-flush.conf \
+        ${D}${systemd_system_unitdir}/systemd-journal-flush.service.d/10-iotgw-log-persist.conf
+
+    install -d ${D}${systemd_system_unitdir}/auditd.service.d
+    install -m 0644 ${UNPACKDIR}/10-iotgw-auditd.conf \
+        ${D}${systemd_system_unitdir}/auditd.service.d/10-iotgw-log-persist.conf
+}
+
+FILES:${PN} += " \
+    ${sbindir}/iotgw-log-persist-prep \
+    ${systemd_system_unitdir}/iotgw-log-persist-prep.service \
+    ${systemd_system_unitdir}/var-volatile-log-journal.mount \
+    ${systemd_system_unitdir}/var-volatile-log-audit.mount \
+    ${systemd_system_unitdir}/systemd-journal-flush.service.d/10-iotgw-log-persist.conf \
+    ${systemd_system_unitdir}/auditd.service.d/10-iotgw-log-persist.conf \
+"
+
+RDEPENDS:${PN} += "util-linux systemd coreutils"

--- a/meta-iot-gateway/recipes-support/iotgw-provision/files/iotgw-provision.sh
+++ b/meta-iot-gateway/recipes-support/iotgw-provision/files/iotgw-provision.sh
@@ -1,7 +1,9 @@
 #!/bin/bash
 set -euo pipefail
 
-STAMP="/var/lib/iotgw-provision.done"
+# Completion stamp on persistent /data (/var/lib is volatile on this image, so a
+# stamp there would make first-boot provisioning re-run every boot).
+STAMP="/data/iotgw-provision.done"
 SRC_DIR="/data/iotgw"
 UBOOT_POLICY="/etc/default/iotgw-uboot-policy"
 CHANGED=0

--- a/meta-iot-gateway/recipes-support/iotgw-pstore-persist/files/var-lib-systemd-pstore.mount
+++ b/meta-iot-gateway/recipes-support/iotgw-pstore-persist/files/var-lib-systemd-pstore.mount
@@ -2,7 +2,7 @@
 Description=Bind /data-backed pstore archive over /var/lib/systemd/pstore
 Documentation=man:systemd-pstore.service(8)
 DefaultDependencies=no
-After=data.mount overlayfs-setup.service systemd-tmpfiles-setup.service
+After=data.mount var-volatile-lib.service systemd-tmpfiles-setup.service
 Wants=data.mount
 RequiresMountsFor=/data
 ConditionPathIsMountPoint=/data

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/iotgw-var-volatile-relabel.tmpfiles.conf
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/iotgw-var-volatile-relabel.tmpfiles.conf
@@ -1,0 +1,16 @@
+# Repair the /var/volatile tmpfs root label at the normal tmpfiles pass.
+#
+# The fstab rootcontext=...:var_t lands as unlabeled_t on the tmpfs root because
+# systemd resolves the mount's SID at the policy-load boundary. A non-recursive
+# `z` (the directory itself only) restores the correct label from file_contexts
+# (/var/volatile -> var_t) without touching the correctly-typed children
+# (var_log_t/tmp_t) or the /data-backed log binds beneath it. Do NOT use `Z`
+# (recursive) here — it would relabel the whole volatile subtree, including the
+# bind mounts.
+#
+# NOTE: this is a steady-state repair, not a full race fix. tmpfiles runs after
+# local-fs.target, whereas OE volatile-binds run before it — so an early
+# volatile-bind operation can still observe the pre-relabel root. That gap is
+# harmless while globally permissive; closing it for enforcing needs an earlier
+# relabel (tracked with the enforcing-transition work), not this entry.
+z /var/volatile - - - - -

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.service
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.service
@@ -3,16 +3,10 @@ Description=Setup overlayfs for read-only rootfs
 DefaultDependencies=no
 After=data.mount
 Before=sysinit.target
-# Early sysinit-phase services that write under /var must wait for this overlay,
-# otherwise they run while /var is still the read-only rootfs lowerdir:
-#  - systemd-journal-flush: silently finds nothing to flush, journald stays on
-#    /run/log/journal for the rest of the boot.
-#  - systemd-timesyncd: StateDirectory=systemd/timesync cannot be created on the
-#    read-only /var and the unit fails with 238/STATE_DIRECTORY.
-# Both race overlayfs-setup toward sysinit.target, so Before=sysinit.target
-# alone is insufficient — order them explicitly.
-Before=systemd-journal-flush.service
-Before=systemd-timesyncd.service
+# This overlays /etc, /home, /root only. /var is no longer overlaid — journald
+# persistence is handled by iotgw-log-persist's bind (ordered before
+# systemd-journal-flush) and timesyncd's StateDirectory lands on the volatile
+# /var/lib tmpfs (volatile-binds), so neither needs to wait on this unit.
 Wants=data.mount
 RequiresMountsFor=/data
 ConditionPathIsMountPoint=/data

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.sh
@@ -1,6 +1,12 @@
 #!/bin/sh
 # Setup overlayfs mounts for read-only rootfs with RAUC
-# This script creates writable overlays on /data for /etc, /var, /home, /root
+# This script creates writable overlays on /data for /etc, /home, /root.
+#
+# /var is deliberately NOT overlaid: it is served by the stock OE volatile model
+# (tmpfs /var/volatile + volatile-binds for /var/{lib,cache,spool}/srv), so it is
+# genuinely volatile. The few must-persist trees are re-homed onto dedicated
+# /data-backed mounts/redirects (journald+audit via iotgw-log-persist; ssh keys,
+# TPM store, influxdb, mosquitto via service config). See #93.
 
 set -e
 
@@ -8,7 +14,7 @@ DATA_PART="/data"
 OVERLAY_BASE="${DATA_PART}/overlays"
 
 # Directories to overlay (make writable on top of read-only rootfs)
-OVERLAY_DIRS="/etc /var /home /root"
+OVERLAY_DIRS="/etc /home /root"
 
 # Ensure /data is mounted
 if ! mountpoint -q "${DATA_PART}"; then
@@ -46,7 +52,7 @@ for dir in ${OVERLAY_DIRS}; do
     # Default options
     opts="lowerdir=${dir},upperdir=${upper},workdir=${work},rw"
     case "${dir}" in
-        /home|/var)
+        /home)
             opts="${opts},nodev,nosuid"
             ;;
     esac

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/systemd-timesyncd-after-volatile-lib.conf
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/systemd-timesyncd-after-volatile-lib.conf
@@ -1,0 +1,7 @@
+[Unit]
+# /var is no longer overlaid, so /var/lib becomes writable via the stock
+# volatile-binds copybind (var-volatile-lib.service). timesyncd's
+# StateDirectory=systemd/timesync cannot be created before that, so without this
+# ordering timesyncd fails 238/STATE_DIRECTORY a few times early in boot and only
+# recovers once the bind lands. Order it after the bind.
+After=var-volatile-lib.service

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
@@ -8,6 +8,7 @@ SRC_URI = "\
     file://overlayfs-setup.sh \
     file://overlayfs-setup.service \
     file://iotgw-var-volatile-relabel.tmpfiles.conf \
+    file://systemd-timesyncd-after-volatile-lib.conf \
 "
 
 inherit systemd
@@ -30,11 +31,18 @@ do_install() {
     install -d ${D}${sysconfdir}/tmpfiles.d
     install -m 0644 ${UNPACKDIR}/iotgw-var-volatile-relabel.tmpfiles.conf \
         ${D}${sysconfdir}/tmpfiles.d/iotgw-var-volatile-relabel.conf
+
+    # Order timesyncd after the volatile-binds /var/lib so its StateDirectory
+    # can be created (no more early 238/STATE_DIRECTORY failures).
+    install -d ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d
+    install -m 0644 ${UNPACKDIR}/systemd-timesyncd-after-volatile-lib.conf \
+        ${D}${systemd_system_unitdir}/systemd-timesyncd.service.d/10-iotgw-after-volatile-lib.conf
 }
 
 FILES:${PN} += " \
     ${sbindir}/overlayfs-setup.sh \
     ${systemd_system_unitdir}/overlayfs-setup.service \
     ${sysconfdir}/tmpfiles.d/iotgw-var-volatile-relabel.conf \
+    ${systemd_system_unitdir}/systemd-timesyncd.service.d/10-iotgw-after-volatile-lib.conf \
 "
 RDEPENDS:${PN} += "bash"

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
@@ -1,5 +1,5 @@
 SUMMARY = "Overlayfs setup for read-only rootfs with RAUC"
-DESCRIPTION = "Provides overlayfs mounts for writable directories (/etc, /var, /home, /root) on top of read-only rootfs"
+DESCRIPTION = "Provides overlayfs mounts for writable directories (/etc, /home, /root) on top of read-only rootfs"
 HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/overlayfs-setup.bb
@@ -7,6 +7,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 SRC_URI = "\
     file://overlayfs-setup.sh \
     file://overlayfs-setup.service \
+    file://iotgw-var-volatile-relabel.tmpfiles.conf \
 "
 
 inherit systemd
@@ -24,10 +25,16 @@ do_install() {
     # Install systemd service
     install -d ${D}${systemd_system_unitdir}
     install -m 0644 ${UNPACKDIR}/overlayfs-setup.service ${D}${systemd_system_unitdir}/
+
+    # Relabel the volatile /var/volatile tmpfs root after policy load.
+    install -d ${D}${sysconfdir}/tmpfiles.d
+    install -m 0644 ${UNPACKDIR}/iotgw-var-volatile-relabel.tmpfiles.conf \
+        ${D}${sysconfdir}/tmpfiles.d/iotgw-var-volatile-relabel.conf
 }
 
 FILES:${PN} += " \
     ${sbindir}/overlayfs-setup.sh \
     ${systemd_system_unitdir}/overlayfs-setup.service \
+    ${sysconfdir}/tmpfiles.d/iotgw-var-volatile-relabel.conf \
 "
 RDEPENDS:${PN} += "bash"

--- a/scripts/ota/ota-pkcs11-provision-check.sh
+++ b/scripts/ota/ota-pkcs11-provision-check.sh
@@ -5,11 +5,17 @@ TARGET="${1:-iotgw}"
 TOKEN_LABEL="${TOKEN_LABEL:-iotgw}"
 KEY_LABEL="${KEY_LABEL:-rauc-client-key}"
 MODULE_PATH="${MODULE_PATH:-/usr/lib/pkcs11/libtpm2_pkcs11.so}"
+# The token DB lives on persistent /data (IOTGW_TPM2_PKCS11_STORE). Every
+# pkcs11-tool/tpm2_ptool call must point at it, or the library falls back to its
+# compile-time default store and reports an empty token even when provisioned.
+STORE_PATH="${TPM2_PKCS11_STORE:-/data/tpm2_pkcs11}"
 
 echo "[pkcs11-check] target=${TARGET}"
-echo "[pkcs11-check] token=${TOKEN_LABEL} key=${KEY_LABEL}"
+echo "[pkcs11-check] token=${TOKEN_LABEL} key=${KEY_LABEL} store=${STORE_PATH}"
 
 ssh "${TARGET}" "set -euo pipefail
+export TPM2_PKCS11_STORE='${STORE_PATH}'
+echo \"[pkcs11-check] store=\${TPM2_PKCS11_STORE}\"
 echo '[pkcs11-check] tool availability:'
 command -v pkcs11-tool >/dev/null && echo '  - pkcs11-tool: OK' || echo '  - pkcs11-tool: MISSING'
 if command -v tpm2_ptool >/dev/null; then
@@ -35,13 +41,16 @@ echo '  pkcs11:token=${TOKEN_LABEL};object=${KEY_LABEL};type=private'
 echo
 echo '[pkcs11-check] next provisioning steps (run on target as root):'
 cat <<'EOF'
+# The token DB lives on persistent /data — export the store for every command:
+export TPM2_PKCS11_STORE=/data/tpm2_pkcs11
+
 # 1) Inspect local tool syntax first (varies by distro build):
 tpm2_ptool --help || tpm2_ptool.py --help
 
 # 2) Initialize token store and create token/object:
 #    (use the command variants shown by --help for your target build)
 #    Typical flow:
-#      - init store
+#      - init store at $TPM2_PKCS11_STORE
 #      - add token label 'iotgw' with SO PIN + user PIN
 #      - add private key object label 'rauc-client-key'
 

--- a/scripts/ota/ota-smoke-target.sh
+++ b/scripts/ota/ota-smoke-target.sh
@@ -464,6 +464,88 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+section "/var narrowing & /data persistence"
+# /var is no longer overlaid — it reverts to the stock OE volatile model
+# (tmpfs /var/volatile + volatile-binds), with the must-persist state re-homed
+# onto dedicated /data-backed binds/redirects. This block asserts the narrowed
+# shape; on a pre-narrowing image (/var still overlaid) it SKIPs cleanly.
+
+# Read the true fstype from PID1's view — the SSH session's mount namespace can
+# misreport mounts.
+vv_fs=$(stat -f -c %T /proc/1/root/var/volatile 2>/dev/null)
+[ -z "$vv_fs" ] && vv_fs=$(stat -f -c %T /var/volatile 2>/dev/null)
+
+if [ "$vv_fs" != "tmpfs" ]; then
+    say_skip "/var narrowing" "/var/volatile fstype is '${vv_fs:-unknown}' (pre-narrowing image — /var still overlaid)"
+else
+    say_pass "/var/volatile is a true tmpfs (overlay narrowed)"
+
+    # /var must no longer carry an overlay upper on /data.
+    if grep -qE 'upperdir=[^ ,]*/overlays/var/' /proc/1/mountinfo 2>/dev/null; then
+        say_fail "/var still has an overlay upper (narrowing incomplete)"
+    else
+        say_pass "/var is not overlaid (no /data/overlays/var upper)"
+    fi
+
+    # Stock volatile-binds now actually run (were condition-skipped under the overlay).
+    for u in var-volatile-lib var-volatile-cache var-volatile-spool; do
+        if systemctl is-active "${u}.service" >/dev/null 2>&1; then
+            say_pass "${u}.service active (stock volatile-binds)"
+        else
+            say_fail "${u}.service not active — /var/lib may be read-only"
+        fi
+    done
+
+    # Journal + audit re-homed onto /data-backed binds (read real paths; /var/log
+    # is a symlink into /var/volatile/log).
+    data_dev=$(findmnt -no SOURCE /data 2>/dev/null)
+    for m in /var/volatile/log/journal /var/volatile/log/audit; do
+        if findmnt --target "$m" >/dev/null 2>&1; then
+            msrc=$(findmnt -no SOURCE --target "$m" 2>/dev/null)
+            case "$msrc" in
+                "${data_dev}"*|*/data/*) say_pass "$m persisted on /data ($msrc)" ;;
+                *) say_fail "$m mounted but not from /data ($msrc)" ;;
+            esac
+        else
+            say_fail "$m is not a bind — journal/audit NOT re-homed to /data"
+        fi
+    done
+    command -v journalctl >/dev/null 2>&1 && du=$(journalctl --disk-usage 2>/dev/null) && [ -n "$du" ] && say_pass "journald: $du"
+
+    # The /data persistence set (must-exist backing dirs).
+    for d in /data/log /data/log/journal /data/log/audit /data/ssh /data/mosquitto; do
+        if [ -d "$d" ]; then say_pass "backing dir present: $d"; else say_fail "backing dir missing: $d"; fi
+    done
+    # Feature/state-dependent dirs — SKIP when the feature/pairing has not populated them.
+    for d in /data/lib/thread /data/lib/bluetooth /data/tpm2_pkcs11 /data/influxdb3; do
+        if [ -d "$d" ]; then say_pass "backing dir present: $d"; else say_skip "backing dir $d" "not created (feature off / no state yet)"; fi
+    done
+
+    # No read-only-filesystem errors this boot — the main regression risk of
+    # dropping the /var overlay (a writer hitting a bare /var path).
+    if command -v journalctl >/dev/null 2>&1; then
+        ro=$(journalctl -b --no-pager 2>/dev/null | grep -icE 'read-only file system')
+        if [ "${ro:-0}" -eq 0 ]; then
+            say_pass "no 'read-only file system' errors this boot"
+        else
+            say_fail "$ro 'read-only file system' error(s) — a writer hit a bare /var path (journalctl -b | grep -i 'read-only')"
+        fi
+    fi
+
+    # /var/volatile root label (steady-state z-relabel → var_t).
+    vvctx=$(stat -c %C /var/volatile 2>/dev/null)
+    case "$vvctx" in
+        *:var_t:*|*var_t) say_pass "/var/volatile labeled var_t ($vvctx)" ;;
+        *unlabeled_t*)    say_skip "/var/volatile label" "unlabeled_t — z-relabel not yet applied (permissive-harmless)" ;;
+        ""|'?')           say_skip "/var/volatile label" "no SELinux context support in stat" ;;
+        *)                say_skip "/var/volatile label" "context '$vvctx'" ;;
+    esac
+fi
+# NOTE: general failed-unit / system-state health is covered by the "Systemd
+# unit health" section above (which flags a degraded state and hints the
+# ota-certs-provision provisioning workflow). Not re-checked here.
+
+# ---------------------------------------------------------------------------
 printf '\n== summary ==\n'
 printf '  PASS: %d\n' "$PASS"
 printf '  FAIL: %d\n' "$FAIL"

--- a/scripts/ota/ota-smoke-target.sh
+++ b/scripts/ota/ota-smoke-target.sh
@@ -499,17 +499,21 @@ else
     # Journal + audit re-homed onto /data-backed binds (read real paths; /var/log
     # is a symlink into /var/volatile/log).
     data_dev=$(findmnt -no SOURCE /data 2>/dev/null)
-    for m in /var/volatile/log/journal /var/volatile/log/audit; do
-        if findmnt --target "$m" >/dev/null 2>&1; then
-            msrc=$(findmnt -no SOURCE --target "$m" 2>/dev/null)
-            case "$msrc" in
-                "${data_dev}"*|*/data/*) say_pass "$m persisted on /data ($msrc)" ;;
-                *) say_fail "$m mounted but not from /data ($msrc)" ;;
-            esac
-        else
-            say_fail "$m is not a bind — journal/audit NOT re-homed to /data"
-        fi
-    done
+    if [ -z "$data_dev" ]; then
+        say_fail "cannot resolve /data source device — journal/audit bind-source checks skipped"
+    else
+        for m in /var/volatile/log/journal /var/volatile/log/audit; do
+            if findmnt --target "$m" >/dev/null 2>&1; then
+                msrc=$(findmnt -no SOURCE --target "$m" 2>/dev/null)
+                case "$msrc" in
+                    "${data_dev}"*|*/data/*) say_pass "$m persisted on /data ($msrc)" ;;
+                    *) say_fail "$m mounted but not from /data ($msrc)" ;;
+                esac
+            else
+                say_fail "$m is not a bind — journal/audit NOT re-homed to /data"
+            fi
+        done
+    fi
     command -v journalctl >/dev/null 2>&1 && du=$(journalctl --disk-usage 2>/dev/null) && [ -n "$du" ] && say_pass "journald: $du"
 
     # The /data persistence set (must-exist backing dirs).


### PR DESCRIPTION
Retires the blanket `/var` OverlayFS and restores true-volatile semantics, re-homing only the must-persist state onto dedicated `/data`-backed mounts and redirects.

## What changes
- **Drop `/var` from the overlay set** — `/var` reverts to the stock OE volatile model: tmpfs `/var/volatile` + `volatile-binds` for `/var/{lib,cache,spool}` and `/srv`. `/etc`, `/home`, `/root` overlays are unchanged.
- **Persist journald + audit** onto dedicated `/data` binds (`/data/log/{journal,audit}`), with an explicit `auditd.conf` retention policy (non-fatal disk actions so a full `/data` never wedges auditing).
- **Redirect the remaining must-persist state to `/data`**: SSH host keys, the TPM PKCS#11 token store, the OpenThread dataset, Bluetooth pairings, mosquitto retained state, the InfluxDB data dir, and the first-boot provisioning stamps.
- Add a conditional `/var narrowing` section to the on-target smoke checks.

## Why
The whole-`/var` overlay made `/var/volatile` persistent (defeating true-volatile semantics), persisted all of `/var` when only a small set needs to survive reboot, and neutralized the stock `volatile-binds`. Full rationale in #93.

## Validation
Installed over RAUC OTA under SELinux and booted:
- `/var/volatile` confirmed a true tmpfs; stock volatile-binds active; **zero** read-only-fs errors; **zero** failed units.
- journald + audit persist to `/data` and survive a reboot (timestamped markers written pre-reboot remain readable afterwards, including the journal marker under the previous boot).
- `/data`-redirected identity/state (SSH host key, mosquitto) carried across the A/B update.

Closes #93.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
