### PR TITLE
feat(watchdog): enable systemd hardware watchdog by default at 15s

### DIFF
--- a/docs/UBOOT_HARDENING.md
+++ b/docs/UBOOT_HARDENING.md
@@ -101,8 +101,9 @@ U-Boot-side slot selection, bootargs, FIT loading (`fatload`), and env save.
 FIT signature verification and kernel handoff happen inside `bootm`, *after*
 the watchdog is stopped — so the kernel never inherits an armed timer, but the
 signature-verify step itself is not watchdog-covered. Linux PID1 watchdog
-feeding remains controlled by `IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG` and is
-intentionally separate.
+feeding is a separate mechanism, now on by default
+(`IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG=1`): systemd feeds `/dev/watchdog0` at
+`RuntimeWatchdogSec=15s`, kept ≤ the ~16s BCM2712 hardware maximum.
 
 ### Env-based RAUC slot selection
 

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -301,12 +301,24 @@ IOTGW_UBOOT_EXTRA_KERNEL_ARGS ?= "${@('panic=%s oops=panic sysrq_always_enabled=
 # /dev/watchdog0 does not reboot.
 IOTGW_ENABLE_HW_WATCHDOG ?= "1"
 
-# Optional: systemd hardware watchdog integration (disabled by default).
-# When enabled, PID1 opens /dev/watchdog and pings it at RuntimeWatchdogSec
-# cadence. Requires IOTGW_ENABLE_HW_WATCHDOG=1 (or another driver source)
-# for /dev/watchdog to exist.
-IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG ?= "0"
-IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC ?= "20s"
+# systemd hardware watchdog integration (enabled by default; issue #56).
+# PID1 opens /dev/watchdog and pings it at RuntimeWatchdogSec cadence, so a
+# wedged kernel/PID1 self-recovers by hardware reset. Requires
+# IOTGW_ENABLE_HW_WATCHDOG=1 (or another driver source) for /dev/watchdog to
+# exist. Ships the vendor drop-in via recipes-support/iotgw-systemd-watchdog
+# (packaged only when this is "1").
+#
+# RUNTIME must stay <= the BCM2712 HW max heartbeat (bcm2835_wdt
+# max_hw_heartbeat_ms ~= 16s). At <=16s systemd programs the hardware timeout
+# directly and pings at RUNTIME/2 (7.5s here) — validated stable on-target
+# (issue #56). ABOVE 16s (e.g. 20s/30s) the kernel must *bridge* the software
+# timeout past the HW max via the watchdog-core worker; the worker->PID1
+# fd-open handoff is racy on BCM2712 and resets the board erratically
+# (reproduced at 20s: reset in ~7-40s; 15s soaks clean). So keep RUNTIME <=15s.
+# SHUTDOWN is only the shutdown-hang guard and is not on the runtime feed path,
+# so >16s there is fine.
+IOTGW_ENABLE_SYSTEMD_HW_WATCHDOG ?= "1"
+IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC ?= "15s"
 IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC ?= "30s"
 
 # Optional TPM2 over SPI profile for Infineon SLB9672-class modules.

--- a/meta-iot-gateway/recipes-support/iotgw-systemd-watchdog/iotgw-systemd-watchdog_1.0.0.bb
+++ b/meta-iot-gateway/recipes-support/iotgw-systemd-watchdog/iotgw-systemd-watchdog_1.0.0.bb
@@ -1,5 +1,10 @@
 SUMMARY = "Systemd PID1 hardware watchdog configuration"
-DESCRIPTION = "Installs systemd.conf drop-in to enable RuntimeWatchdogSec/ShutdownWatchdogSec when explicitly enabled."
+DESCRIPTION = "Installs a systemd.conf vendor drop-in enabling \
+RuntimeWatchdogSec/ShutdownWatchdogSec when explicitly enabled. Shipped under \
+${nonarch_libdir}/systemd (not ${sysconfdir}): on this image /etc is an overlay \
+whose upperdir lives on /data, so a runtime-written /etc drop-in is invisible \
+until /data mounts; the vendor dir is read at PID1 start regardless, and leaves \
+/etc free for operator overrides."
 HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
@@ -12,12 +17,12 @@ S = "${UNPACKDIR}"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
 do_install() {
-    install -d ${D}${sysconfdir}/systemd/system.conf.d
+    install -d ${D}${nonarch_libdir}/systemd/system.conf.d
     sed -e "s|@IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC@|${IOTGW_SYSTEMD_RUNTIME_WATCHDOG_SEC}|g" \
         -e "s|@IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC@|${IOTGW_SYSTEMD_SHUTDOWN_WATCHDOG_SEC}|g" \
         ${UNPACKDIR}/60-iotgw-watchdog.conf.in \
-        > ${D}${sysconfdir}/systemd/system.conf.d/60-iotgw-watchdog.conf
-    chmod 0644 ${D}${sysconfdir}/systemd/system.conf.d/60-iotgw-watchdog.conf
+        > ${D}${nonarch_libdir}/systemd/system.conf.d/60-iotgw-watchdog.conf
+    chmod 0644 ${D}${nonarch_libdir}/systemd/system.conf.d/60-iotgw-watchdog.conf
 }
 
-FILES:${PN} = "${sysconfdir}/systemd/system.conf.d/60-iotgw-watchdog.conf"
+FILES:${PN} = "${nonarch_libdir}/systemd/system.conf.d/60-iotgw-watchdog.conf"


### PR DESCRIPTION
Enables the systemd hardware watchdog by default on all images. PID1 feeds `/dev/watchdog0` at `RuntimeWatchdogSec=15s` — kept ≤ the ~16s BCM2712 hardware max, above which the kernel bridging/handoff path resets the board erratically. The vendor drop-in ships under `/usr/lib/systemd` so it arms at PID1 start independent of the `/etc`-overlay/`/data` mount timing.

Validated on hardware: arms 15s at boot, 20-min soak clean; contrast 20s reset in 7–40s.

Closes #56.
