### PR TITLE
fix(sbom-cve): resolve dated report + same-build cohort check

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,6 +142,7 @@ scripts/                     # host-side tooling (release, OTA bench, signing, T
 | Flashing, provisioning, target ops, SSH-namespace caveat | `docs/OPERATIONS.md` |
 | RAUC OTA install/rollback | `docs/RAUC_UPDATE.md`, `docs/OTA_UPDATE.md` |
 | Kernel config / CVE & driver backports | `docs/KERNEL.md`, `docs/KERNEL_CVE_PATCH.md`, `docs/KERNEL_DRIVER_BACKPORT.md` |
+| SBOM / CVE scanning, reading reports, userspace triage | `docs/SBOM_CVE.md` |
 | Release workflow | `docs/RELEASE.md` |
 | Partition layouts | `docs/PARTITIONS.md` |
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: help base dev prod \
         bundle-dev-full-fit sign-bootfiles-fit-yk sign-bootfiles-fit-softhsm bundle-dev-full-fit-resign bundle-prod-full-fit bundle-prod-full-fit-resign \
-        tools-venv test-sign-fit test-sign-fit-softhsm \
+        tools-venv test-sign-fit test-sign-fit-softhsm test-sbom-cve \
         sbom-cve cve-report sbom-report layers parse clean-lock
 
 KAS ?= kas
@@ -70,6 +70,7 @@ help:
 	@echo "  make sbom-cve                     # Build dev image with wrynose SBOM+CVE reports"
 	@echo "  make cve-report                   # Summarise the CVE report (buckets, kernel split, CVE_STATUS scaffold)"
 	@echo "  make sbom-report                  # Summarise the SBOM (license inventory + HIGH-risk review)"
+	@echo "  make test-sbom-cve                # Run sbom-cve report/cohort tests (fixtures, no build)"
 	@echo "  -- Utilities --"
 	@echo "  make layers                       # Show layers for RAUC stack"
 	@echo "  make parse                        # Parse-only for RAUC stack"
@@ -175,6 +176,11 @@ test-sign-fit:
 test-sign-fit-softhsm:
 	SOFTHSM_AVAILABLE=1 $(UV) run pytest scripts/fit-signing/tests/
 
+# sbom-cve report/cohort readers: fixture-based tests, no Yocto build required.
+# The readers are stdlib-only; only this test suite uses the uv venv.
+test-sbom-cve:
+	$(UV) run pytest scripts/sbom-cve/tests/
+
 bundle-dev-full-fit-resign: | $(KAS_WORK_DIR)
 	$(call iotgw_bitbake,bitbake -C do_configure iot-gw-bundle-full-fit,$(BASE),iot-gw-image-dev)
 
@@ -203,6 +209,11 @@ sbom-cve: | $(KAS_WORK_DIR)
 
 # Host-side report readers over the sbom-cve-check deploy artifacts. Stdlib-only
 # Python (no venv), read-only — run after `make sbom-cve` produced the reports.
+# Convention: a scan and its image outputs (manifest/testdata/SPDX/CVE JSON)
+# share one IMAGE_NAME stem (e.g. iot-gw-image-dev-raspberrypi5.rootfs-<BUILDNAME>)
+# and belong together — archive/reference them by that stem. The readers resolve
+# the dated file (not the un-dated symlink) and warn when the selected scan is
+# not the same, newest build; pass --strict (CVE_REPORT_ARGS=--strict) to fail.
 CVE_REPORT_ARGS  ?=
 SBOM_REPORT_ARGS ?=
 cve-report:

--- a/Makefile
+++ b/Makefile
@@ -212,8 +212,10 @@ sbom-cve: | $(KAS_WORK_DIR)
 # Convention: a scan and its image outputs (manifest/testdata/SPDX/CVE JSON)
 # share one IMAGE_NAME stem (e.g. iot-gw-image-dev-raspberrypi5.rootfs-<BUILDNAME>)
 # and belong together — archive/reference them by that stem. The readers resolve
-# the dated file (not the un-dated symlink) and warn when the selected scan is
-# not the same, newest build; pass --strict (CVE_REPORT_ARGS=--strict) to fail.
+# the dated file (not the un-dated symlink) and warn when the selected scan is a
+# mismatched/incomplete cohort or not the newest build. Pass --strict (fail on a
+# broken cohort) and/or --require-latest (fail if a newer image exists), e.g.
+# CVE_REPORT_ARGS='--strict --require-latest'.
 CVE_REPORT_ARGS  ?=
 SBOM_REPORT_ARGS ?=
 cve-report:

--- a/docs/SBOM_CVE.md
+++ b/docs/SBOM_CVE.md
@@ -71,8 +71,11 @@ Every image output shares one `IMAGE_NAME` stem, e.g.
   a copy (a required `.manifest`/`.testdata.json` companion is missing), its
   testdata `IMAGE_NAME` disagrees with the stem (mismatched pairing), or a
   **newer image build exists** than the scan (image rebuilt, scan not re-run);
-- accept `--strict` to exit non-zero on any such warning (use it for
-  release/CI; interactive use warns and continues).
+- accept `--strict` to exit non-zero on a cohort **integrity** failure
+  (a missing/mismatched companion), and `--require-latest` to additionally fail
+  when a **newer** image build exists than the scan. A stale-but-intact scan
+  chosen with `-i` is a deliberate selection, so it is not an integrity failure;
+  interactive use warns and continues.
 
 **Convention:** a scan and its image outputs (`.manifest`, `.testdata.json`,
 `.spdx.json`, `.sbom-cve-check.*.json`) belong together — reference and archive

--- a/docs/SBOM_CVE.md
+++ b/docs/SBOM_CVE.md
@@ -1,0 +1,143 @@
+# SBOM & CVE Scanning — Field Guide
+
+How this repo generates a software bill of materials and CVE report for an
+image, how to read them, and how to turn a scanner row into a defensible
+engineering disposition. For carrying a kernel fix as a backport patch, see
+[Kernel CVE Patch — Field Guide](KERNEL_CVE_PATCH.md); this page is the
+image-wide scanning + userspace-triage companion.
+
+---
+
+## What it is
+
+Scanning runs `sbom-cve-check` (bootlin) over the image's SPDX 3.0 graph:
+
+- `kas/cve.yml` is an additive overlay that enables `create-spdx` +
+  `sbom-cve-check` and sets `SPDX_INCLUDE_VEX = "all"`, so `CVE_STATUS`
+  dispositions flow into the report as VEX.
+- The scanner databases (NVD-FKIE and CVE-List-V5) are **pinned by SRCREV** in
+  `kas/cve.yml` and fetched with auto-update disabled — a scan is reproducible
+  with respect to database content. "Reproducible" is not "current": the pinned
+  database has a deliberate age; refresh it on a policy cadence.
+- The custom kernel recipe normalises `CVE_PRODUCT = "linux_kernel"` /
+  `CVE_VERSION = "${LINUX_VERSION}"` and emits compiled-source SPDX, which keeps
+  the kernel from flooding the report with CPE mismatches.
+
+Provenance is Yocto's and is trusted: `testdata.IMAGE_NAME`,
+`SpdxDocument.name`, and the deploy filename stem are one identity; buildhistory
+records every layer revision; the deployed database `HEAD`s equal the SRCREV
+pins. This guide does not add a parallel provenance system — it only makes the
+host-side readers select and present one build unambiguously.
+
+## Running a scan
+
+```bash
+make sbom-cve        # build iot-gw-image-dev with the CVE/SBOM overlay + scan
+make cve-report      # summarise the CVE report (buckets, kernel split, scaffold)
+make sbom-report     # summarise the SBOM (license inventory + HIGH-risk review)
+make test-sbom-cve   # fixture tests for the readers (no build)
+```
+
+`make sbom-cve` is opt-in and slow (SPDX generation over the whole image); it is
+deliberately not run on every build, and CI runs no Yocto builds. Reports land
+in `build/tmp/deploy/images/<machine>/` and are **never committed** — they are
+regenerated on demand.
+
+## Reading the CVE report
+
+`make cve-report` (reader: `scripts/sbom-cve/cve-report.py`) prints:
+
+- a provenance line naming the **dated** report file that was read;
+- `# status totals: Ignored=N, Patched=N, Unpatched=N` — the scanner buckets;
+- a CISA CVSS distribution and a **kernel/userland split** (the kernel needs
+  config-aware triage, so it is hidden by default — `--kernel` to include);
+- the sorted Unpatched rows, and, with `--cve-status`, a `CVE_STATUS[...]`
+  scaffold grouped by recipe for hand triage; `--csv` dumps every row.
+
+Useful flags: `--status <Patched|Ignored|Unpatched|*>`, `--top N`, `--all`.
+
+`make sbom-report` gives the license inventory, category tally, download-coverage
+gap (over *source* nodes only), and a HIGH-risk license review.
+
+## Same-build safety
+
+Every image output shares one `IMAGE_NAME` stem, e.g.
+`iot-gw-image-dev-<machine>.rootfs-<BUILDNAME>`, alongside an un-dated
+`*.rootfs.*` symlink to the newest. The readers:
+
+- resolve the **dated** file (not the symlink), so the provenance line always
+  identifies the exact build;
+- run a same-build check and print `# WARNING:` lines when the selected scan is
+  a copy (a required `.manifest`/`.testdata.json` companion is missing), its
+  testdata `IMAGE_NAME` disagrees with the stem (mismatched pairing), or a
+  **newer image build exists** than the scan (image rebuilt, scan not re-run);
+- accept `--strict` to exit non-zero on any such warning (use it for
+  release/CI; interactive use warns and continues).
+
+**Convention:** a scan and its image outputs (`.manifest`, `.testdata.json`,
+`.spdx.json`, `.sbom-cve-check.*.json`) belong together — reference and archive
+them **by the shared stem**, never the symlink. `testdata.json` can contain
+secrets; the readers read only its `IMAGE_NAME` and never print or copy it.
+
+## Triaging a row into a disposition
+
+A scanner row is not a verdict. Before adding metadata or dropping a finding
+from the actionable set, ground the conclusion in a **retained, re-derivable**
+artifact — record the command, not just the prose. The scanner flattens
+everything to `Patched`/`Ignored`; capture the real engineering meaning:
+
+| Disposition | Minimum evidence |
+|---|---|
+| `fixed-version` | shipped version (manifest) past the upstream fixed boundary/commit |
+| `cpe-incorrect` | wrong-product proof (e.g. a match against a different project of the same name) |
+| `not-applicable-config` | the vulnerable feature is compiled out (`do_configure`/defconfig line) **and**, if a binary, the provider is another package |
+| `not-applicable-platform` | the advisory's platform scope vs. this image's `aarch64` |
+| `disputed` | an upstream/CNA dispute link |
+| component-not-present | `files-in-image.txt` showing the package is build-closure only, not installed — express at **image/product VEX**, never a recipe `fixed` |
+| left open | an explicit reason; nothing proven yet (e.g. kernel ancestry pending) |
+
+**Scope rules for where metadata lives:**
+
+- recipe-wide facts (fixed-version, wrong-CPE, feature-off) → that recipe's
+  `.bbappend`;
+- distro-wide false positives true across all images → a distro include
+  (`conf/distro/include/iotgw-cve-ignores.inc`);
+- build-closure-only absence → image/product VEX or the triage record, **not** a
+  global recipe suppression.
+
+**Preserve uncertainty.** Do not collapse a multi-row fan-out (one CVE emitted
+against many binary packages of the same source) into a single "newer version"
+claim without confirming the shared source. Do not adopt OE-Core exclusions
+wholesale to lower a count — each must be reviewed for applicability to this
+image's configuration and threat model. `no-version-range` kernel/glibc rows
+stay open until proven, not bulk-suppressed because they look old.
+
+## Kernel CVEs
+
+Kernel triage differs from userspace: the question is **fix-commit ancestry +
+compiled-config reachability**, not a version-range boundary. The kernel recipe
+already includes OE-Core's generic and version-specific `cve-exclusion*.inc`;
+the residual `no-version-range` rows need per-CVE work. OE-Core's
+`improve_kernel_cve_report.py` can enrich the report from the compiled-source
+SPDX (dropping CVEs whose files are not built), but its output must pass a
+validation gate before it is trusted:
+
+1. the compiled file set is large and plausible, with kernel-relative roots
+   (`arch/`, `fs/`, `net/`) aligned to the CNA `programFiles`;
+2. CVEs in known-compiled subsystems still survive as affected — if a compiled
+   subsystem's CVEs all vanish, the compiled-path roots are misaligned and the
+   result is a false mass "not applicable," not a real reduction;
+3. the internal tally reconciles against the total kernel-CNA set.
+
+Exact string matching means a path-root mismatch silently reclassifies
+everything as not-applicable and looks like success — always run the gate.
+Carry a security fix even when today's Kconfig disables the vulnerable path, so
+a later config change cannot expose unpatched source. Patch mechanics:
+[Kernel CVE Patch — Field Guide](KERNEL_CVE_PATCH.md).
+
+## Not this
+
+- Do not commit generated SBOM/CVE artifacts (they are large and rebuildable).
+- Do not synthesise `CVE_STATUS` from a version string or a CVE's age alone.
+- Do not treat a matching filename timestamp as proof two artifacts share a
+  build — use the stem + the readers' same-build check.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -78,6 +78,10 @@ step-by-step workflow: identifying the right stable backport, annotating
 for Yocto QA (`Upstream-Status:`, `CVE:`), wiring into `SRC_URI`, and
 tracking the patch's sunset on the next `SRCREV` bump.
 
+For image-wide scanning and userspace-package triage — generating the SBOM
+and CVE report (`make sbom-cve`), reading it, and turning a scanner row into a
+`CVE_STATUS` disposition — see [SBOM & CVE Scanning — Field Guide](SBOM_CVE.md).
+
 ---
 
 ## Compiler Hardening

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,10 @@
 #
 # This file does NOT define a pip-installable package. Its purpose is
 # to give `uv` a reproducible runtime + dev environment for the FIT
-# signing tool and its test suite under scripts/fit-signing/. Yocto/BitBake
-# builds do not depend on uv or on this venv.
+# signing tool and the host-side tool test suites (FIT signing under
+# scripts/fit-signing/, sbom-cve report readers under scripts/sbom-cve/).
+# The sbom-cve scripts are themselves stdlib-only; only their pytest suite
+# uses this venv. Yocto/BitBake builds do not depend on uv or on this venv.
 #
 # Operator signing targets run through `uv run`; direct invocations of
 # scripts/fit-signing/sign_fit.py re-exec under .venv when needed.
@@ -26,7 +28,7 @@ dev = [
 ]
 
 [tool.pytest.ini_options]
-testpaths = ["scripts/fit-signing/tests"]
+testpaths = ["scripts/fit-signing/tests", "scripts/sbom-cve/tests"]
 addopts = ["-ra"]
 
 [tool.uv]

--- a/scripts/sbom-cve/cohort.py
+++ b/scripts/sbom-cve/cohort.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""
+Shared cohort helpers for the sbom-cve report readers (cve-report.py,
+sbom-report.py).
+
+Yocto writes every image output with the same IMAGE_NAME stem, e.g.
+  iot-gw-image-dev-raspberrypi5.rootfs-20260724073419
+plus an un-dated *.rootfs.* symlink to the newest one. Provenance itself is
+sound (testdata.IMAGE_NAME == SpdxDocument.name == the filename stem, and
+buildhistory/DB pins record the rest); the only defect is that the readers
+auto-locate the *newest* match, which resolves to the un-dated symlink and hides
+which build was read. These helpers make the readers (a) resolve the newest
+DATED report, and (b) confirm the selected scan and its companion image
+artifacts belong to one — and the newest — build, catching the case where an
+image was rebuilt but the scan was not re-run.
+
+Read-only, stdlib-only; produces no build state. Note: testdata.json can carry
+secrets, so only its IMAGE_NAME is ever read and it is never printed or copied.
+"""
+
+import glob
+import json
+import os
+import re
+import sys
+
+# Cohort member suffixes on the shared IMAGE_NAME stem. Ordered longest-first so
+# build_stem() strips the most specific one (the augmented SPDX also ends in
+# ".spdx.json").
+CVE_JSON_SUFFIX = ".sbom-cve-check.yocto.json"
+AUG_SPDX_SUFFIX = ".sbom-cve-check.spdx.json"
+BASE_SPDX_SUFFIX = ".spdx.json"
+MANIFEST_SUFFIX = ".manifest"
+TESTDATA_SUFFIX = ".testdata.json"
+_STEM_SUFFIXES = sorted(
+    (CVE_JSON_SUFFIX, AUG_SPDX_SUFFIX, BASE_SPDX_SUFFIX,
+     MANIFEST_SUFFIX, TESTDATA_SUFFIX),
+    key=len, reverse=True,
+)
+
+# The 14-digit BUILDNAME (a sortable datetime stamp) trailing an IMAGE_NAME stem.
+_BUILDID_RE = re.compile(r"-(\d{14})$")
+
+
+def die(msg):
+    print("error: %s" % msg, file=sys.stderr)
+    sys.exit(1)
+
+
+def load(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except FileNotFoundError:
+        die("input not found: %s" % path)
+    except json.JSONDecodeError as e:
+        die("malformed JSON in %s: %s" % (path, e))
+
+
+def resolve_newest(deploy_glob):
+    """Newest DATED report matching deploy_glob.
+
+    Resolves symlinks and dedupes by real path so the un-dated *.rootfs.* symlink
+    and its dated target do not tie on mtime — the result is always the real
+    dated file.
+    """
+    reals = {os.path.realpath(h) for h in glob.glob(deploy_glob)}
+    if not reals:
+        die("no files match %s under the deploy tree. "
+            "Pass -i explicitly or build an image first." % deploy_glob)
+    return max(reals, key=os.path.getmtime)
+
+
+def build_stem(path):
+    """The IMAGE_NAME stem of a deploy artifact (its cohort suffix stripped)."""
+    name = os.path.basename(os.path.realpath(path))
+    for suf in _STEM_SUFFIXES:
+        if name.endswith(suf):
+            return name[:-len(suf)]
+    return name
+
+
+def _build_id(stem):
+    """The trailing 14-digit BUILDNAME of a stem, or None."""
+    m = _BUILDID_RE.search(stem or "")
+    return m.group(1) if m else None
+
+
+def companions(report_path):
+    """Map cohort role -> same-stem sibling path (None if absent)."""
+    real = os.path.realpath(report_path)
+    d = os.path.dirname(real)
+    stem = build_stem(real)
+    roles = {
+        "manifest": MANIFEST_SUFFIX,
+        "testdata": TESTDATA_SUFFIX,
+        "base_spdx": BASE_SPDX_SUFFIX,
+        "aug_spdx": AUG_SPDX_SUFFIX,
+        "cve_json": CVE_JSON_SUFFIX,
+    }
+    out = {}
+    for role, suf in roles.items():
+        cand = os.path.join(d, stem + suf)
+        out[role] = cand if os.path.exists(cand) else None
+    return out
+
+
+def _newer_build_id(stem, deploy_dir):
+    """Newest same-image dated-manifest BUILDNAME strictly newer than `stem`'s.
+
+    Restricted to the same image-link prefix so a newer build of a *different*
+    image variant does not falsely flag this scan.
+    """
+    sel = _build_id(stem)
+    if not sel:
+        return None
+    link = _BUILDID_RE.sub("", stem)  # image-link stem, timestamp removed
+    ids = []
+    for h in glob.glob(os.path.join(deploy_dir, link + "-*" + MANIFEST_SUFFIX)):
+        bid = _build_id(build_stem(os.path.realpath(h)))
+        if bid:
+            ids.append(bid)
+    newest = max(ids) if ids else None
+    return newest if (newest and newest > sel) else None
+
+
+def check_cohort(report_path):
+    """Same-build warnings for the selected report. Empty == consistent cohort.
+
+    Surfaces: a required image companion missing (scan is a copy or the image
+    outputs were pruned); testdata whose IMAGE_NAME disagrees with the stem
+    (mismatched pairing); and a newer image build than the selected scan.
+    """
+    warnings = []
+    real = os.path.realpath(report_path)
+    stem = build_stem(real)
+    comp = companions(real)
+
+    for role in ("manifest", "testdata"):
+        if comp[role] is None:
+            warnings.append(
+                "no %s companion for %s (scan may be a copy, or the image "
+                "outputs were pruned)" % (role, stem))
+
+    if comp["testdata"]:
+        image_name = None
+        try:
+            with open(comp["testdata"]) as f:
+                image_name = json.load(f).get("IMAGE_NAME")
+        except (OSError, ValueError):
+            warnings.append("could not read testdata companion for %s" % stem)
+        if image_name and image_name != stem:
+            warnings.append(
+                "testdata IMAGE_NAME %r != selected scan stem %r "
+                "(mismatched pairing)" % (image_name, stem))
+
+    newer = _newer_build_id(stem, os.path.dirname(real))
+    if newer:
+        warnings.append(
+            "a newer image build %s exists than the selected scan %s "
+            "(re-run `make sbom-cve`, or pass -i for the intended build)"
+            % (newer, _build_id(stem)))
+
+    return warnings
+
+
+def report_provenance(path, strict, label):
+    """Print the resolved dated provenance line + any same-build warnings.
+
+    Returns the real (dated) path. In strict mode, exits non-zero if the cohort
+    check produced warnings.
+    """
+    real = os.path.realpath(path)
+    print("# %s: %s" % (label, os.path.basename(real)))
+    warnings = check_cohort(real)
+    for w in warnings:
+        print("# WARNING: %s" % w, file=sys.stderr)
+    if warnings and strict:
+        die("cohort validation failed in --strict mode (%d warning(s))"
+            % len(warnings))
+    return real

--- a/scripts/sbom-cve/cohort.py
+++ b/scripts/sbom-cve/cohort.py
@@ -65,10 +65,13 @@ def resolve_newest(deploy_glob):
     dated file.
     """
     reals = {os.path.realpath(h) for h in glob.glob(deploy_glob)}
+    reals = {p for p in reals if os.path.exists(p)}  # drop dangling symlinks
     if not reals:
-        die("no files match %s under the deploy tree. "
+        die("no readable files match %s under the deploy tree. "
             "Pass -i explicitly or build an image first." % deploy_glob)
-    return max(reals, key=os.path.getmtime)
+    # (mtime, path) so an mtime tie is broken deterministically by path rather
+    # than by hash-seeded set iteration order.
+    return max(reals, key=lambda p: (os.path.getmtime(p), p))
 
 
 def build_stem(path):
@@ -125,20 +128,28 @@ def _newer_build_id(stem, deploy_dir):
 
 
 def check_cohort(report_path):
-    """Same-build warnings for the selected report. Empty == consistent cohort.
+    """Classify same-build issues for the selected report.
 
-    Surfaces: a required image companion missing (scan is a copy or the image
-    outputs were pruned); testdata whose IMAGE_NAME disagrees with the stem
-    (mismatched pairing); and a newer image build than the selected scan.
+    Returns (integrity, freshness):
+
+    - integrity: the selected scan's OWN cohort is broken — a required
+      .manifest/.testdata.json companion is missing (the scan is a copy, or the
+      image outputs were pruned), or testdata IMAGE_NAME disagrees with the stem
+      (mismatched pairing). These are validation failures.
+    - freshness: a newer image build exists than the selected scan. This is a
+      staleness heads-up, not corruption — an explicitly chosen older build is
+      legitimate, so it does not fail --strict (see --require-latest).
+
+    Empty lists == a consistent, newest cohort.
     """
-    warnings = []
+    integrity, freshness = [], []
     real = os.path.realpath(report_path)
     stem = build_stem(real)
     comp = companions(real)
 
     for role in ("manifest", "testdata"):
         if comp[role] is None:
-            warnings.append(
+            integrity.append(
                 "no %s companion for %s (scan may be a copy, or the image "
                 "outputs were pruned)" % (role, stem))
 
@@ -148,34 +159,39 @@ def check_cohort(report_path):
             with open(comp["testdata"]) as f:
                 image_name = json.load(f).get("IMAGE_NAME")
         except (OSError, ValueError):
-            warnings.append("could not read testdata companion for %s" % stem)
+            integrity.append("could not read testdata companion for %s" % stem)
         if image_name and image_name != stem:
-            warnings.append(
+            integrity.append(
                 "testdata IMAGE_NAME %r != selected scan stem %r "
                 "(mismatched pairing)" % (image_name, stem))
 
     newer = _newer_build_id(stem, os.path.dirname(real))
     if newer:
-        warnings.append(
+        freshness.append(
             "a newer image build %s exists than the selected scan %s "
-            "(re-run `make sbom-cve`, or pass -i for the intended build)"
-            % (newer, _build_id(stem)))
+            "(re-run `make sbom-cve` for the latest, or select deliberately "
+            "with -i)" % (newer, _build_id(stem)))
 
-    return warnings
+    return integrity, freshness
 
 
-def report_provenance(path, strict, label):
+def report_provenance(path, strict, require_latest, label):
     """Print the resolved dated provenance line + any same-build warnings.
 
-    Returns the real (dated) path. In strict mode, exits non-zero if the cohort
-    check produced warnings.
+    Returns the real (dated) path. Exits non-zero when --strict and the cohort
+    has integrity issues, or when --require-latest and a newer build exists.
+    A stale-but-intact scan chosen with -i is not an error under --strict alone.
     """
     real = os.path.realpath(path)
     print("# %s: %s" % (label, os.path.basename(real)))
-    warnings = check_cohort(real)
-    for w in warnings:
+    integrity, freshness = check_cohort(real)
+    for w in integrity + freshness:
         print("# WARNING: %s" % w, file=sys.stderr)
-    if warnings and strict:
-        die("cohort validation failed in --strict mode (%d warning(s))"
-            % len(warnings))
+    reasons = []
+    if strict and integrity:
+        reasons.append("%d integrity" % len(integrity))
+    if require_latest and freshness:
+        reasons.append("%d freshness" % len(freshness))
+    if reasons:
+        die("cohort validation failed (%s issue(s))" % ", ".join(reasons))
     return real

--- a/scripts/sbom-cve/cohort.py
+++ b/scripts/sbom-cve/cohort.py
@@ -157,13 +157,20 @@ def check_cohort(report_path):
         image_name = None
         try:
             with open(comp["testdata"]) as f:
-                image_name = json.load(f).get("IMAGE_NAME")
+                testdata = json.load(f)
         except (OSError, ValueError):
             integrity.append("could not read testdata companion for %s" % stem)
-        if image_name and image_name != stem:
-            integrity.append(
-                "testdata IMAGE_NAME %r != selected scan stem %r "
-                "(mismatched pairing)" % (image_name, stem))
+        else:
+            if isinstance(testdata, dict):
+                image_name = testdata.get("IMAGE_NAME")
+            if not (isinstance(image_name, str) and image_name):
+                integrity.append(
+                    "testdata companion for %s has no usable IMAGE_NAME "
+                    "(cannot confirm pairing)" % stem)
+            elif image_name != stem:
+                integrity.append(
+                    "testdata IMAGE_NAME %r != selected scan stem %r "
+                    "(mismatched pairing)" % (image_name, stem))
 
     newer = _newer_build_id(stem, os.path.dirname(real))
     if newer:

--- a/scripts/sbom-cve/cve-report.py
+++ b/scripts/sbom-cve/cve-report.py
@@ -131,11 +131,14 @@ def main(argv):
     ap.add_argument("--year", type=int,
                     help="build year for the future-dated flag (default: today)")
     ap.add_argument("--strict", action="store_true",
-                    help="exit non-zero if the selected scan fails cohort checks")
+                    help="exit non-zero on a cohort integrity failure "
+                         "(missing/mismatched companion)")
+    ap.add_argument("--require-latest", action="store_true",
+                    help="also fail if a newer image build exists than the scan")
     args = ap.parse_args(argv)
 
     path = args.input or resolve_newest(DEPLOY_GLOB)
-    path = report_provenance(path, args.strict, "report")
+    path = report_provenance(path, args.strict, args.require_latest, "report")
     data = load(path)
     build_year = args.year or datetime.date.today().year
 

--- a/scripts/sbom-cve/cve-report.py
+++ b/scripts/sbom-cve/cve-report.py
@@ -19,10 +19,9 @@ Usage:
 import argparse
 import csv
 import datetime
-import glob
-import json
-import os
 import sys
+
+from cohort import die, load, report_provenance, resolve_newest
 
 # Newest matching report under the standard deploy tree when -i is absent.
 DEPLOY_GLOB = "build/tmp/deploy/images/*/*.sbom-cve-check.yocto.json"
@@ -39,30 +38,6 @@ BUCKETS = [
 # The kernel dominates the CVE count via NVD CPE matching against the full
 # kernel tree; split it out so the userland signal is readable.
 KERNEL_PKG = "linux-iotgw-mainline-fit"
-
-
-def die(msg):
-    print("error: %s" % msg, file=sys.stderr)
-    sys.exit(1)
-
-
-def locate():
-    """Return the newest cve-check report under the deploy tree."""
-    hits = glob.glob(DEPLOY_GLOB)
-    if not hits:
-        die("no *.sbom-cve-check.yocto.json under build/tmp/deploy/images. "
-            "Pass -i explicitly or build an image first.")
-    return max(hits, key=os.path.getmtime)
-
-
-def load(path):
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except FileNotFoundError:
-        die("input not found: %s" % path)
-    except json.JSONDecodeError as e:
-        die("malformed JSON in %s: %s" % (path, e))
 
 
 def score_of(issue):
@@ -155,13 +130,14 @@ def main(argv):
                     help="emit CVE_STATUS[...] scaffold grouped by recipe")
     ap.add_argument("--year", type=int,
                     help="build year for the future-dated flag (default: today)")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero if the selected scan fails cohort checks")
     args = ap.parse_args(argv)
 
-    path = args.input or locate()
+    path = args.input or resolve_newest(DEPLOY_GLOB)
+    path = report_provenance(path, args.strict, "report")
     data = load(path)
     build_year = args.year or datetime.date.today().year
-
-    print("# report: %s" % os.path.basename(path))
 
     status_totals = {}
     for pkg, issue in cve_iter(data, "*"):

--- a/scripts/sbom-cve/sbom-report.py
+++ b/scripts/sbom-cve/sbom-report.py
@@ -122,11 +122,14 @@ def main(argv):
     ap.add_argument("--all", action="store_true", help="show every license")
     ap.add_argument("--csv", help="write package/license/download CSV to path")
     ap.add_argument("--strict", action="store_true",
-                    help="exit non-zero if the selected SBOM fails cohort checks")
+                    help="exit non-zero on a cohort integrity failure "
+                         "(missing/mismatched companion)")
+    ap.add_argument("--require-latest", action="store_true",
+                    help="also fail if a newer image build exists than the SBOM")
     args = ap.parse_args(argv)
 
     path = args.input or resolve_newest(DEPLOY_GLOB)
-    path = report_provenance(path, args.strict, "sbom")
+    path = report_provenance(path, args.strict, args.require_latest, "sbom")
     print("# loading %s (large graph; a moment) ..." % os.path.basename(path),
           file=sys.stderr)
     graph = load(path).get("@graph", [])

--- a/scripts/sbom-cve/sbom-report.py
+++ b/scripts/sbom-cve/sbom-report.py
@@ -17,11 +17,11 @@ Usage:
 
 import argparse
 import csv
-import glob
-import json
 import os
 import re
 import sys
+
+from cohort import load, report_provenance, resolve_newest
 
 # Newest matching SBOM under the standard deploy tree when -i is absent.
 DEPLOY_GLOB = "build/tmp/deploy/images/*/*.sbom-cve-check.spdx.json"
@@ -82,30 +82,6 @@ def classify_license(expr):
     return "unknown", "MEDIUM"
 
 
-def die(msg):
-    print("error: %s" % msg, file=sys.stderr)
-    sys.exit(1)
-
-
-def locate():
-    """Return the newest SPDX SBOM under the deploy tree."""
-    hits = glob.glob(DEPLOY_GLOB)
-    if not hits:
-        die("no *.sbom-cve-check.spdx.json under build/tmp/deploy/images. "
-            "Pass -i explicitly or build an image first.")
-    return max(hits, key=os.path.getmtime)
-
-
-def load(path):
-    try:
-        with open(path) as f:
-            return json.load(f)
-    except FileNotFoundError:
-        die("input not found: %s" % path)
-    except json.JSONDecodeError as e:
-        die("malformed JSON in %s: %s" % (path, e))
-
-
 def recipe_key(spdx_id):
     """The per-recipe document segment after /spdxdocs/ — the node join key.
 
@@ -145,9 +121,12 @@ def main(argv):
     ap.add_argument("--top", type=int, default=25, help="license rows to show")
     ap.add_argument("--all", action="store_true", help="show every license")
     ap.add_argument("--csv", help="write package/license/download CSV to path")
+    ap.add_argument("--strict", action="store_true",
+                    help="exit non-zero if the selected SBOM fails cohort checks")
     args = ap.parse_args(argv)
 
-    path = args.input or locate()
+    path = args.input or resolve_newest(DEPLOY_GLOB)
+    path = report_provenance(path, args.strict, "sbom")
     print("# loading %s (large graph; a moment) ..." % os.path.basename(path),
           file=sys.stderr)
     graph = load(path).get("@graph", [])
@@ -202,7 +181,6 @@ def main(argv):
         category, _ = classify_license(expr)
         packages_by_category[category] = packages_by_category.get(category, 0) + 1
 
-    print("# sbom: %s" % os.path.basename(path))
     print("\n=== inventory ===")
     print("  recipes                  %5d" % purpose.get("specification", 0))
     print("  installed packages       %5d" % purpose.get("install", 0))

--- a/scripts/sbom-cve/tests/test_cohort.py
+++ b/scripts/sbom-cve/tests/test_cohort.py
@@ -70,28 +70,32 @@ def test_companions_present_and_missing(tmp_path):
 
 def test_clean_cohort_has_no_warnings(tmp_path):
     stem = make_build(tmp_path, "20260724073419")
-    assert cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX)) == []
+    integrity, freshness = cohort.check_cohort(
+        tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert integrity == [] and freshness == []
 
 
-def test_testdata_image_name_mismatch_warns(tmp_path):
+def test_testdata_image_name_mismatch_is_integrity(tmp_path):
     stem = make_build(tmp_path, "20260724073419",
                       image_name="other-image.rootfs-20260101000000")
-    warns = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
-    assert any("mismatched pairing" in w for w in warns)
+    integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("mismatched pairing" in w for w in integrity)
 
 
-def test_missing_companion_warns(tmp_path):
+def test_missing_companion_is_integrity(tmp_path):
     stem = make_build(tmp_path, "20260724073419", roles=("cve",))
-    warns = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
-    assert any("no manifest companion" in w for w in warns)
-    assert any("no testdata companion" in w for w in warns)
+    integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("no manifest companion" in w for w in integrity)
+    assert any("no testdata companion" in w for w in integrity)
 
 
-def test_newer_image_warns(tmp_path):
-    old = make_build(tmp_path, "20260722113844")
-    make_build(tmp_path, "20260724073419")  # newer build present in same dir
-    warns = cohort.check_cohort(tmp_path / (old + cohort.CVE_JSON_SUFFIX))
-    assert any("newer image build 20260724073419" in w for w in warns)
+def test_newer_image_is_freshness_not_integrity(tmp_path):
+    old = make_build(tmp_path, "20260722113844")  # full, intact cohort
+    make_build(tmp_path, "20260724073419")        # newer build present in dir
+    integrity, freshness = cohort.check_cohort(
+        tmp_path / (old + cohort.CVE_JSON_SUFFIX))
+    assert integrity == []  # the older scan's own cohort is intact
+    assert any("newer image build 20260724073419" in w for w in freshness)
 
 
 def test_newer_image_of_other_variant_does_not_warn(tmp_path):
@@ -99,16 +103,67 @@ def test_newer_image_of_other_variant_does_not_warn(tmp_path):
     # a newer build of a DIFFERENT image variant must not flag the dev scan
     prod = "iot-gw-image-prod-raspberrypi5.rootfs-20260724073419"
     (tmp_path / (prod + cohort.MANIFEST_SUFFIX)).write_text("x 1.0\n")
-    warns = cohort.check_cohort(tmp_path / (dev + cohort.CVE_JSON_SUFFIX))
-    assert not any("newer image build" in w for w in warns)
+    _, freshness = cohort.check_cohort(tmp_path / (dev + cohort.CVE_JSON_SUFFIX))
+    assert freshness == []
 
 
-def test_strict_mode_exits_nonzero_on_stale_scan(tmp_path):
-    old = make_build(tmp_path, "20260722113844")
-    make_build(tmp_path, "20260724073419")  # newer image => stale selection
+def test_resolve_newest_skips_dangling_symlink(tmp_path):
+    stem = make_build(tmp_path, "20260724073419", roles=("cve",))
+    dated = tmp_path / (stem + cohort.CVE_JSON_SUFFIX)
+    stale = tmp_path / (LINK_STEM + cohort.CVE_JSON_SUFFIX)
+    os.symlink("gone" + cohort.CVE_JSON_SUFFIX, stale)  # dangling symlink
+    got = cohort.resolve_newest(str(tmp_path / ("*" + cohort.CVE_JSON_SUFFIX)))
+    assert os.path.basename(got) == dated.name  # dangling link skipped, no crash
+
+
+def test_resolve_newest_tie_is_deterministic(tmp_path):
+    a = tmp_path / (LINK_STEM + "-20260724070000" + cohort.CVE_JSON_SUFFIX)
+    b = tmp_path / (LINK_STEM + "-20260724080000" + cohort.CVE_JSON_SUFFIX)
+    a.write_text("{}")
+    b.write_text("{}")
+    os.utime(a, (1000, 1000))
+    os.utime(b, (1000, 1000))  # identical mtime -> tie broken by path
+    got = cohort.resolve_newest(str(tmp_path / ("*" + cohort.CVE_JSON_SUFFIX)))
+    assert os.path.basename(got) == b.name  # greater path wins, stably
+
+
+def test_cve_reader_strict_tolerates_stale_but_intact(tmp_path):
+    old = make_build(tmp_path, "20260722113844")  # full cohort
+    make_build(tmp_path, "20260724073419")        # newer image present
     cve = tmp_path / (old + cohort.CVE_JSON_SUFFIX)
     r = subprocess.run(
         [sys.executable, str(SBOM_DIR / "cve-report.py"), "--strict", "-i", str(cve)],
+        capture_output=True, text=True)
+    assert r.returncode == 0                    # freshness-only: not a failure
+    assert "newer image build" in r.stderr      # but still warned
+
+
+def test_cve_reader_require_latest_fails_on_newer_image(tmp_path):
+    old = make_build(tmp_path, "20260722113844")
+    make_build(tmp_path, "20260724073419")
+    cve = tmp_path / (old + cohort.CVE_JSON_SUFFIX)
+    r = subprocess.run(
+        [sys.executable, str(SBOM_DIR / "cve-report.py"),
+         "--require-latest", "-i", str(cve)],
+        capture_output=True, text=True)
+    assert r.returncode != 0
+
+
+def test_cve_reader_strict_fails_on_missing_companion(tmp_path):
+    stem = make_build(tmp_path, "20260724073419", roles=("cve",))  # no companions
+    cve = tmp_path / (stem + cohort.CVE_JSON_SUFFIX)
+    r = subprocess.run(
+        [sys.executable, str(SBOM_DIR / "cve-report.py"), "--strict", "-i", str(cve)],
+        capture_output=True, text=True)
+    assert r.returncode != 0
+    assert "WARNING" in r.stderr
+
+
+def test_sbom_reader_strict_fails_on_missing_companion(tmp_path):
+    stem = make_build(tmp_path, "20260724073419", roles=("aug_spdx",))
+    spdx = tmp_path / (stem + cohort.AUG_SPDX_SUFFIX)
+    r = subprocess.run(
+        [sys.executable, str(SBOM_DIR / "sbom-report.py"), "--strict", "-i", str(spdx)],
         capture_output=True, text=True)
     assert r.returncode != 0
     assert "WARNING" in r.stderr

--- a/scripts/sbom-cve/tests/test_cohort.py
+++ b/scripts/sbom-cve/tests/test_cohort.py
@@ -1,0 +1,114 @@
+"""Fixture-based tests for cohort selection + same-build validation.
+
+Synthetic deploy dirs only; no Yocto build required.
+"""
+import json
+import os
+import pathlib
+import subprocess
+import sys
+
+# Make the hyphen-free shared module importable (the report scripts are
+# hyphenated and can't be imported; done here rather than in a conftest.py to
+# avoid a top-level `conftest` module clash with scripts/fit-signing/tests).
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent.parent))
+import cohort  # noqa: E402
+
+SBOM_DIR = pathlib.Path(cohort.__file__).resolve().parent
+LINK_STEM = "iot-gw-image-dev-raspberrypi5.rootfs"
+
+_ROLE_SUFFIX = {
+    "cve": cohort.CVE_JSON_SUFFIX,
+    "aug_spdx": cohort.AUG_SPDX_SUFFIX,
+    "base_spdx": cohort.BASE_SPDX_SUFFIX,
+    "manifest": cohort.MANIFEST_SUFFIX,
+    "testdata": cohort.TESTDATA_SUFFIX,
+}
+
+
+def make_build(d, buildid,
+               roles=("cve", "aug_spdx", "base_spdx", "manifest", "testdata"),
+               image_name=None):
+    """Write a synthetic build cohort into dir `d`; return its stem."""
+    stem = "%s-%s" % (LINK_STEM, buildid)
+    for role in roles:
+        p = d / (stem + _ROLE_SUFFIX[role])
+        if role == "cve":
+            p.write_text(json.dumps({"version": "1", "package": []}))
+        elif role in ("aug_spdx", "base_spdx"):
+            p.write_text(json.dumps({"@graph": []}))
+        elif role == "manifest":
+            p.write_text("some-pkg 1.0 aarch64\n")
+        elif role == "testdata":
+            name = stem if image_name is None else image_name
+            p.write_text(json.dumps({"IMAGE_NAME": name}))
+    return stem
+
+
+def test_resolve_newest_returns_dated_not_symlink(tmp_path):
+    stem = make_build(tmp_path, "20260724073419", roles=("cve",))
+    dated = tmp_path / (stem + cohort.CVE_JSON_SUFFIX)
+    link = tmp_path / (LINK_STEM + cohort.CVE_JSON_SUFFIX)
+    os.symlink(dated.name, link)  # undated symlink -> dated file
+    got = cohort.resolve_newest(str(tmp_path / ("*" + cohort.CVE_JSON_SUFFIX)))
+    assert os.path.basename(got) == dated.name
+
+
+def test_build_stem_strips_each_suffix():
+    for suf in _ROLE_SUFFIX.values():
+        assert cohort.build_stem("/x/" + LINK_STEM + "-20260724073419" + suf) == \
+            LINK_STEM + "-20260724073419"
+
+
+def test_companions_present_and_missing(tmp_path):
+    stem = make_build(tmp_path, "20260724073419",
+                      roles=("cve", "manifest", "testdata"))
+    comp = cohort.companions(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert comp["cve_json"] and comp["manifest"] and comp["testdata"]
+    assert comp["aug_spdx"] is None and comp["base_spdx"] is None
+
+
+def test_clean_cohort_has_no_warnings(tmp_path):
+    stem = make_build(tmp_path, "20260724073419")
+    assert cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX)) == []
+
+
+def test_testdata_image_name_mismatch_warns(tmp_path):
+    stem = make_build(tmp_path, "20260724073419",
+                      image_name="other-image.rootfs-20260101000000")
+    warns = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("mismatched pairing" in w for w in warns)
+
+
+def test_missing_companion_warns(tmp_path):
+    stem = make_build(tmp_path, "20260724073419", roles=("cve",))
+    warns = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("no manifest companion" in w for w in warns)
+    assert any("no testdata companion" in w for w in warns)
+
+
+def test_newer_image_warns(tmp_path):
+    old = make_build(tmp_path, "20260722113844")
+    make_build(tmp_path, "20260724073419")  # newer build present in same dir
+    warns = cohort.check_cohort(tmp_path / (old + cohort.CVE_JSON_SUFFIX))
+    assert any("newer image build 20260724073419" in w for w in warns)
+
+
+def test_newer_image_of_other_variant_does_not_warn(tmp_path):
+    dev = make_build(tmp_path, "20260722113844")
+    # a newer build of a DIFFERENT image variant must not flag the dev scan
+    prod = "iot-gw-image-prod-raspberrypi5.rootfs-20260724073419"
+    (tmp_path / (prod + cohort.MANIFEST_SUFFIX)).write_text("x 1.0\n")
+    warns = cohort.check_cohort(tmp_path / (dev + cohort.CVE_JSON_SUFFIX))
+    assert not any("newer image build" in w for w in warns)
+
+
+def test_strict_mode_exits_nonzero_on_stale_scan(tmp_path):
+    old = make_build(tmp_path, "20260722113844")
+    make_build(tmp_path, "20260724073419")  # newer image => stale selection
+    cve = tmp_path / (old + cohort.CVE_JSON_SUFFIX)
+    r = subprocess.run(
+        [sys.executable, str(SBOM_DIR / "cve-report.py"), "--strict", "-i", str(cve)],
+        capture_output=True, text=True)
+    assert r.returncode != 0
+    assert "WARNING" in r.stderr

--- a/scripts/sbom-cve/tests/test_cohort.py
+++ b/scripts/sbom-cve/tests/test_cohort.py
@@ -82,6 +82,31 @@ def test_testdata_image_name_mismatch_is_integrity(tmp_path):
     assert any("mismatched pairing" in w for w in integrity)
 
 
+def test_testdata_empty_object_is_integrity(tmp_path):
+    stem = make_build(tmp_path, "20260724073419",
+                      roles=("cve", "manifest"))
+    (tmp_path / (stem + cohort.TESTDATA_SUFFIX)).write_text(json.dumps({}))
+    integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("no usable IMAGE_NAME" in w for w in integrity)
+
+
+def test_testdata_non_object_is_integrity_not_a_crash(tmp_path):
+    stem = make_build(tmp_path, "20260724073419",
+                      roles=("cve", "manifest"))
+    (tmp_path / (stem + cohort.TESTDATA_SUFFIX)).write_text(json.dumps([]))
+    integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("no usable IMAGE_NAME" in w for w in integrity)
+
+
+def test_testdata_empty_image_name_is_integrity(tmp_path):
+    stem = make_build(tmp_path, "20260724073419",
+                      roles=("cve", "manifest"))
+    (tmp_path / (stem + cohort.TESTDATA_SUFFIX)).write_text(
+        json.dumps({"IMAGE_NAME": ""}))
+    integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))
+    assert any("no usable IMAGE_NAME" in w for w in integrity)
+
+
 def test_missing_companion_is_integrity(tmp_path):
     stem = make_build(tmp_path, "20260724073419", roles=("cve",))
     integrity, _ = cohort.check_cohort(tmp_path / (stem + cohort.CVE_JSON_SUFFIX))


### PR DESCRIPTION
Fixes report selection in the existing `sbom-cve` readers. They auto-picked the newest match, which resolves to the un-dated `*.rootfs.*` symlink — so a report couldn't show which build it described, and a stale scan could be read against a newer image unnoticed (which happened during triage: a scan was read against an image built two days later).

A shared `scripts/sbom-cve/cohort.py` now resolves the **dated** file, confirms the selected scan and its image outputs share one `IMAGE_NAME` stem, and warns — or `--strict` fails — on a mismatched pairing, a missing companion, or a newer image build. Both readers print the dated provenance and drop their duplicated `die`/`load`/`locate`. It reads only `IMAGE_NAME` from testdata and never serialises it (testdata carries secrets).

Adds fixture tests (`make test-sbom-cve`) and `docs/SBOM_CVE.md` (scanning workflow, report reading, same-build convention, userspace triage).

Yocto's own provenance is trusted and unchanged — this only disambiguates our host-side report selection. No scan artifacts committed, no `CVE_STATUS` metadata.
