### PR TITLE
ci(supply-chain): pin actions to SHAs, add Dependabot, scope token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,31 @@
+---
+# Keeps the SHA pins in .github/workflows/ from rotting.
+#
+# Every `uses:` in this repo is pinned to a full commit SHA with the version
+# in a trailing comment. Dependabot understands that pairing: it bumps the
+# SHA and rewrites the comment together, so the pin stays both immutable and
+# legible. Without this, pinning just freezes the actions at whatever was
+# current the day someone pinned them.
+#
+# No `pip` ecosystem entry on purpose: pyproject.toml / uv.lock drive the
+# host-side signing tooling (see docs/FIT_BOOT_SIGNING.md), which CI never
+# installs — the only Python CI touches is an inline, already-pinned
+# `pip install yamllint==...`. Add a pip entry if that changes.
+#
+# No Yocto layer entry is possible: layer revisions are SHA-pinned in
+# rpi5.yml / kas/*.yml, which Dependabot does not parse. Those bumps stay
+# manual and deliberate.
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      # Match AGENTS.md "Commit style" so the commit-msg hook and git-cliff
+      # both accept what Dependabot opens.
+      prefix: "chore(ci)"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -7,12 +7,19 @@ on:
     branches: [ main, "release-*" ]
   workflow_dispatch:
 
+# This job only reads the tree — checkout, shellcheck, yamllint, greps.
+# Without an explicit block the token inherits the repository default, which
+# an admin can flip to read-write in one click, silently granting write to a
+# workflow that runs on every push to main.
+permissions:
+  contents: read
+
 jobs:
   hygiene:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Ensure release docs/scripts exist
         run: |
@@ -29,7 +36,9 @@ jobs:
 
       - name: shellcheck (all tracked scripts)
         run: |
-          mapfile -t scripts < <(git ls-files 'scripts/*.sh')
+          # scripts/hooks/* are extension-less by git-hook convention, so the
+          # *.sh glob misses them — list them explicitly or they go unlinted.
+          mapfile -t scripts < <(git ls-files 'scripts/*.sh' 'scripts/hooks/*')
           if [[ ${#scripts[@]} -eq 0 ]]; then
             echo "no tracked scripts/*.sh found"
             exit 0

--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -19,12 +19,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout full history and tags
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
       - name: Generate release notes
-        uses: orhun/git-cliff-action@v4
+        uses: orhun/git-cliff-action@f50e11560dce63f7c33227798f90b924471a88b5 # v4.8.0
         with:
           version: v2.13.1
           config: cliff.toml


### PR DESCRIPTION
Hardens the two GitHub Actions workflows against the tag-mutability and
token-scope halves of the same threat model.

**Action pinning.** `uses: ...@v4` resolves through a mutable tag, so a
retagged or compromised action runs with repository context and no review.
Both actions are now pinned to full commit SHAs, with the version kept in a
trailing comment for legibility.

**Dependabot.** Pinning on its own converts a supply-chain risk into a
staleness one. A `github-actions` entry keeps the pins current; it
understands the SHA-plus-comment pairing and rewrites both together. Its
commit prefix is set so the subjects it opens pass the repo's `commit-msg`
hook and git-cliff. No `pip` entry (CI installs only an inline pinned
yamllint) and no layer entry (layer SHAs live in the kas configs, which
Dependabot cannot parse — those stay manual and deliberate).

**Token scope.** `release-hygiene` only reads the tree but declared no
`permissions:`, so its token inherited the repository default. It now
declares `contents: read`. `release-notes` already scoped itself.

**Lint coverage.** Widens the shellcheck glob to `scripts/hooks/*`, which
the `*.sh` pattern missed because git hooks are extension-less by
convention. Those hooks gate every commit and had never been linted.

### Considered and dropped

A step asserting every tracked `.patch` declares `Upstream-Status` was
drafted, then removed. Since wrynose, `patch-status` sits in
`CHECKLAYER_REQUIRED_TESTS`, which `ERROR_QA` interpolates, so bitbake
already hard-fails `do_patch` for every layer including this one — and
nothing in this repo overrides it. Branches are built locally before a PR
opens, so the rule is enforced before review begins. The check could only
fire on a patch nobody built, and would have duplicated an existing
guarantee for no added coverage.

### Verification

Checked against sources other than the workflow itself:

- both pinned SHAs dereference to their commented tags via the GitHub tags
  API — `actions/checkout` v4.4.0, `orhun/git-cliff-action` v4.8.0
- `shellcheck -x` over `scripts/hooks/*` is clean, so the widened glob does
  not introduce a red build
- `yamllint` with the repo config passes on the edited workflow