### PR TITLE
feat(boot): enforce module signatures and fail-closed overlay setup

### DIFF
--- a/meta-iot-gateway/recipes-kernel/linux/files/fragments/security-prod.cfg
+++ b/meta-iot-gateway/recipes-kernel/linux/files/fragments/security-prod.cfg
@@ -8,8 +8,9 @@
 # ----------------------------------------------------------------------------
 CONFIG_MODULE_SIG=y
 CONFIG_MODULE_SIG_SHA256=y
-# Let the build auto-generate a key if not provided; disable force for now
-# CONFIG_MODULE_SIG_FORCE is not set
+# Let the build auto-generate a key if not provided and reject modules that are
+# unsigned or cannot be verified by a key trusted by the running kernel.
+CONFIG_MODULE_SIG_FORCE=y
 
 # ----------------------------------------------------------------------------
 # LSM (Linux Security Modules)

--- a/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.service
+++ b/meta-iot-gateway/recipes-support/overlayfs-setup/files/overlayfs-setup.service
@@ -9,7 +9,8 @@ Before=sysinit.target
 # /var/lib tmpfs (volatile-binds), so neither needs to wait on this unit.
 Wants=data.mount
 RequiresMountsFor=/data
-ConditionPathIsMountPoint=/data
+# Do not use ConditionPathIsMountPoint here: a false condition is a clean skip,
+# which would let the required sysinit dependency succeed without overlays.
 
 [Service]
 Type=oneshot
@@ -17,4 +18,7 @@ RemainAfterExit=yes
 ExecStart=/usr/sbin/overlayfs-setup.sh
 
 [Install]
-WantedBy=sysinit.target
+# Persistent overlays are part of the boot-success contract.  Make sysinit
+# fail closed when /data cannot be mounted or the overlays cannot be assembled,
+# so boot-complete.target cannot allow RAUC to mark that slot good.
+RequiredBy=sysinit.target


### PR DESCRIPTION
## Summary
- `CONFIG_MODULE_SIG_FORCE=y` rejects kernel modules that are unsigned or unverifiable, closing the gap where signing was configured but not enforced.
- `overlayfs-setup.service` moves `WantedBy` → `RequiredBy=sysinit.target` and drops `ConditionPathIsMountPoint=/data`, so a failure to mount/assemble the persistent overlays fails sysinit closed instead of silently proceeding to a half-built rootfs.

Sourced from the security-enforcement gap assessment (module enforcement item CS-04; mark-good health item #8).

## Validation status — draft until both are confirmed

- [x] `CONFIG_MODULE_SIG_FORCE=y` — confirmed live (`sig_enforce=Y`) on-target under a full real session (SSH, RAUC bundle install, Wi-Fi driver load), no rejected modules.
- [ ] Fail-closed overlay path — **not yet validated**. Attempted via masking `data.mount` and rebooting; this does not reach the real failure mode, because `/etc` (where the mask itself lives, via the persistent overlay) is only overlaid *after* `data.mount` already succeeds — the change can never be visible early enough to affect that boot's own bootstrap. Confirming this needs a destructive test against a disposable `/data` partition (e.g. a spare SD card), not the shared dev unit.

## Test plan
- [ ] Flash a disposable SD card / test unit
- [ ] Corrupt or otherwise force `/data`'s filesystem to fail
- [ ] Confirm `sysinit.target` fails closed, `boot-complete.target`/RAUC mark-good never runs, and the device does not silently boot without persistent overlays
- [ ] Confirm recovery path (re-provisioning `/data`) is documented and works

🤖 Generated with [Claude Code](https://claude.com/claude-code)