### PR TITLE
feat(hardening): SSH listen scope, firewall family-qualification, RAUC D-Bus, listen-guard

### DIFF
--- a/.github/workflows/release-hygiene.yml
+++ b/.github/workflows/release-hygiene.yml
@@ -45,6 +45,42 @@ jobs:
           fi
           shellcheck -S warning "${scripts[@]}"
 
+      - name: nftables rules name an address family
+        run: |
+          # In a "table inet", a rule naming a port with no family match admits
+          # it on IPv4 AND IPv6 alike. That is how SSH became reachable over a
+          # global IPv6 address: the ruleset family-qualified ICMP but not the
+          # service ports, and nothing checked.
+          #
+          # This lint only works because the OTBR rules live in their own .conf
+          # file. They were previously embedded as text inside a sed script in
+          # iotgw-firewall.bb, invisible to any grep over *.conf — so a check
+          # like this would have passed while the branch that actually shipped
+          # carried unqualified rules.
+          mapfile -t rulesets < <(git ls-files '*/nftables*.conf')
+          if [[ ${#rulesets[@]} -eq 0 ]]; then
+            echo "no tracked nftables rulesets found"
+            exit 0
+          fi
+          # Matches tcp/udp dport ANYWHERE on a rule line (not just as the
+          # first token, so "ct state new tcp dport 22 accept" is caught
+          # too). Comments are stripped before matching, both whole-line and
+          # trailing, so a rule cannot evade on the strength of its own
+          # comment, and a rule already constrained by "meta nfproto", "ip",
+          # or "ip6" is accepted.
+          rc=0
+          for f in "${rulesets[@]}"; do
+            bad=$(sed -E 's/#.*$//' "$f" \
+              | grep -nE '\b(tcp|udp)[[:space:]]+dport\b' \
+              | grep -vE '\bmeta[[:space:]]+nfproto\b|\bip6?\b') || true
+            if [[ -n "$bad" ]]; then
+              echo "$bad"
+              echo "::error file=$f::port rule with no address family (add 'meta nfproto ipv4'/'ipv6')"
+              rc=1
+            fi
+          done
+          exit $rc
+
       - name: Install yamllint
         run: pip install --quiet yamllint==1.35.1
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -275,15 +275,54 @@ lynis audit system
 ```bash
 # First boot audit (full log + normalized summary)
 lynis audit system --quick --no-colors > /data/lynis-baseline.log
-grep -E 'hardening_index=|^warning\\[\\]=|^suggestion\\[\\]=' /var/log/lynis-report.dat \
+grep -E 'hardening_index=|^warning\[\]=|^suggestion\[\]=' /var/log/lynis-report.dat \
   > /data/lynis-baseline.summary
 
 # Compare over time
 lynis audit system --quick --no-colors > /tmp/lynis-current.log
-grep -E 'hardening_index=|^warning\\[\\]=|^suggestion\\[\\]=' /var/log/lynis-report.dat \
+grep -E 'hardening_index=|^warning\[\]=|^suggestion\[\]=' /var/log/lynis-report.dat \
   > /tmp/lynis-current.summary
 diff -u /data/lynis-baseline.summary /tmp/lynis-current.summary
 ```
+
+Lynis has no test for listener address family or bind scope, which is why the
+listening-socket check below exists as a separate, independent control — it is
+not a Lynis finding this product tunes toward.
+
+### Listening Socket Check
+
+Asserts that only the intended sockets are listening, on the intended address
+families, and that the firewall's rules are family-qualified.
+
+```bash
+scripts/run-target-checks.sh <device-ip> exposure
+```
+
+Two independent layers, because they catch different things:
+
+| Layer | Runs | Catches |
+|---|---|---|
+| `iotgw-listen-guard.bbclass` | every image build, no board needed | a socket unit binding an unintended address; covers variants that have never been flashed |
+| `scripts/security/exposure-target.sh` | on a running target | the resulting system, including daemons that bind their own sockets and the live firewall ruleset |
+| `scripts/security/exposure-probe-host.sh` | from a second host | actual reachability — a device cannot prove its own |
+
+**The socket-activation trap.** `sshd` on this image is socket-activated:
+systemd binds the listening socket from `sshd.socket` and hands `sshd -i` an
+already-connected fd. `ListenAddress` and `AddressFamily` in `sshd_config` are
+therefore **inert** — sshd never opens a listening socket, so it never applies
+them. Listen scope lives in `sshd.socket.d/override.conf`.
+
+Upstream ships a bare `ListenStream=22`, which systemd binds **dual-stack**
+(`*:22`). On a device holding a global IPv6 address that is an un-NATed,
+publicly routable management port. The override pins it to `0.0.0.0:22`, and the
+empty `ListenStream=` reset preceding it is required — `ListenStream=` is a
+list, so without the reset the drop-in *adds* a listener and the dual-stack bind
+survives. `systemctl show sshd.socket -p Listen` must return exactly one entry.
+
+The same class applies to the firewall: in a `table inet`, a rule naming a port
+with no family match admits it on IPv4 **and** IPv6. Every service rule in
+`nftables.conf` carries an explicit `meta nfproto` match, enforced at build time
+by `iotgw-firewall.bb` and at runtime by `exposure-target.sh`.
 
 ---
 
@@ -348,7 +387,9 @@ Before deploying to production:
 - [ ] Review and customize firewall rules
 - [ ] Enable kernel security features (`igw_security_prod`)
 - [ ] Run `kernel-hardening-checker -c /proc/config.gz` on the deployed device and review the report
-- [ ] Run Lynis audit and address findings
+- [ ] Regenerate the Lynis baseline and review the diff against `docs/security-baselines/`
+- [ ] Verify only expected TCP/UDP listeners are present (`run-target-checks.sh <ip> exposure`)
+- [ ] Confirm reachability from a second host on every zone the device attaches to, over **both** IPv4 and IPv6 (`exposure-probe-host.sh`) — a device cannot prove its own reachability
 - [ ] Disable unused network services
 - [ ] Configure audit log forwarding (if applicable)
 - [ ] Set up SSH key-based authentication

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -14,6 +14,10 @@ In scope:
 - Provisioning path (`/data/iotgw` inputs -> on-device config/cred stores)
 - Core services (networking, OTA, observability, container runtime, TPM helpers)
 - Local/remote management interfaces (SSH, D-Bus mediated services)
+- Network exposure: listening sockets, firewall policy, and **address family**
+  reachability on every attached interface
+- Radio interfaces and their firmware: Wi-Fi (link security, supplicant policy),
+  Bluetooth, and Thread/OpenThread
 
 Out of scope:
 - Fleet backend internals not in this repository
@@ -35,6 +39,71 @@ Out of scope:
 4. Provisioning input store (`/data/iotgw`) -> privileged provisioning services
 5. Local root/admin shell -> all runtime secret and control planes
 6. Network ingress (MQTT/SSH/management) -> internal services
+7. Upstream layer defaults -> shipped product policy (see "Inherited vs
+   Authored Configuration")
+
+**Address families are a boundary, not a detail.** IPv4 subnet separation
+between two interfaces does **not** imply IPv6 separation: interfaces on
+different v4 subnets routinely share a single globally routable v6 prefix via
+SLAAC, and IPv6 has no NAT to fall back on. Any reasoning of the form "that
+interface is on a separate network" must be re-checked per family before it
+counts as a control.
+
+## Attacker Positions
+
+Controls are only meaningful against a position. This list is the lookup: a
+control that maps to no in-scope position is a nicety, however good it sounds.
+
+| # | Position | Reaches | Primary controls |
+|---|---|---|---|
+| A1 | Unauthenticated network peer (LAN, routed, Wi-Fi, IPv6) | Listening sockets admitted by the firewall | listen scope, family-qualified firewall rules, service auth |
+| A2 | Radio-proximate peer (Wi-Fi, BLE, Thread) | Link-layer association, pairing, commissioning | link security (WPA2/WPA3 + PMF), BlueZ policy, Thread commissioning |
+| A3 | Compromised confined service (non-root) | Local IPC — D-Bus, Unix sockets, device nodes | per-service sandboxing, D-Bus method authorization, MAC policy |
+| A4 | Local authenticated user | Shell, sudo policy, group memberships | account policy, sudoers scope, `hidepid` |
+| A5 | Physical / removable storage | SD contents, UART, U-Boot console | boot-chain signing, console policy, storage-at-rest posture |
+| A6 | Update-path actor (bundle source, D-Bus caller) | Rootfs replacement, slot/boot state | bundle signature policy, installer authorization, anti-rollback |
+
+Notes on scope: A4 is largely development-only — production images carry no
+interactive accounts. A5 is bounded by the documented absence of OTP-rooted
+secure boot; see `docs/FIT_BOOT_SIGNING.md` for what signing does and does not
+cover.
+
+## Inherited vs Authored Configuration
+
+**The recurring failure mode in this product is not weak policy we wrote — it is
+absent policy we never wrote, because an upstream layer already supplied one.**
+Services authored in `meta-iot-gateway` are consistently well-contained.
+Components arriving from OE-Core, meta-raspberrypi or other layers ship with
+*their* defaults, which are chosen for generality rather than for an appliance,
+and are silently adopted.
+
+Instances found in this product (each a real defect, not hypothetical):
+
+| Inherited default | Effect | Position |
+|---|---|---|
+| `sshd.socket` with a bare `ListenStream=<port>` | systemd binds dual-stack; SSH answers on every address the device holds, including globally routable IPv6 | A1 |
+| RAUC D-Bus policy granting `context="default"` | Any local process may call a root, unsandboxed installer | A3, A6 |
+| brcmfmac SDIO device-ID -> vendor-backend mapping | Binds the Wi-Fi part to a backend lacking the external-SAE implementation, so WPA3 cannot work despite capable firmware | A2 |
+| Radio firmware version/lineage chosen by an upstream machine conf | Firmware — a security-relevant input on the primary radio attack surface — is neither pinned nor reviewed by us | A2 |
+
+Contrast: `nftables` rules that admitted a port on both address families were
+**our** file, and the same file already family-qualified its ICMP rules. Authored
+policy fails by omission in one rule; inherited policy fails wholesale and
+invisibly, because no file in this repository is wrong.
+
+Practices that follow:
+
+1. **Review what you inherit, not only what you write.** A component's default
+   config is a decision the product makes, whether or not anyone made it.
+2. **Prefer overrides that travel with the package** over ones an image recipe
+   must remember to install — an image variant that omits a hardening package
+   must not thereby lose a listen-scope or authorization control.
+3. **Pin security-relevant upstream inputs deliberately**, with a recorded
+   reason and an upgrade path — firmware blobs included.
+4. **Assert the resulting system, not the inputs.** Only a check that inspects
+   the assembled image or the running device can see a defect that lives in a
+   file this repository does not contain. See `docs/SECURITY.md`,
+   "Listening Socket Check".
 
 ## Key Assets
 
@@ -86,6 +155,32 @@ Every new or modified service should be reviewed for:
 - Capability minimization (`CapabilityBoundingSet=`, `AmbientCapabilities=`)
 - Syscall and namespace restrictions when compatible
 - Secret handling path (no secrets in image defaults; avoid argv leaks)
+- **Its D-Bus policy, if it claims a bus name** — a well-sandboxed non-root
+  service is not contained if it can reach a privileged one over the system bus.
+  Restrict state-changing interfaces or members to the accounts that need them;
+  keep read-only properties and introspection open so diagnostics and health
+  reporting keep working. A policy that names a group degrades safely to
+  root-only when that group is absent.
+
+**This review applies to inherited units too, and that is where the gaps are.**
+`systemd-analyze security` separates the two populations cleanly — services
+authored here sit in the protected band, services adopted from upstream layers
+do not:
+
+| Population | Typical exposure |
+|---|---|
+| Authored in this layer (health daemon, OTBR units, broker) | ~1-5, "OK"/"PROTECTED" |
+| Inherited from upstream layers (installer, smartcard daemon, HCI attach, audit, bus daemon) | ~9+, "UNSAFE" |
+
+A high score is not automatically a defect — some components legitimately need
+broad privilege (a slot installer writes raw block devices and must run as
+root). The defect is leaving such a component **both** broadly privileged
+**and** broadly reachable. Reduce reachability first: it is usually a policy
+file, whereas capability minimization on a privileged writer risks failing
+mid-operation, at the worst possible moment.
+
+Sandboxing directives added to an update or storage path must be validated by a
+real end-to-end operation, not by the exposure score falling.
 
 ## Current Focus Areas
 
@@ -93,3 +188,25 @@ Every new or modified service should be reviewed for:
 2. OTA security verification gates (pre/post install).
 3. TPM-backed production secret model.
 4. Formal service hardening checklist enforcement in CI.
+5. Auditing inherited upstream defaults — listen scope, D-Bus authorization,
+   device-ID/driver bindings, and radio firmware pinning.
+6. Link-layer security posture: management-frame protection on existing
+   networks, and WPA3-SAE support.
+7. Assertion coverage for exposure: only expected listeners, on the expected
+   address families, with family-qualified firewall rules.
+
+## Verification Posture
+
+Configuration presence is not enforcement, and a passing build is not evidence.
+Anything in this document that claims a control is *effective* must be traceable
+to a check whose answer does not come from reading our own configuration:
+
+- **Off-device** for reachability — a device cannot prove what is reachable
+  from elsewhere. See `scripts/security/exposure-probe-host.sh`.
+- **On-device** for effective state — merged unit properties, the live firewall
+  ruleset, actual listening sockets. See `scripts/security/exposure-target.sh`.
+- **Build-time** for regressions that must be caught without hardware, and for
+  image variants that are rarely flashed.
+
+Where a claim has not been verified, this document should say so rather than
+imply coverage. See `AGENTS.md`, "Validating behaviour changes".

--- a/meta-iot-gateway/classes/iotgw-listen-guard.bbclass
+++ b/meta-iot-gateway/classes/iotgw-listen-guard.bbclass
@@ -1,0 +1,85 @@
+# Fail the image build if a systemd socket unit binds a network address we did
+# not intend.
+#
+# Runs as a ROOTFS_POSTPROCESS_COMMAND against the assembled rootfs, not a
+# pre-do_configure recipe check: the defect this guards against (SSH's
+# inherited dual-stack sshd.socket) lived in a unit no recipe here
+# referenced, so nothing about it exists before packages are installed.
+#
+# Covers socket-activated units only. A daemon that binds its own socket
+# directly is asserted at runtime instead, by a separate on-target check.
+# Says nothing about reachability; that pairing (bound + firewalled) is
+# asserted at runtime too.
+#
+# IOTGW_NET_LISTEN_ALLOW: space-separated "<unit>=<address>" pairs, compared
+# by EXACT SET EQUALITY. A listener that silently disappears is as much a
+# regression as one that appears.
+
+IOTGW_NET_LISTEN_ALLOW ??= "sshd.socket=0.0.0.0:22"
+
+ROOTFS_POSTPROCESS_COMMAND += "iotgw_rootfs_listen_guard;"
+
+iotgw_rootfs_listen_guard() {
+    _lg_expected="${IOTGW_NET_LISTEN_ALLOW}"
+    _lg_found=""
+
+    for _lg_dir in "${IMAGE_ROOTFS}${systemd_system_unitdir}" \
+                   "${IMAGE_ROOTFS}${sysconfdir}/systemd/system"; do
+        [ -d "$_lg_dir" ] || continue
+        for _lg_unit in "$_lg_dir"/*.socket; do
+            [ -e "$_lg_unit" ] || continue
+            # A unit symlinked to /dev/null is masked and never starts.
+            if [ -L "$_lg_unit" ] && [ "$(readlink "$_lg_unit")" = "/dev/null" ]; then
+                continue
+            fi
+            _lg_name=$(basename "$_lg_unit")
+
+            # Merge in systemd's own order (unit, then /usr/lib and /etc
+            # drop-ins, each lexically); an empty assignment resets the list,
+            # which is the override mechanism this guard exists to verify.
+            _lg_val=""
+            for _lg_src in "$_lg_unit" \
+                           "${IMAGE_ROOTFS}${systemd_system_unitdir}/${_lg_name}.d"/*.conf \
+                           "${IMAGE_ROOTFS}${sysconfdir}/systemd/system/${_lg_name}.d"/*.conf; do
+                [ -e "$_lg_src" ] || continue
+                while IFS= read -r _lg_line; do
+                    case "$_lg_line" in
+                        ListenStream=|ListenDatagram=|ListenSequentialPacket=)
+                            _lg_val=""   # list reset
+                            ;;
+                        ListenStream=*|ListenDatagram=*|ListenSequentialPacket=*)
+                            _lg_v=${_lg_line#*=}
+                            # AF_UNIX (path/abstract) and ListenNetlink= are
+                            # not network listeners; several system services
+                            # use the latter and would false-positive here.
+                            case "$_lg_v" in
+                                /*|@*) : ;;
+                                *) _lg_val="${_lg_val:+$_lg_val,}$_lg_v" ;;
+                            esac
+                            ;;
+                    esac
+                done < "$_lg_src"
+            done
+
+            [ -n "$_lg_val" ] && _lg_found="${_lg_found} ${_lg_name}=${_lg_val}"
+        done
+    done
+
+    _lg_found=$(echo $_lg_found | tr ' ' '\n' | sort | tr '\n' ' ')
+    _lg_want=$(echo $_lg_expected | tr ' ' '\n' | sort | tr '\n' ' ')
+
+    if [ "$_lg_found" != "$_lg_want" ]; then
+        bbfatal "iotgw-listen-guard: network-listening socket units do not match policy.
+
+  expected: ${_lg_want:-(none)}
+  found:    ${_lg_found:-(none)}
+
+A bare port (e.g. 'ListenStream=22') binds DUAL-STACK. To pin a family, ship
+a drop-in at <unit>.d/override.conf with an empty ListenStream= reset
+followed by the pinned address (ListenStream= is a list; without the reset
+the drop-in adds a listener instead of replacing one). Example:
+recipes-connectivity/openssh/files/sshd.socket-iotgw.conf. If this listener
+is intended, add it to IOTGW_NET_LISTEN_ALLOW in
+conf/distro/include/iotgw-common.inc."
+    fi
+}

--- a/meta-iot-gateway/conf/distro/include/iotgw-common.inc
+++ b/meta-iot-gateway/conf/distro/include/iotgw-common.inc
@@ -188,6 +188,21 @@ ROOT_HOME ?= "/root"
 # so overriding it in kas/local.yml keeps hardening + OTA management aligned.
 IOTGW_WIFI_IFACE ?= "wlan0"
 
+# Network-listening systemd socket units permitted in the image, as
+# "<unit>=<address>" pairs. Enforced by iotgw-listen-guard.bbclass at rootfs
+# assembly, by EXACT SET EQUALITY — so a listener that appears AND one that
+# silently disappears both fail the build.
+#
+# sshd is pinned to IPv4 because upstream's sshd.socket ships a bare
+# "ListenStream=22", which systemd binds dual-stack; with a global IPv6 address
+# on any interface that makes SSH reachable off-link with no NAT in the path.
+# The pin lives in recipes-connectivity/openssh/files/sshd.socket-iotgw.conf and
+# rides inside openssh-sshd so no image can install sshd without it.
+#
+# Only covers socket-ACTIVATED units. A daemon that binds its own socket
+# directly is asserted at runtime instead, by an on-target check.
+IOTGW_NET_LISTEN_ALLOW ?= "sshd.socket=0.0.0.0:22"
+
 # Allow injecting Wi-Fi credentials from the shell environment without committing them
 # Usage: export IOTGW_WIFI_SSID=MySSID IOTGW_WIFI_PSK=Secret && bitbake iot-gw-image-rauc
 BB_ENV_PASSTHROUGH_ADDITIONS .= " IOTGW_WIFI_SSID IOTGW_WIFI_PSK IOTGW_WIFI_IFACE IOTGW_ENABLE_OTBR"

--- a/meta-iot-gateway/recipes-connectivity/openssh/files/sshd.socket-iotgw.conf
+++ b/meta-iot-gateway/recipes-connectivity/openssh/files/sshd.socket-iotgw.conf
@@ -1,0 +1,16 @@
+# Pin the socket-activated SSH listener to IPv4.
+#
+# Upstream's sshd.socket ships a bare "ListenStream=22", which systemd binds
+# dual-stack (answers on every IPv6 address too). This cannot be fixed in
+# sshd_config: sshd runs as "sshd -i" and only ever inherits an
+# already-connected fd from systemd, so ListenAddress/AddressFamily in
+# sshd_config are read but never applied.
+
+[Socket]
+# The empty assignment is load-bearing: ListenStream= is a list, so a drop-in
+# that only adds a value keeps upstream's "22" too, leaving *:22 bound and
+# this override silently inert.
+ListenStream=
+ListenStream=0.0.0.0:22
+
+# Verify: `systemctl show sshd.socket -p Listen` -> exactly one entry.

--- a/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
+++ b/meta-iot-gateway/recipes-connectivity/openssh/openssh_%.bbappend
@@ -1,6 +1,8 @@
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
 
-SRC_URI:append = " file://openssh-hostkeys.tmpfiles.conf"
+SRC_URI:append = " file://openssh-hostkeys.tmpfiles.conf \
+                   file://sshd.socket-iotgw.conf \
+                 "
 
 do_install:append() {
     # Host keys live on the persistent /data partition, so the host identity is
@@ -24,6 +26,22 @@ do_install:append() {
     install -d ${D}${sysconfdir}/tmpfiles.d
     install -m 0644 ${UNPACKDIR}/openssh-hostkeys.tmpfiles.conf \
         ${D}${sysconfdir}/tmpfiles.d/openssh-hostkeys.conf
+
+    # Pin the socket-activated listener to IPv4. This rides inside openssh-sshd
+    # rather than a separate hardening package on purpose: the listen scope must
+    # not depend on an image recipe remembering to install a security package.
+    # packagegroup-iot-gw-security, for instance, reaches only the dev image, so
+    # a drop-in placed there would leave every other variant dual-stack.
+    #
+    # Guarded on the same PACKAGECONFIG that installs the unit - in service mode
+    # sshd.socket does not exist and a drop-in for it would be dead config.
+    if ${@bb.utils.contains('PACKAGECONFIG', 'systemd-sshd-socket-mode', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}/sshd.socket.d
+        install -m 0644 ${UNPACKDIR}/sshd.socket-iotgw.conf \
+            ${D}${systemd_system_unitdir}/sshd.socket.d/override.conf
+    fi
 }
 
-FILES:${PN}-sshd:append = " ${sysconfdir}/tmpfiles.d/openssh-hostkeys.conf"
+FILES:${PN}-sshd:append = " ${sysconfdir}/tmpfiles.d/openssh-hostkeys.conf \
+                            ${systemd_system_unitdir}/sshd.socket.d/override.conf \
+                          "

--- a/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
+++ b/meta-iot-gateway/recipes-core/images/iot-gw-image-base.inc
@@ -1,7 +1,7 @@
 ## Common base include for IoT Gateway images (RPi5)
 
 # Core inheritance shared by all image variants
-inherit core-image iotgw-rootfs extrausers
+inherit core-image iotgw-rootfs iotgw-listen-guard extrausers
 inherit iotgw-rauc-image
 
 # Label the rootfs with SELinux file contexts at do_rootfs (runs setfiles

--- a/meta-iot-gateway/recipes-ota/rauc/files/de.pengutronix.rauc-iotgw.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/de.pengutronix.rauc-iotgw.conf
@@ -1,0 +1,46 @@
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<!--
+  Restrict who may drive RAUC over the system bus. meta-rauc's shipped policy
+  grants send_destination to context="default": any local process can call
+  InstallBundle or Mark on rauc.service, which runs as root and unsandboxed.
+
+  /usr/share/dbus-1/system.d loads, then /etc/dbus-1/system.d loads after it;
+  a same-named file in /etc does not replace the upstream one. Revoking the
+  blanket grant needs an explicit <deny> below, which wins because later
+  rules take precedence.
+-->
+
+<busconfig>
+
+  <policy context="default">
+    <!-- Revoke the upstream blanket grant; add back only read-only access. -->
+    <deny send_destination="de.pengutronix.rauc"/>
+    <allow send_destination="de.pengutronix.rauc"
+           send_interface="org.freedesktop.DBus.Properties"/>
+    <allow send_destination="de.pengutronix.rauc"
+           send_interface="org.freedesktop.DBus.Introspectable"/>
+    <allow send_destination="de.pengutronix.rauc"
+           send_interface="org.freedesktop.DBus.Peer"/>
+
+    <!-- GetSlotStatus is read-only but shares an interface with InstallBundle
+         and Mark, so it needs its own member-level exception rather than an
+         interface-wide allow. -->
+    <allow send_destination="de.pengutronix.rauc"
+           send_interface="de.pengutronix.rauc.Installer"
+           send_member="GetSlotStatus"/>
+  </policy>
+
+  <!-- root and 'ota' (ota-updater.service User=ota) retain full access; ota
+       is what actually drives installs. -->
+  <policy user="root">
+    <allow own="de.pengutronix.rauc"/>
+    <allow send_destination="de.pengutronix.rauc"/>
+  </policy>
+
+  <policy user="ota">
+    <allow send_destination="de.pengutronix.rauc"/>
+  </policy>
+
+</busconfig>

--- a/meta-iot-gateway/recipes-ota/rauc/files/rauc-hardening.service.conf
+++ b/meta-iot-gateway/recipes-ota/rauc/files/rauc-hardening.service.conf
@@ -1,0 +1,15 @@
+# Conservative sandboxing for rauc.service. It stays root (writes raw slot
+# block devices, updates /uboot-env, mounts bundles, runs hooks); "root
+# reachable by any local process" is the actual defect, fixed separately in
+# de.pengutronix.rauc-iotgw.conf. This only reduces blast radius after a
+# compromise of rauc itself, restricted to directives that cannot plausibly
+# interfere with those operations.
+
+[Service]
+NoNewPrivileges=yes      # no reason to traverse a setuid binary as root already
+ProtectKernelModules=yes # rauc never loads/unloads modules
+ProtectClock=yes         # signing-time checks read the clock, never set it
+ProtectHostname=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+LockPersonality=yes

--- a/meta-iot-gateway/recipes-ota/rauc/rauc_%.bbappend
+++ b/meta-iot-gateway/recipes-ota/rauc/rauc_%.bbappend
@@ -27,6 +27,8 @@ SRC_URI:append = " \
     file://overlay-reconcile.py \
     file://99-iotgw-rauc-slots.rules \
     file://rauc-tpm2-pkcs11-store.service.conf \
+    file://de.pengutronix.rauc-iotgw.conf \
+    file://rauc-hardening.service.conf \
 "
 
 IOTGW_RAUC_STREAMING_KEY_MODE_EFFECTIVE ?= "file"
@@ -76,6 +78,22 @@ do_install:append() {
     install -m 0644 ${UNPACKDIR}/99-iotgw-rauc-slots.rules \
         ${D}${sysconfdir}/udev/rules.d/99-iotgw-rauc-slots.rules
 
+    # Restrict who may call the root RAUC service over D-Bus. meta-rauc's own
+    # policy grants send_destination to context="default" - i.e. every local
+    # process - to a root, unsandboxed installer. /etc/dbus-1/system.d is
+    # included AFTER /usr/share/dbus-1/system.d by system.conf, so this file's
+    # explicit <deny> revokes that grant. See the file header for why a
+    # same-named replacement would NOT have worked.
+    install -d ${D}${sysconfdir}/dbus-1/system.d
+    install -m 0644 ${UNPACKDIR}/de.pengutronix.rauc-iotgw.conf \
+        ${D}${sysconfdir}/dbus-1/system.d/de.pengutronix.rauc-iotgw.conf
+
+    # Conservative unit sandboxing. Numbered above the TPM drop-in so ordering
+    # is explicit rather than incidental.
+    install -d ${D}${sysconfdir}/systemd/system/rauc.service.d
+    install -m 0644 ${UNPACKDIR}/rauc-hardening.service.conf \
+        ${D}${sysconfdir}/systemd/system/rauc.service.d/20-iotgw-hardening.conf
+
     if ${@bb.utils.contains('IOTGW_RAUC_PKCS11_USES_TPM2', '1', 'true', 'false', d)}; then
         install -d ${D}${sysconfdir}/systemd/system/rauc.service.d
         sed -e "s|@IOTGW_TPM2_PKCS11_STORE@|${IOTGW_TPM2_PKCS11_STORE}|g" \
@@ -91,6 +109,9 @@ do_install:append() {
 FILES:rauc-grow-data-part:append = " ${sbindir}/grow-data-partition.sh"
 FILES:${PN}-service:append = " ${datadir}/iotgw/overlay-reconcile/managed-paths.conf ${datadir}/iotgw/overlay-reconcile/managed-paths.d/network.conf ${datadir}/iotgw/overlay-reconcile/managed-paths.d/observability.conf ${libexecdir}/rauc/overlay-reconcile.py"
 FILES:${PN}:append = " ${sysconfdir}/udev/rules.d/99-iotgw-rauc-slots.rules"
+FILES:${PN}-service:append = " ${sysconfdir}/dbus-1/system.d/de.pengutronix.rauc-iotgw.conf \
+                               ${sysconfdir}/systemd/system/rauc.service.d/20-iotgw-hardening.conf \
+                             "
 FILES:${PN}-service:append = "${@bb.utils.contains('IOTGW_RAUC_PKCS11_USES_TPM2', '1', ' ${sysconfdir}/systemd/system/rauc.service.d/10-tpm2-pkcs11-store.conf', '', d)}"
 RDEPENDS:${PN}-service:append = " python3-core"
 RDEPENDS:${PN}-service:append = "${@bb.utils.contains('IOTGW_RAUC_STREAMING_KEY_MODE_EFFECTIVE', 'pkcs11', ' openssl-engines libp11', '', d)}"

--- a/meta-iot-gateway/recipes-security/iotgw-firewall/files/nftables-otbr.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-firewall/files/nftables-otbr.conf
@@ -1,0 +1,17 @@
+    # OTBR web UI and agent REST API, IPv4 only.
+    #
+    # Both daemons currently bind 0.0.0.0 (otbr-webui on :80, otbr-agent on
+    # :8081), so an unqualified rule here would pre-authorise them on IPv6 the
+    # moment either gained a "::" bind. Naming the family keeps the firewall
+    # correct independently of how upstream binds.
+    #
+    # These endpoints are UNAUTHENTICATED and expose state-changing routes.
+    # The rule admits them from any source on the attached IPv4 networks;
+    # confining that is a network-design question, not a firewall one.
+    meta nfproto ipv4 tcp dport 80 accept
+    meta nfproto ipv4 tcp dport 8081 accept
+    #
+    # Port 443 is deliberately NOT admitted. Nothing on the image listens on it,
+    # and an accept rule with no service behind it is a standing authorisation
+    # for whatever binds there next. Re-add it in the same commit that
+    # introduces a TLS listener, not before.

--- a/meta-iot-gateway/recipes-security/iotgw-firewall/files/nftables.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-firewall/files/nftables.conf
@@ -2,6 +2,16 @@
 # Do not flush the whole ruleset; other services (e.g. OTBR) manage their own tables.
 # iotgw-nftables.service deletes this table in ExecStartPre (ignored if missing)
 # before loading this file, so this config remains idempotent.
+#
+# ADDRESS FAMILY: this is a "table inet", so a rule written as
+# "tcp dport 22 accept", with no family match, admits the port on IPv4 AND
+# IPv6 alike. That is almost never what a service rule means here, and it is
+# how SSH became reachable over a global IPv6 address. Every service rule below
+# therefore carries an explicit "meta nfproto" match.
+#
+# Rule of thumb for anything added here: if a rule names a port, it must also
+# name a family. Enforced both at build time (do_install bbfatals on any dport
+# rule with no family token) and against the live ruleset on target.
 
 table inet filter {
   chain input {
@@ -18,8 +28,10 @@ table inet filter {
     ip protocol icmp accept
     ip6 nexthdr icmpv6 accept
 
-    # SSH
-    tcp dport 22 accept
+    # SSH, IPv4 only. The listener is pinned to 0.0.0.0:22 by
+    # sshd.socket.d/override.conf; this rule is the second, independent
+    # expression of the same intent, so neither control alone is load-bearing.
+    meta nfproto ipv4 tcp dport 22 accept
     @OTBR_RULES@
   }
 

--- a/meta-iot-gateway/recipes-security/iotgw-firewall/iotgw-firewall.bb
+++ b/meta-iot-gateway/recipes-security/iotgw-firewall/iotgw-firewall.bb
@@ -3,22 +3,48 @@ HOMEPAGE = "https://github.com/umair-as/rpi5-iot-gateway"
 LICENSE = "MIT"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
-SRC_URI = "file://nftables.conf"
+SRC_URI = "file://nftables.conf \
+           file://nftables-otbr.conf \
+          "
 
 S = "${UNPACKDIR}"
 PACKAGE_ARCH = "${MACHINE_ARCH}"
 
+# The OTBR rules live in their own file rather than inline in a sed script.
+# As embedded sed text they were invisible to any grep over *.conf, so a lint or
+# guard scanning the tracked ruleset would have passed while the OTBR build
+# branch - the one that actually shipped - carried unqualified rules. Keeping
+# them in a real file means one pattern covers both build configurations.
 do_install() {
     install -d ${D}${datadir}/iotgw-firewall
     install -m 0644 ${UNPACKDIR}/nftables.conf ${D}${datadir}/iotgw-firewall/nftables.conf
 
     if [ "${IOTGW_ENABLE_OTBR}" = "1" ]; then
-        sed -i '/@OTBR_RULES@/c\    # OTBR web UI and REST API\
-    tcp dport 80 accept\
-    tcp dport 443 accept\
-    tcp dport 8081 accept' ${D}${datadir}/iotgw-firewall/nftables.conf
+        # Splice the file in at the marker, then drop the marker line itself.
+        sed -i -e '/@OTBR_RULES@/r ${UNPACKDIR}/nftables-otbr.conf' \
+               -e '/@OTBR_RULES@/d' \
+               ${D}${datadir}/iotgw-firewall/nftables.conf
     else
         sed -i '/@OTBR_RULES@/d' ${D}${datadir}/iotgw-firewall/nftables.conf
+    fi
+
+    # Fail the build rather than ship a rule that silently spans both families.
+    # Matches tcp/udp dport ANYWHERE on a rule line (not just as the first
+    # token, so "ct state new tcp dport 22 accept" is caught too). Comments
+    # are stripped BEFORE matching, both whole-line and trailing ("tcp dport
+    # 22 accept # ip note" must not evade on the strength of its own
+    # comment), and a rule already constrained by "meta nfproto", "ip", or
+    # "ip6" is accepted.
+    _nft_file="${D}${datadir}/iotgw-firewall/nftables.conf"
+    _nft_bad=$(sed -E 's/#.*$//' "${_nft_file}" \
+        | grep -nE '\b(tcp|udp)[[:space:]]+dport\b' \
+        | grep -vE '\bmeta[[:space:]]+nfproto\b|\bip6?\b') || true
+    if [ -n "${_nft_bad}" ]; then
+        bbfatal "iotgw-firewall: the lines below name a port with no address family.
+${_nft_bad}
+In a 'table inet' they admit the port on IPv4 AND IPv6. Add an explicit \
+'meta nfproto ipv4' / 'meta nfproto ipv6' match. See the header comment in \
+recipes-security/iotgw-firewall/files/nftables.conf."
     fi
 }
 

--- a/meta-iot-gateway/recipes-security/iotgw-sshd-hardening/files/99-iotgw.conf
+++ b/meta-iot-gateway/recipes-security/iotgw-sshd-hardening/files/99-iotgw.conf
@@ -2,6 +2,11 @@
 # - Allow key-based auth
 # - Keep password auth enabled for convenience (dev images)
 # - Root login allowed only via keys (no password)
+#
+# SCOPE: authentication policy only. sshd is socket-activated here (systemd
+# hands sshd@.service an already-connected fd via "sshd -i"), so
+# ListenAddress/AddressFamily would be read but never applied if added below.
+# Listen scope lives in sshd.socket-iotgw.conf instead.
 
 # Display legal banner before authentication
 Banner /etc/issue.net

--- a/scripts/run-target-checks.sh
+++ b/scripts/run-target-checks.sh
@@ -16,8 +16,13 @@
 #   scripts/run-target-checks.sh --list
 #
 # With no check names, runs the default smoke set (ota-fit-slot ota-smoke
-# container-smoke). ota-bench is excluded from the default set (it is a
-# benchmark, not a pass/fail check) but can be named explicitly.
+# container-smoke exposure). ota-bench is excluded from the default set (it is
+# a benchmark, not a pass/fail check) but can be named explicitly.
+#
+# The "exposure" check asserts listen scope, address family, and firewall
+# qualification. It cannot test off-device reachability - a device cannot prove
+# its own; pair it with scripts/security/exposure-probe-host.sh from a second
+# host.
 #
 # Environment overrides:
 #   IOTGW_TARGET     device host/IP (used if no positional host is given)
@@ -39,11 +44,12 @@ check_path() {
         ota-smoke)       echo "ota/ota-smoke-target.sh" ;;
         container-smoke) echo "container/container-smoke-target.sh" ;;
         ota-bench)       echo "ota/ota-bench-target.sh" ;;
+        exposure)        echo "security/exposure-target.sh" ;;
         *)               return 1 ;;
     esac
 }
-ALL_CHECKS="ota-fit-slot ota-smoke container-smoke ota-bench"
-DEFAULT_CHECKS="ota-fit-slot ota-smoke container-smoke"
+ALL_CHECKS="ota-fit-slot ota-smoke container-smoke ota-bench exposure"
+DEFAULT_CHECKS="ota-fit-slot ota-smoke container-smoke exposure"
 
 usage() {
     sed -nE 's/^# ?//p' "${BASH_SOURCE[0]}" | sed -n '1,33p'

--- a/scripts/security/exposure-probe-host.sh
+++ b/scripts/security/exposure-probe-host.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Off-device reachability oracle for the IoT Gateway.
+#
+# A device cannot prove its own external reachability: its own view of listeners
+# and firewall rules is exactly the view that can be wrong. This script runs on
+# a SECOND host and answers the only question that matters, what actually
+# accepts a connection from somewhere else.
+#
+# Non-destructive by construction: TCP connect only. No authentication attempt,
+# no HTTP request, no state-changing call. A successful connect is closed
+# immediately.
+#
+# Usage:
+#   scripts/security/exposure-probe-host.sh --v4 <addr> [--v6 <addr>] [--otbr] [--ports "22 80 ..."]
+#
+# Addresses are ARGUMENTS ONLY and have no defaults, this repo is public, and a
+# baked-in address would leak the deployment. Get them from the device (strip
+# the /prefix, these commands print CIDR, not a bare address):
+#   ip -4 -o addr show scope global | awk '{print $4}' | cut -d/ -f1
+#   ip -6 -o addr show scope global | awk '{print $4}' | cut -d/ -f1
+#
+# --otbr: this image was built with IOTGW_ENABLE_OTBR=1, so ports 80/8081
+# are expected open. It defaults off, matching the distro's own default;
+# without it, 80/8081 are reported as INFO (observed, not asserted), since
+# this host has no way to know whether the target image has OTBR at all.
+#
+# Exit status: 0 if the observed reachability matches the expected policy
+# (IPv4 management reachable, IPv6 not) AND every asserted probe returned a
+# decisive result, non-zero otherwise. A probe that could not run at all (bad
+# address, no route, DNS failure) is a FAIL, never a silent pass.
+#
+# Expected policy after the IPv4-only listener pin:
+#   v4: 22 open (management), 80/8081 open only with --otbr, 1883 filtered,
+#       443 closed
+#   v6: nothing open
+
+set -u
+
+V4=""
+V6=""
+OTBR=0
+PORTS="22 80 443 1883 8081"
+TIMEOUT=3
+
+usage() { sed -nE 's/^# ?//p' "${BASH_SOURCE[0]}" | sed -n '1,33p'; }
+
+is_uint() { case "$1" in ''|*[!0-9]*) return 1 ;; *) return 0 ;; esac; }
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --v4)      V4="${2:-}"; shift 2 ;;
+        --v6)      V6="${2:-}"; shift 2 ;;
+        --otbr)    OTBR=1; shift ;;
+        --ports)   PORTS="${2:-}"; shift 2 ;;
+        --timeout) TIMEOUT="${2:-}"; shift 2 ;;
+        -h|--help) usage; exit 0 ;;
+        *) printf 'error: unknown argument %s\n\n' "$1" >&2; usage >&2; exit 2 ;;
+    esac
+done
+
+if [ -z "$V4" ] && [ -z "$V6" ]; then
+    printf 'error: give at least --v4 or --v6 (no defaults; see --help)\n\n' >&2
+    usage >&2
+    exit 2
+fi
+
+# --ports/--timeout are spliced into a bash -c string below (to reach
+# /dev/tcp); reject anything non-numeric here rather than pass operator input
+# through to a shell command string unvalidated.
+if ! is_uint "$TIMEOUT" || [ "$TIMEOUT" -eq 0 ]; then
+    printf 'error: --timeout must be a positive integer, got %s\n' "$TIMEOUT" >&2
+    exit 2
+fi
+for _p in $PORTS; do
+    if ! is_uint "$_p" || [ "$_p" -lt 1 ] || [ "$_p" -gt 65535 ]; then
+        printf 'error: --ports must be space-separated integers 1-65535, got %s\n' "$_p" >&2
+        exit 2
+    fi
+done
+
+PASS=0
+FAIL=0
+
+say_pass() { printf '  \e[32mPASS\e[0m %s\n' "$1"; PASS=$((PASS+1)); }
+say_fail() { printf '  \e[31mFAIL\e[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+say_info() { printf '  \e[36mINFO\e[0m %s\n' "$1"; }
+
+# ICMP reachability gate. A TCP connect that times out is ambiguous by itself:
+# this device's own firewall policy is DROP, not REJECT, so "port filtered by
+# policy" and "address unreachable" produce the identical symptom (no reply
+# before our timeout). Confirming basic reachability first means a later TCP
+# timeout can be read as "filtered", not "who knows".
+reachable() {
+    local addr="$1"
+    case "$addr" in
+        *:*) ping -6 -c 1 -W "$TIMEOUT" "$addr" >/dev/null 2>&1 ;;
+        *)   ping -4 -c 1 -W "$TIMEOUT" "$addr" >/dev/null 2>&1 ;;
+    esac
+}
+
+# Bash's /dev/tcp does NOT accept bracketed IPv6 literals ("[::1]" fails
+# name resolution outright, confirmed empirically); it wants the bare address.
+# Prints one of: open | closed | filtered | error: <reason>
+probe() {
+    local addr="$1" port="$2" out rc
+    out=$(timeout "$TIMEOUT" bash -c "exec 3<>/dev/tcp/${addr}/${port}" 2>&1)
+    rc=$?
+    if [ "$rc" -eq 0 ]; then
+        echo "open"
+        return
+    fi
+    if [ "$rc" -eq 124 ]; then
+        echo "filtered"   # no reply within timeout; caller gates this on reachable()
+        return
+    fi
+    case "$out" in
+        *"Connection refused"*)
+            echo "closed" ;;
+        *"Name or service not known"*|*"Temporary failure in name resolution"*)
+            echo "error: name resolution failed for ${addr}" ;;
+        *"No route to host"*|*"Network is unreachable"*)
+            echo "error: no route to ${addr}" ;;
+        *"Invalid argument"*)
+            echo "error: invalid address syntax for /dev/tcp: ${addr}" ;;
+        *)
+            echo "error: unrecognized /dev/tcp failure: ${out:-<no output>}" ;;
+    esac
+}
+
+# expect: "open", "closed" (closed accepts either a refusal or, once
+# reachability is confirmed, a firewall-filtered timeout as equivalent), or
+# "either" to report the observed state as INFO without a pass/fail verdict.
+assert() {
+    local family="$1" addr="$2" port="$3" expect="$4" state
+
+    if ! reachable "$addr"; then
+        say_fail "${family} tcp/${port}: host unreachable (ping failed), cannot assert ${expect}"
+        return
+    fi
+
+    state=$(probe "$addr" "$port")
+    case "$state" in
+        error:*)
+            say_fail "${family} tcp/${port}: PROBE ERROR, ${state#error: } (not evidence of open or closed)"
+            return
+            ;;
+        filtered)
+            state="closed"   # reachability already confirmed above
+            ;;
+    esac
+
+    if [ "$expect" = "either" ]; then
+        say_info "${family} tcp/${port} ${state} (OTBR-dependent, unasserted; pass --otbr if this image has it)"
+    elif [ "$state" = "$expect" ]; then
+        say_pass "${family} tcp/${port} ${state} (expected)"
+    else
+        say_fail "${family} tcp/${port} ${state}, expected ${expect}"
+    fi
+}
+
+if [ -n "$V4" ]; then
+    printf '\n== IPv4 (%s) ==\n' "$V4"
+    for p in $PORTS; do
+        case "$p" in
+            22) assert IPv4 "$V4" "$p" open ;;
+            80|8081)
+                if [ "$OTBR" -eq 1 ]; then
+                    assert IPv4 "$V4" "$p" open
+                else
+                    assert IPv4 "$V4" "$p" either
+                fi
+                ;;
+            *)  assert IPv4 "$V4" "$p" closed ;;
+        esac
+    done
+fi
+
+if [ -n "$V6" ]; then
+    printf '\n== IPv6 (%s) ==\n' "$V6"
+    # Every port must be closed over IPv6 regardless of --otbr: OTBR's web UI
+    # and agent REST bind IPv4-only by design, so this is a policy invariant,
+    # not an OTBR-presence question. The management plane is IPv4-only by
+    # policy: the sshd.socket listener is pinned to 0.0.0.0:22 and the firewall
+    # rules are family-qualified. A single open port here means one of those two
+    # controls regressed.
+    for p in $PORTS; do
+        assert IPv6 "$V6" "$p" closed
+    done
+fi
+
+printf '\n== summary ==\n'
+printf '  PASS: %d\n' "$PASS"
+printf '  FAIL: %d\n' "$FAIL"
+
+[ "$FAIL" -eq 0 ]

--- a/scripts/security/exposure-target.sh
+++ b/scripts/security/exposure-target.sh
@@ -1,0 +1,333 @@
+#!/bin/bash
+# Network-exposure assertions for the IoT Gateway distro (iotgw).
+#
+# Answers one question the rest of the smoke suite does not: is anything
+# listening, or admitted by the firewall, on an address family or scope we did
+# not intend?
+#
+# Why this exists. sshd on this image is socket-activated (sshd@.service under
+# Accept=yes), so systemd - not sshd - owns the listening socket. Upstream's
+# sshd.socket ships a bare "ListenStream=22", which systemd binds DUAL-STACK
+# (*:22). With a global IPv6 address on any interface that makes SSH reachable
+# over un-NATed IPv6. ListenAddress/AddressFamily in sshd_config are INERT
+# under socket activation and cannot fix it; the listen scope lives in
+# sshd.socket.d/override.conf.
+#
+# The single highest-value assertion here is the "Listen" property check in the
+# first section: systemd's own answer, and the only thing that distinguishes an
+# override that RESET the ListenStream list from one that merely APPENDED to it
+# (the latter silently keeps *:22 and is the most likely way the fix regresses).
+#
+# Usage:
+#   # On target directly:
+#   sudo ./exposure-target.sh
+#
+#   # From host over SSH (no copy needed):
+#   ssh <gw> 'sudo bash -s' < scripts/security/exposure-target.sh
+#
+#   # Via the runner:
+#   scripts/run-target-checks.sh <device-ip> exposure
+#
+# Pairs with:
+#   scripts/security/exposure-probe-host.sh - the off-device reachability
+#     oracle. A device cannot prove its own external reachability; that check
+#     must run from a second host.
+#
+# Environment overrides:
+#   IOTGW_EXPECT_SSH_LISTEN  expected sshd.socket Listen value
+#                            (default: 0.0.0.0:22)
+#   IOTGW_LISTEN_ALLOW       space-separated allowlist of non-loopback
+#                            listening addresses, "addr:port" as ss prints them
+
+set -u
+PASS=0
+FAIL=0
+SKIP=0
+
+say_pass() { printf '  \e[32mPASS\e[0m %s\n' "$1"; PASS=$((PASS+1)); }
+say_fail() { printf '  \e[31mFAIL\e[0m %s\n' "$1"; FAIL=$((FAIL+1)); }
+say_skip() { printf '  \e[33mSKIP\e[0m %s - %s\n' "$1" "${2:-}"; SKIP=$((SKIP+1)); }
+section()  { printf '\n== %s ==\n' "$1"; }
+
+# Expected sshd.socket listener. IPv4-only is deliberate: the listener itself
+# enforces the family, rather than depending on a firewall rule staying correct.
+EXPECT_SSH_LISTEN="${IOTGW_EXPECT_SSH_LISTEN:-0.0.0.0:22}"
+
+# OTBR (ports 80/8081) is an optional image feature (IOTGW_ENABLE_OTBR),
+# default off in the distro itself. Assuming it is present unconditionally
+# would fail this check on any correctly-built non-OTBR image, so its
+# presence is detected on THIS target rather than assumed.
+_otbr_ports=""
+if command -v systemctl >/dev/null 2>&1 \
+   && systemctl list-unit-files 'otbr-web.service' 'otbr-agent.service' 2>/dev/null | grep -q '\.service'; then
+    _otbr_ports="0.0.0.0:80 0.0.0.0:8081"
+fi
+
+# Non-loopback, non-link-scoped listeners we intend to have.
+#   22          sshd (IPv4-only after the socket pin)
+#   80 / 8081   OTBR web UI and agent REST, IPv4-only binds, only when OTBR
+#               is actually part of this image (see _otbr_ports above)
+#   1883        mosquitto; also binds v6, admitted by NO firewall rule
+#   5353        Avahi/mDNS; also binds v6, admitted by NO firewall rule
+# The v6 binds on 1883/5353 are safe only because the firewall does not admit
+# those ports. That pairing is ASSERTED against the live ruleset in the IPv6
+# section below rather than assumed here - assuming it is how this class of bug
+# happens in the first place.
+DEFAULT_LISTEN_ALLOW="0.0.0.0:22 ${_otbr_ports} 0.0.0.0:1883 [::]:1883 0.0.0.0:5353 [::]:5353"
+LISTEN_ALLOW="${IOTGW_LISTEN_ALLOW:-$DEFAULT_LISTEN_ALLOW}"
+
+in_allowlist() {
+    local needle="$1" item
+    for item in $LISTEN_ALLOW; do
+        [ "$item" = "$needle" ] && return 0
+    done
+    return 1
+}
+
+# Loopback binds are not an exposure surface; they auto-pass.
+is_loopback() {
+    case "$1" in
+        127.*|'[::1]'*|*'%lo:'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# Interface-scoped ("%iface") and link-local (fe80::) binds cannot be reached
+# from off-link regardless of the firewall - the scope is enforced by the
+# kernel, not by policy. These are the DHCP client (:68), the DHCPv6 client
+# (:546) and OTBR's ephemeral Thread port, whose number changes per boot and so
+# cannot be allowlisted by value. Reported, not judged.
+is_link_scoped() {
+    case "$1" in
+        *%*|'[fe80:'*) return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+section "sshd.socket listen scope"
+if ! command -v systemctl >/dev/null 2>&1; then
+    say_skip "sshd.socket Listen" "systemctl not available"
+elif ! systemctl cat sshd.socket >/dev/null 2>&1; then
+    say_skip "sshd.socket Listen" "unit not present (sshd may not be socket-activated)"
+else
+    # systemd renders this as "Listen=0.0.0.0:22 (Stream)". A dual-stack bind
+    # from a bare "ListenStream=22" renders as "[::]:22 (Stream)". An override
+    # that appended instead of resetting yields TWO entries.
+    listen_raw=$(systemctl show sshd.socket -p Listen --value 2>/dev/null)
+    listen_count=$(printf '%s\n' "$listen_raw" | grep -c '(Stream)')
+    listen_addr=$(printf '%s' "$listen_raw" | sed -E 's/ \(Stream\)//g' | tr -s ' ')
+
+    printf '    Listen = %s\n' "${listen_raw:-(empty)}"
+
+    if [ "$listen_count" -gt 1 ]; then
+        say_fail "sshd.socket has $listen_count stream listeners - the override APPENDED instead of resetting the ListenStream list (needs a bare 'ListenStream=' first)"
+    elif [ "$listen_addr" = "$EXPECT_SSH_LISTEN" ]; then
+        say_pass "sshd.socket Listen = $listen_addr"
+    else
+        say_fail "sshd.socket Listen = '${listen_addr:-(empty)}', expected '$EXPECT_SSH_LISTEN'"
+    fi
+
+    # Prove the drop-in is actually being read, not just that the value is right
+    # for some other reason.
+    if systemctl cat sshd.socket 2>/dev/null | grep -q 'sshd\.socket\.d/'; then
+        say_pass "sshd.socket drop-in present in merged unit"
+    else
+        say_fail "no sshd.socket.d/ drop-in in merged unit - upstream default is unmodified"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+section "listening socket inventory"
+if ! command -v ss >/dev/null 2>&1; then
+    say_skip "listener inventory" "ss not available (iproute2-ss)"
+else
+    unexpected=0
+    seen=""
+    # -H omits the header; field 4 is Local Address:Port for both -tln and -uln.
+    while read -r laddr; do
+        [ -z "$laddr" ] && continue
+        seen="$seen $laddr"
+        if is_loopback "$laddr"; then
+            continue
+        fi
+        if is_link_scoped "$laddr"; then
+            printf '    link-scoped (not off-link reachable): %s\n' "$laddr"
+            continue
+        fi
+        if in_allowlist "$laddr"; then
+            say_pass "listener $laddr (expected)"
+        else
+            say_fail "listener $laddr is NOT in the expected set"
+            unexpected=$((unexpected + 1))
+        fi
+    done <<EOF
+$( { ss -tlnH; ss -ulnH; } 2>/dev/null | awk '{print $4}' | sort -u )
+EOF
+
+    # A listener that VANISHED matters as much as one that appeared - a missing
+    # service is a regression too, and a subset check would not notice.
+    for want in $LISTEN_ALLOW; do
+        case " $seen " in
+            *" $want "*) : ;;
+            *) say_fail "expected listener $want is ABSENT" ;;
+        esac
+    done
+
+    [ "$unexpected" -eq 0 ] && say_pass "no unexpected non-loopback listeners"
+fi
+
+# ---------------------------------------------------------------------------
+section "firewall address-family qualification"
+# Ports the input chain admits. Consumed by the IPv6 section below to verify
+# that every wildcard v6 listener is in fact unreachable, rather than assuming
+# it. Empty string means "could not determine" and the v6 section degrades to a
+# SKIP rather than a false PASS.
+FW_ACCEPT_PORTS=""
+if ! command -v nft >/dev/null 2>&1; then
+    say_skip "nftables ruleset" "nft not available"
+else
+    if nft -c -f /etc/nftables.conf >/dev/null 2>&1; then
+        say_pass "/etc/nftables.conf parses"
+    else
+        say_fail "/etc/nftables.conf does not parse"
+    fi
+
+    # In a "table inet", a rule such as "tcp dport 22 accept" with no family
+    # qualifier matches BOTH IPv4 and IPv6. nft prints its own canonical form,
+    # so a qualified rule appears as "meta nfproto ipv4 tcp dport 22 accept"
+    # (or with a leading "ip "/"ip6 " match). Anything with a dport and no
+    # family token is unqualified.
+    chain=$(nft list chain inet filter input 2>/dev/null)
+    if [ -z "$chain" ]; then
+        say_skip "inet filter input" "chain not present"
+    else
+        FW_ACCEPT_PORTS=$(printf '%s\n' "$chain" \
+            | grep -E 'dport .* accept' \
+            | sed -E 's/.*dport[[:space:]]+\{?[[:space:]]*([0-9, ]+).*/\1/' \
+            | tr ',' ' ' | tr -s ' ' '\n' | grep -E '^[0-9]+$' | sort -un | tr '\n' ' ')
+        printf '    input chain admits ports: %s\n' "${FW_ACCEPT_PORTS:-(none)}"
+
+        unqualified=$(printf '%s\n' "$chain" \
+            | grep -E 'dport' \
+            | grep -vE 'nfproto (ipv4|ipv6)' \
+            | grep -vE '(^|[[:space:]])ip6?[[:space:]]' || true)
+        if [ -z "$unqualified" ]; then
+            say_pass "all dport rules in inet filter input are family-qualified"
+        else
+            say_fail "unqualified dport rule(s) in inet filter input - these match IPv4 AND IPv6:"
+            printf '%s\n' "$unqualified" | sed 's/^/        /'
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+section "IPv6 reachability posture"
+# Report the COUNT only. This output is meant to be pasteable into a commit
+# body, and the repo is public - a global address identifies the site.
+if ! command -v ip >/dev/null 2>&1; then
+    say_skip "global IPv6 addresses" "ip not available"
+else
+    gua_count=$(ip -6 -o addr show scope global 2>/dev/null | wc -l)
+    printf '    global IPv6 addresses: %s\n' "$gua_count"
+    if [ "$gua_count" -eq 0 ]; then
+        say_pass "no global IPv6 addresses - v6 exposure not reachable off-link"
+    else
+        # Not a failure by itself: OTBR border routing legitimately needs
+        # infrastructure IPv6. It IS a failure if a service is bound v6-wide.
+        v6_wide=$( { ss -tlnH; ss -ulnH; } 2>/dev/null | awk '{print $4}' \
+            | grep -E '^\[::\]:' | sort -u || true)
+        if [ -z "$v6_wide" ]; then
+            say_pass "$gua_count global IPv6 address(es) present, but no wildcard v6 listeners"
+        elif [ -z "$FW_ACCEPT_PORTS" ]; then
+            say_skip "wildcard v6 listeners" \
+                "firewall accept set unknown - cannot prove these are unreachable"
+        else
+            # A wildcard v6 bind is acceptable ONLY if the firewall does not
+            # admit its port. Checking the listener against a static allowlist
+            # would just re-encode the assumption; checking it against the LIVE
+            # ruleset is what catches the two controls drifting apart - which is
+            # exactly how SSH ended up reachable over IPv6.
+            for l in $v6_wide; do
+                lport="${l##*:}"
+                if printf ' %s ' "$FW_ACCEPT_PORTS" | grep -q " $lport "; then
+                    say_fail "wildcard v6 listener $l AND firewall admits port $lport, with $gua_count global IPv6 address(es) - reachable off-link"
+                else
+                    say_pass "wildcard v6 listener $l is unreachable (firewall does not admit $lport)"
+                fi
+            done
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+section "D-Bus authorization (RAUC)"
+# rauc.service runs as root and unsandboxed by necessity - it writes raw slot
+# images. meta-rauc's shipped policy grants send_destination to
+# context="default", so ANY local process could call InstallBundle or Mark:
+# replace the rootfs, flip boot state, or roll back to an older still-signed
+# bundle. Signature verification constrains what may be installed, not who may
+# ask. This asserts the override in
+# /etc/dbus-1/system.d/de.pengutronix.rauc-iotgw.conf is actually in force.
+#
+# Non-destructive by construction: the probe calls a method that DOES NOT EXIST.
+# D-Bus evaluates policy before dispatch, so a blocked caller gets AccessDenied
+# and an permitted caller gets UnknownMethod - nothing is ever executed.
+if ! command -v busctl >/dev/null 2>&1; then
+    say_skip "RAUC D-Bus authorization" "busctl not available"
+elif ! busctl --system status de.pengutronix.rauc >/dev/null 2>&1 \
+     && ! busctl --system list 2>/dev/null | grep -q de.pengutronix.rauc; then
+    say_skip "RAUC D-Bus authorization" "rauc not present on the bus"
+else
+    # Test as a confined service account rather than 'nobody' - it represents
+    # the actual threat: a compromised non-root service pivoting to root.
+    probe_user=""
+    for u in mosquitto otbr nobody; do
+        id "$u" >/dev/null 2>&1 && { probe_user="$u"; break; }
+    done
+
+    if [ -z "$probe_user" ]; then
+        say_skip "RAUC D-Bus authorization" "no unprivileged account to probe with"
+    else
+        probe_out=$(su -s /bin/sh -c \
+            "busctl --system call de.pengutronix.rauc / de.pengutronix.rauc.Installer IotgwPolicyProbe" \
+            "$probe_user" 2>&1)
+
+        # busctl's actual wording on this stack is "Call failed: Access denied"
+        # (verified on-target), which is neither AccessDenied (no space) nor
+        # "Permission denied" (different word). Matching only those two
+        # earlier patterns turned a genuine, correct denial into an
+        # "inconclusive" SKIP instead of a PASS.
+        case "$probe_out" in
+            *AccessDenied*|*[Aa]ccess\ denied*|*"not allowed"*|*[Pp]ermission\ denied*)
+                say_pass "state-changing Installer call from '$probe_user' is DENIED by policy" ;;
+            *UnknownMethod*|*"Unknown method"*|*"No such method"*)
+                say_fail "'$probe_user' reached the Installer interface (got UnknownMethod, not AccessDenied) - any local process can call InstallBundle/Mark on a root service" ;;
+            *)
+                say_fail "RAUC D-Bus authorization: unrecognized busctl response, treating as unverified: ${probe_out%%$'\n'*}" ;;
+        esac
+
+        # The override must not break the legitimate readers: edge-healthd calls
+        # GetSlotStatus, and denying it would silently break health reporting.
+        if su -s /bin/sh -c \
+            "busctl --system call de.pengutronix.rauc / de.pengutronix.rauc.Installer GetSlotStatus" \
+            "$probe_user" >/dev/null 2>&1; then
+            say_pass "read-only GetSlotStatus still permitted for '$probe_user' (edge-healthd path intact)"
+        else
+            say_fail "GetSlotStatus is denied for '$probe_user' - the policy is too tight and breaks edge-healthd health reporting"
+        fi
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+section "external reachability"
+say_skip "off-device reachability" \
+    "a device cannot prove its own external reachability - run scripts/security/exposure-probe-host.sh from a second host"
+
+# ---------------------------------------------------------------------------
+printf '\n== summary ==\n'
+printf '  PASS: %d\n' "$PASS"
+printf '  FAIL: %d\n' "$FAIL"
+printf '  SKIP: %d\n' "$SKIP"
+
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## Summary

Closes the "inherited defaults, not authored weaknesses" gap documented in this PR's `docs/THREAT_MODEL.md` update: SSH bound dual-stack via upstream's `sshd.socket` default, RAUC's D-Bus policy allowed any local process to drive a root unsandboxed installer, and firewall rules admitted ports on both address families with no qualifier. These are real defects found by a manual security review of D-Bus authorization and IPv4/IPv6 exposure mapping — not something tuned to satisfy a third-party audit tool's scoring.

- **SSH**: pin the socket-activated listener to IPv4
- **listen-guard**: `iotgw-listen-guard.bbclass` fails the image build if the assembled rootfs's socket-activated listeners don't exactly match policy
- **CI + build-time**: lint tracked `nftables*.conf` for port rules missing an address-family qualifier — matches `tcp`/`udp dport` anywhere on a rule line (not just as the first token), strips comments before matching (so a rule can't evade on the strength of its own trailing comment)
- **firewall**: family-qualify all service rules, split OTBR ruleset into its own file
- **RAUC**: revoke the upstream D-Bus blanket grant, fail closed then re-open only read-only/liveness/health-reporting access + root/`ota`; add conservative service sandboxing
- **exposure tooling**: `exposure-target.sh` (on-target) and `exposure-probe-host.sh` (cross-host) assert this product's own listen-scope/firewall/reachability/RAUC-authorization policy — OTBR-aware (see below), not hardcoded to this operator's own build config
- **docs**: SECURITY.md, THREAT_MODEL.md

## Validation

- [x] `make parse` — 0 errors
- [x] On-target exposure check — **PASS: 16, FAIL: 0, SKIP: 1** (only the expected "run from a second host" skip; RAUC D-Bus authorization is decisive — PASS on both the denied-Installer-call and the still-permitted-GetSlotStatus checks)
- [x] Cross-host reachability probe, OTBR-enabled target, `--otbr` — **PASS: 10, FAIL: 0**: IPv4 22/80/8081 open, 443/1883 closed; IPv6 all 5 closed, backed by a passing ICMP reachability gate
- [x] Cross-host reachability probe, same target, **without** `--otbr` — **PASS: 8, FAIL: 0**, ports 80/8081 correctly reported as unasserted INFO rather than judged against an assumption the probing host can't confirm
- [ ] Prod-image build with the security packagegroup — split out above, not part of this PR anymore

### Bugs found in review and fixed before the results above were captured

1. **IPv6 bracket bug.** `exposure-probe-host.sh` bracketed IPv6 literals for bash's `/dev/tcp` (`[::1]`), which bash does not accept, it fails name resolution outright:
   ```
   $ bash -c 'exec 3<>/dev/tcp/[::1]/22'
   bash: line 1: [::1]: Name or service not known
   $ bash -c 'exec 3<>/dev/tcp/::1/22'      # unbracketed: works
   ```
   Every IPv6 result in an earlier version of this PR was a resolution failure silently misreported as "closed". Fixed by removing the bracket and adding an ICMP reachability gate before each TCP probe (this device's firewall policy is DROP not REJECT, so a filtered port and an unreachable address are indistinguishable by TCP timeout alone — confirmed: a real open port, a real closed port, and a bogus unreachable address all produced an identical bare timeout with no distinguishing output). A probe that cannot reach a decisive result is now a hard FAIL, never folded into "closed".

2. **RAUC authorization false-SKIP.** `exposure-target.sh`'s RAUC D-Bus check matched only `AccessDenied` (no space) and `"Permission denied"`, but the real busctl wording on this stack is `"Access denied"` (confirmed on-target: `busctl --system call de.pengutronix.rauc / de.pengutronix.rauc.Installer IotgwPolicyProbe` as an unprivileged service account returns `Call failed: Access denied`) — a genuine, correct policy denial fell through to an "inconclusive" SKIP instead of PASS. Fixed the pattern; changed the unrecognized-response fallback from SKIP to FAIL.

3. **OTBR default-profile assumption.** Both exposure scripts hardcoded ports 80/8081 (OTBR web UI/agent REST) as always-expected-open, but `IOTGW_ENABLE_OTBR` defaults off in the distro (it's only "1" in this operator's own gitignored `kas/local.yml`) — a correctly-built non-OTBR image would have failed this check for being correct. `exposure-target.sh` now detects OTBR's actual presence on the target (`systemctl list-unit-files otbr-web.service otbr-agent.service`); `exposure-probe-host.sh` takes an explicit `--otbr` flag and reports those two ports as unasserted INFO without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)